### PR TITLE
Cells Children Refactoring Stage 1

### DIFF
--- a/object_database/web/cells/Messenger.py
+++ b/object_database/web/cells/Messenger.py
@@ -150,7 +150,7 @@ def _getFlatStructure(parent_id, cell, name_in_parent):
 
 def _getFlatChildren(cell):
     own_children = {}
-    for child_name, child in cell.namedChildren.items():
+    for child_name, child in cell.children.items():
         own_children[child_name] = _resolveFlatChild(child)
 
     return own_children
@@ -178,7 +178,7 @@ def _getExpandedStructure(parent_id, cell, name_in_parent):
 
 def _getExpandedChildren(cell):
     own_children = {}
-    for child_name, child in cell.namedChildren.items():
+    for child_name, child in cell.children.items():
         own_children[child_name] = _resolveExpandedChild(cell.identity, child,
                                                          child_name)
     return own_children

--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -84,4 +84,6 @@ from object_database.web.cells.util import (
 
 from object_database.web.cells.views.resizable_panel import ResizablePanel
 
+from object_database.web.cells.children import Children
+
 MAX_FPS = 10

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1672,7 +1672,7 @@ class Subscribed(Cell):
         return Subscribed(newCellFactory)
 
     def sortsAs(self):
-        for c in self.children.values():
+        for c in self.children.allChildren:
             return c.sortsAs()
 
         return Cell.makeCell(self.cellFactory()).sortsAs()
@@ -2459,7 +2459,7 @@ class Expands(Cell):
         # an inline script!
         self.exportData['events'] = {"onclick": inlineScript}
 
-        for c in self.children.values():
+        for c in self.children.allChildren:
             if c.cells is not None:
                 c.prepareForReuse()
 

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -296,7 +296,7 @@ class Cells:
         self.markDirty(cell)
 
     def _cellOutOfScope(self, cell):
-        for c in cell.children.values():
+        for c in cell.children.allChildren:
             self._cellOutOfScope(c)
 
         self.markToDiscard(cell)
@@ -746,9 +746,9 @@ class Cell:
             if stopSearchingAtFoundTag:
                 return cells
 
-        for child in self.children:
+        for child in self.children.allChildren:
             cells.extend(
-                self.children[child].findChildrenByTag(
+                child.findChildrenByTag(
                     tag, stopSearchingAtFoundTag)
             )
 
@@ -756,7 +756,7 @@ class Cell:
 
     def visitAllChildren(self, visitor):
         visitor(self)
-        for child in self.children.values():
+        for child in self.children.allChildren:
             child.visitAllChildren(visitor)
 
     def findChildrenMatching(self, filtr):
@@ -1541,7 +1541,7 @@ class Container(Cell):
 
     def setContents(self, newContents, newChildren):
         #self.namedChildren['child'] = list(newChildren.values())[0]  # Hacky!
-        self.children['child'] = newChildren
+        self.children['child'] = Cell.makeCell(newChildren)
         self.markDirty()
 
 

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1625,8 +1625,7 @@ class ContextualDisplay(Cell):
     def recalculate(self):
         with self.view():
             childCell = self.getChild()
-            self.children = {"____child__": childCell}
-            self.namedChildren['child'] = childCell
+            self.children['child'] = childCell
 
 
 class Subscribed(Cell):
@@ -1682,15 +1681,13 @@ class Subscribed(Cell):
                     self.wrapsSequence = True
                 elif isinstance(c, HorizontalSequence):
                     self.wrapsHorizSequence = True
-                self.children = {'____contents__': c}
-                self.namedChildren['content'] = c
+                self.children['content'] = c
             except SubscribeAndRetry:
                 raise
             except Exception:
                 tracebackCell = Traceback(
                     traceback.format_exc())
-                self.children = {'____contents__': tracebackCell}
-                self.namedChildren['content'] = tracebackCell
+                self.children['content'] = tracebackCell
                 self._logger.error(
                     "Subscribed inner function threw exception:\n%s", traceback.format_exc())
 
@@ -1814,13 +1811,11 @@ class SubscribedSequence(Cell):
 
             self._processChild(current_child, new_children)
 
-        self.children = {"____child_%s__" %
-                         i: new_children[i] for i in range(len(new_children))}
-        self.namedChildren['elements'] = new_children
+        self.children['elements'] = new_children
 
     def sortAs(self):
-        if len(self.namedChildren['elements']):
-            return self.namedChildren['elements'][0].sortAs()
+        if len(self.children['elements']):
+            return self.children['elements'][0].sortAs()
 
     def _processChild(self, child, children):
         """Determines whether or not to flatten nested
@@ -1836,7 +1831,7 @@ class SubscribedSequence(Cell):
             # or SubscribedSequence of some kind.
             # In this case, we need to flatten its elements.
             # Note that only matching orientations flatten.
-            children += child.namedChildren['content'].namedChildren['elements']
+            children += child.children['content'].children['elements']
         else:
             children.append(child)
 
@@ -1895,23 +1890,18 @@ class Popover(Cell):
         contentCell = Cell.makeCell(contents)
         detailCell = Cell.makeCell(detail)
         titleCell = Cell.makeCell(title)
-        self.children = {
-            '____contents__': contentCell,
-            '____detail__': detailCell,
-            '____title__': titleCell
-        }
-        self.namedChildren = {
+        self.children.addFromDict({
             'content': contentCell,
             'detail': detailCell,
             'title': titleCell
-        }
+        })
 
     def recalculate(self):
         self.exportData['width'] = self.width
 
     def sortsAs(self):
-        if '____title__' in self.children:
-            return self.children['____title__'].sortsAs()
+        if self.children.hasChildNamed('title'):
+            return self.children['title'].sortAs()
 
 
 class Grid(Cell):
@@ -1960,7 +1950,6 @@ class Grid(Cell):
 
             self._resetSubscriptionsToViewReads(v)
 
-        new_children = {}
         new_named_children = {
             'headers': [],
             'rowLabels': [],
@@ -1971,23 +1960,17 @@ class Grid(Cell):
         for col_ix, col in enumerate(self.cols):
             seen.add((None, col))
             if (None, col) in self.existingItems:
-                new_children["____header_%s__" %
-                             (col_ix)] = self.existingItems[(None, col)]
                 new_named_children['headers'].append(self.existingItems[(None, col)])
             else:
                 try:
                     headerCell = Cell.makeCell(self.headerFun(col[0]))
-                    self.existingItems[(None, col)] = \
-                        new_children["____header_%s__" % col_ix] = \
-                        headerCell
+                    self.existingItems[(None, col)] = headerCell
                     new_named_children['headers'].append(headerCell)
                 except SubscribeAndRetry:
                     raise
                 except Exception:
                     tracebackCell = Traceback(traceback.format_exc)()
-                    self.existingItems[(None, col)] = \
-                        new_children["____header_%s__" % col_ix] = \
-                        tracebackCell
+                    self.existingItems[(None, col)] = tracebackCell
                     new_named_children['headers'].append(tracebackCell)
 
         if self.rowLabelFun is not None:
@@ -1995,23 +1978,17 @@ class Grid(Cell):
                 seen.add((None, row))
                 if (row, None) in self.existingItems:
                     rowLabelCell = self.existingItems[(row, None)]
-                    new_children["____rowlabel_%s__" %
-                                 (row_ix)] = rowLabelCell
                     new_named_children['rowLabels'].append(rowLabelCell)
                 else:
                     try:
                         rowLabelCell = Cell.makeCell(self.rowLabelFun(row[0]))
-                        self.existingItems[(row, None)] = \
-                            new_children["____rowlabel_%s__" % row_ix] = \
-                            rowLabelCell
+                        self.existingItems[(row, None)] = rowLabelCell
                         new_named_children['rowLabels'].append(rowLabelCell)
                     except SubscribeAndRetry:
                         raise
                     except Exception:
                         tracebackCell = Traceback(traceback.format_exc())
-                        self.existingItems[(row, None)] = \
-                            new_children["____rowlabel_%s__" % row_ix] = \
-                            tracebackCell
+                        self.existingItems[(row, None)] = tracebackCell
                         new_named_children['rowLabels'].append(tracebackCell)
 
         seen = set()
@@ -2021,27 +1998,21 @@ class Grid(Cell):
             for col_ix, col in enumerate(self.cols):
                 seen.add((row, col))
                 if (row, col) in self.existingItems:
-                    new_children["____child_%s_%s__" % (row_ix, col_ix)] = \
-                        self.existingItems[(row, col)]
                     new_named_children_column.append(self.existingItems[(row, col)])
                 else:
                     try:
                         dataCell = Cell.makeCell(self.rendererFun(row[0], col[0]))
-                        self.existingItems[(row, col)] = \
-                            new_children["____child_%s_%s__" % (row_ix, col_ix)] = \
-                            dataCell
+                        self.existingItems[(row, col)] = dataCell
                         new_named_children_column.append(dataCell)
                     except SubscribeAndRetry:
                         raise
                     except Exception:
                         tracebackCell = Traceback(traceback.format_exc())
-                        self.existingItems[(row, col)] = \
-                            new_children["____child_%s_%s__" % (row_ix, col_ix)] = \
-                            tracebackCell
+                        self.existingItems[(row, col)] = tracebackCell
                         new_named_children_column.append(tracebackCell)
 
-        self.children = new_children
-        self.namedChildren = new_named_children
+        self.children = Children(self)
+        self.children.addFromDict(new_named_children)
 
         for i in list(self.existingItems):
             if i not in seen:
@@ -2248,7 +2219,6 @@ class Table(Cell):
 
             self._resetSubscriptionsToViewReads(v)
 
-        new_children = {}
         new_named_children = {
             'headers': [],
             'dataCells': [],
@@ -2261,23 +2231,17 @@ class Table(Cell):
         for col_ix, col in enumerate(self.cols):
             seen.add((None, col))
             if (None, col) in self.existingItems:
-                new_children["____header_%s__" %
-                             (col_ix)] = self.existingItems[(None, col)]
                 new_named_children['headers'].append(self.existingItems[(None, col)])
             else:
                 try:
                     headerCell = self.makeHeaderCell(col_ix)
-                    self.existingItems[(None, col)] = \
-                        new_children["____header_%s__" % col_ix] = \
-                        headerCell
+                    self.existingItems[(None, col)] = headerCell
                     new_named_children['headers'].append(headerCell)
                 except SubscribeAndRetry:
                     raise
                 except Exception:
                     tracebackCell = Traceback(traceback.format_exc())
-                    self.existingItems[(None, col)] = \
-                        new_children["____header_%s__" % col_ix] = \
-                        tracebackCell
+                    self.existingItems[(None, col)] = tracebackCell
                     new_named_children['headers'].append(tracebackCell)
 
         seen = set()
@@ -2287,27 +2251,21 @@ class Table(Cell):
             for col_ix, col in enumerate(self.cols):
                 seen.add((row, col))
                 if (row, col) in self.existingItems:
-                    new_children["____child_%s_%s__" % (row_ix, col_ix)] = \
-                        self.existingItems[(row, col)]
                     new_named_children_columns.append(self.existingItems[(row, col)])
                 else:
                     try:
                         dataCell = Cell.makeCell(self.rendererFun(row, col))
-                        self.existingItems[(row, col)] = \
-                            new_children["____child_%s_%s__" % (row_ix, col_ix)] = \
-                            dataCell
+                        self.existingItems[(row, col)] = dataCell
                         new_named_children_columns.append(dataCell)
                     except SubscribeAndRetry:
                         raise
                     except Exception:
                         tracebackCell = Traceback(traceback.format_exc())
-                        self.existingItems[(row, col)] = \
-                            new_children["____child_%s_%s__" % (row_ix, col_ix)] = \
-                            tracebackCell
+                        self.existingItems[(row, col)] = tracebackCell
                         new_named_children_columns.append(tracebackCell)
 
-        self.children = new_children
-        self.namedChildren = new_named_children
+        self.children = Children(self)
+        self.children.addFromDict(new_named_children)
 
         for i in list(self.existingItems):
             if i not in seen:
@@ -2317,8 +2275,7 @@ class Table(Cell):
 
         if totalPages <= 1:
             pageCell = Cell.makeCell(totalPages).nowrap()
-            self.children['____page__'] = pageCell
-            self.namedChildren['page'] = pageCell
+            self.children['page'] = pageCell
         else:
             pageCell = (
                 SingleLineTextBox(self.curPage, pattern="[0-9]+")
@@ -2326,13 +2283,11 @@ class Table(Cell):
                 .height(20)
                 .nowrap()
             )
-            self.children['____page__'] = pageCell
-            self.namedChildren['page'] = pageCell
+            self.children['page'] = pageCell
         if self.curPage.get() == "1":
             leftCell = Octicon(
                 "triangle-left", color="lightgray").nowrap()
-            self.children['____left__'] = leftCell
-            self.namedChildren['left'] = leftCell
+            self.children['left'] = leftCell
         else:
             leftCell = (
                 Clickable(
@@ -2340,13 +2295,11 @@ class Table(Cell):
                     lambda: self.curPage.set(str(int(self.curPage.get())-1))
                 ).nowrap()
             )
-            self.children['____left__'] = leftCell
-            self.namedChildren['left'] = leftCell
+            self.children['left'] = leftCell
         if self.curPage.get() == str(totalPages):
             rightCell = Octicon(
                 "triangle-right", color="lightgray").nowrap()
-            self.children['____right__'] = rightCell
-            self.namedChildren['right'] = rightCell
+            self.children['right'] = rightCell
         else:
             rightCell = (
                 Clickable(
@@ -2354,8 +2307,7 @@ class Table(Cell):
                     lambda: self.curPage.set(str(int(self.curPage.get())+1))
                 ).nowrap()
             )
-            self.children['____right__'] = rightCell
-            self.namedChildren['right'] = rightCell
+            self.children['right'] = rightCell
 
         # temporary js WS refactoring data
         self.exportData['totalPages'] = totalPages
@@ -2380,8 +2332,7 @@ class Clickable(Cell):
             )
 
     def recalculate(self):
-        self.children = {'____contents__': self.content}
-        self.namedChildren = {'content': self.content}
+        self.children = {'content': self.content}
         self.exportData['bold'] = self.bold
 
         # TODO: this event handling situation must be refactored
@@ -2405,8 +2356,7 @@ class Button(Clickable):
         self.style = style
 
     def recalculate(self):
-        self.children = {'____contents__': self.content}
-        self.namedChildren = {'content': self.content}
+        self.children = {'content': self.content}
 
         isActive = False
         if self.active:
@@ -2427,9 +2377,7 @@ class ButtonGroup(Cell):
         self.buttons = buttons
 
     def recalculate(self):
-        self.children = {
-            f'____button_{i}__': self.buttons[i] for i in range(len(self.buttons))}
-        self.namedChildren['buttons'] = self.buttons
+        self.children['buttons'] = self.buttons
 
 
 class LoadContentsFromUrl(Cell):
@@ -2498,14 +2446,10 @@ class Expands(Cell):
     def recalculate(self):
         inlineScript = "cellSocket.sendString(JSON.stringify({'event':'click', 'target_cell': '%s'}))" % self.identity
 
-        self.children = {
-            '____child__': self.open if self.isExpanded else self.closed,
-            '____icon__': self.openedIcon if self.isExpanded else self.closedIcon
-        }
-        self.namedChildren = {
+        self.children.addFromDict({
             'content': self.open if self.isExpanded else self.closed,
             'icon': self.openedIcon if self.isExpanded else self.closedIcon
-        }
+        })
 
         # TODO: Refactor this. We shouldn't need to send
         # an inline script!
@@ -2517,7 +2461,6 @@ class Expands(Cell):
 
     def onMessage(self, msgFrame):
         self.isExpanded = not self.isExpanded
-
         self.markDirty()
 
 
@@ -2676,10 +2619,7 @@ class Sheet(Cell):
 
     def recalculate(self):
         errorCell = Subscribed(lambda: Traceback(self.error.get()) if self.error.get() is not None else Text(""))
-        self.children = {
-            '____error__': errorCell
-        }
-        self.namedChildren['error'] = errorCell
+        self.children['error'] = errorCell
 
         # Deleted the postscript that was here.
         # Should now be implemented completely
@@ -2748,14 +2688,10 @@ class Plot(Cell):
     def recalculate(self):
         chartUpdaterCell = Subscribed(lambda: _PlotUpdater(self))
         errorCell = Subscribed(lambda: Traceback(self.error.get()) if self.error.get() is not None else Text(""))
-        self.children = {
-            '____chart_updater__': chartUpdaterCell,
-            '____error__': errorCell
-        }
-        self.namedChildren = {
+        self.children.addFromDict({
             'chartUpdater': chartUpdaterCell,
             'error': errorCell
-        }
+        })
         self.postscript = ""
 
     def onMessage(self, msgFrame):
@@ -2863,7 +2799,6 @@ class _PlotUpdater(Cell):
     def recalculate(self):
         with self.view() as v:
             # we only exist to run our postscript
-            self.children = {}  # Does this Cell type ever have children?
             self.postscript = ""
             self.linePlot.error.set(None)
 
@@ -2947,5 +2882,4 @@ class Panel(Cell):
         self.content = Cell.makeCell(content)
 
     def recalculate(self):
-        self.children['____content__'] = Cell.makeCell(self.content)
-        self.namedChildren['content'] = Cell.makeCell(self.content)
+        self.children['content'] = Cell.makeCell(self.content)

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -152,7 +152,7 @@ class CellsTests(unittest.TestCase):
         self.assertEqual(pair[1].parent, sequence)
 
         # Assert that the first Container has a Cell child
-        self.assertIsInstance(pair[0].namedChildren['child'], Cell)
+        self.assertIsInstance(pair[0].children['child'], Cell)
 
     def test_cells_reusable(self):
         c1 = Card(Text("HI"))
@@ -498,7 +498,7 @@ class CellsMessagingTests(unittest.TestCase):
         self.assertEqual(msgs[0]['id'], sequence.identity)
 
         # Sequence's namedChildren should have a length now of 3
-        self.assertEqual(len(sequence.namedChildren['elements']), 3)
+        self.assertEqual(len(sequence.children['elements']), 3)
 
 
 class CellsStructureTests(unittest.TestCase):
@@ -759,7 +759,7 @@ class CellsSubscribedSequenceHandlingTests(unittest.TestCase):
         self.cells.withRoot(sub_seq)
         self.cells._recalculateCells()
         self.assertEqual(len(sub_seq.items), 50)
-        self.assertEqual(len(sub_seq.namedChildren['elements']), 50)
+        self.assertEqual(len(sub_seq.children['elements']), 50)
 
     def test_elements_length_changed(self):
         exampleData = self.exampleItems

--- a/object_database/web/cells/children.py
+++ b/object_database/web/cells/children.py
@@ -9,10 +9,12 @@ class Children():
     def addChildNamed(self, name, childStructure):
         if name in self.namedChildren:
             self.removeChildNamed(name)
+        if childStructure is None:
+            return
         self.namedChildren[name] = self._addChildStructure(childStructure, name)
 
     def addFromDict(self, childrenDict):
-        for key, val in childrenDict:
+        for key, val in childrenDict.items():
             self[key] = val
 
     def removeChildNamed(self, name):
@@ -45,6 +47,9 @@ class Children():
         if child in self._reverseLookup:
             return self._reverseLookup[child]
         return None
+
+    def items(self):
+        return self.namedChildren.items()
 
     def _getDimensions(self, item, dimensions=0):
         if isinstance(item, list):

--- a/object_database/web/cells/children.py
+++ b/object_database/web/cells/children.py
@@ -1,0 +1,68 @@
+class Children():
+    def __init__(self, parent=None):
+        self.namedChildren = {}
+        self.allChildren = []
+        self.parent = parent
+
+
+    def addChildNamed(self, name, childStructure):
+        if name in self.namedChildren:
+            self.removeChildNamed(name)
+        self.namedChildren[name] = self._addChildStructure(childStructure)
+
+    def removeChildNamed(self, name):
+        if not name in self.namedChildren:
+            return False
+        found = self.namedChildren[name]
+        success = self._removeChildStructure(found)
+        if not success:
+            return False
+        del self.namedChildren[name]
+        return True
+
+    def dimensionsForChildNamed(self, name):
+        found = self.namedChildren[name]
+        return self._getDimensions(found)
+
+    def _getDimensions(self, item, dimensions=0):
+        if isinstance(item, list):
+            return self._getDimensions(item[0], dimensions + 1)
+        return dimensions
+
+    def _removeChildStructure(self, structure):
+        if isinstance(structure, list):
+            return [self._removeChildStructure(s) for s in structure]
+        else:
+            self.allChildren.remove(structure)
+            self._unsetParent(structure)
+            return True
+
+    def _addChildStructure(self, structure):
+        if isinstance(structure, list):
+            return [self._addChildStructure(item) for item in structure]
+        else:
+            self.allChildren.append(structure)
+            self._setParent(structure)
+            return structure
+
+    def _setParent(self, child):
+        try:
+            child.parent = self.parent
+        except:
+            pass
+
+    def _unsetParent(self, child):
+        try:
+            child.parent = None
+        except:
+            pass
+
+    def __getitem__(self, key):
+        return self.namedChildren[key]
+
+    def __setitem__(self, key, value):
+        self.addChildNamed(key, value)
+
+    def __delitem__(self, key):
+        if key in self.namedChildren:
+            self.removeChildNamed(key)

--- a/object_database/web/cells/children.py
+++ b/object_database/web/cells/children.py
@@ -11,6 +11,10 @@ class Children():
             self.removeChildNamed(name)
         self.namedChildren[name] = self._addChildStructure(childStructure, name)
 
+    def addFromDict(self, childrenDict):
+        for key, val in childrenDict:
+            self[key] = val
+
     def removeChildNamed(self, name):
         if not name in self.namedChildren:
             return False
@@ -20,6 +24,12 @@ class Children():
             return False
         del self.namedChildren[name]
         return True
+
+    def removeAll(self):
+        for child in self.allChildren:
+            self._unsetParent(child)
+        self.namedChildren = {}
+        self.allChildren = []
 
     def dimensionsForChildNamed(self, name):
         found = self.namedChildren[name]

--- a/object_database/web/cells/children.py
+++ b/object_database/web/cells/children.py
@@ -3,12 +3,13 @@ class Children():
         self.namedChildren = {}
         self.allChildren = []
         self.parent = parent
+        self._reverseLookup = {}
 
 
     def addChildNamed(self, name, childStructure):
         if name in self.namedChildren:
             self.removeChildNamed(name)
-        self.namedChildren[name] = self._addChildStructure(childStructure)
+        self.namedChildren[name] = self._addChildStructure(childStructure, name)
 
     def removeChildNamed(self, name):
         if not name in self.namedChildren:
@@ -24,6 +25,14 @@ class Children():
         found = self.namedChildren[name]
         return self._getDimensions(found)
 
+    def hasChild(self, child):
+        return child in self.allChildren
+
+    def findNameFor(self, child):
+        if child in self._reverseLookup:
+            return self._reverseLookup[child]
+        return None
+
     def _getDimensions(self, item, dimensions=0):
         if isinstance(item, list):
             return self._getDimensions(item[0], dimensions + 1)
@@ -34,15 +43,17 @@ class Children():
             return [self._removeChildStructure(s) for s in structure]
         else:
             self.allChildren.remove(structure)
+            del self._reverseLookup[structure]
             self._unsetParent(structure)
             return True
 
-    def _addChildStructure(self, structure):
+    def _addChildStructure(self, structure, name):
         if isinstance(structure, list):
-            return [self._addChildStructure(item) for item in structure]
+            return [self._addChildStructure(item, name) for item in structure]
         else:
             self.allChildren.append(structure)
             self._setParent(structure)
+            self._reverseLookup[structure] = name
             return structure
 
     def _setParent(self, child):

--- a/object_database/web/cells/children.py
+++ b/object_database/web/cells/children.py
@@ -38,6 +38,9 @@ class Children():
     def hasChild(self, child):
         return child in self.allChildren
 
+    def hasChildNamed(self, name):
+        return name in self.namedChildren
+
     def findNameFor(self, child):
         if child in self._reverseLookup:
             return self._reverseLookup[child]

--- a/object_database/web/cells/children.py
+++ b/object_database/web/cells/children.py
@@ -1,5 +1,66 @@
+#   Copyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+
 class Children():
+    """A 'Collection-Like' object that holds Cell child references.
+
+    By 'Collection-like' we mean that this object maintains
+    some polymorphism with collections like Dictionaries and
+    Lists.
+
+    Children maintains an internal dictionary that maps child
+    names to either a Cell instance, a list of Cell instances,
+    or an n-dimensional (list of list, etc) of Cell instances.
+    For the purposes of recalculation and rendering, it also
+    maintains a flat list of all contained Cell instance children
+    regardless of what name they appear under in the current dict.
+
+    Convenience methods for adding and removing maintain the
+    integrity of both the flat list and the internal dict.
+
+    Overrides like `__setitem__` etc simply wrap the explicit
+    convenience methods in more list/dictionary like syntax.
+
+    Properties
+    ----------
+    namedChildren: dict
+        A dictionary that maps unique names to
+        a Cell instance, a list of Cell instances,
+        or an n-dimensional (list of list, etc)
+        list of Cell instances
+    allChildren: list
+        A flat list of all child Cell instances,
+        regardless of their place in namedChildren
+    parent: Cell
+        A reference to a Cell instance that will serve
+        as the parent for all added Cell instance
+        children.
+    _reverseLookup: dict
+        A dictionary that maps Cell instances to
+        the key where the instance appears in
+        namedChildren. Used for reverse lookups.
+    """
     def __init__(self, parent=None):
+        """
+        Parameters
+        ----------
+        parent: Cell
+            A reference to a Cell instance that all
+            become the parent for all added children.
+        """
         self.namedChildren = {}
         self.allChildren = []
         self.parent = parent
@@ -7,6 +68,37 @@ class Children():
 
 
     def addChildNamed(self, name, childStructure):
+        """Adds a child with the given name.
+
+        If the name is already set in the internal
+        dictionary, we call `removeChildNamed first
+        in order to unset parent on the previous child,
+        should it exist.
+
+        We use a recursive call to `_addChildstructure` in
+        order to deal with multi-dimensional values.
+
+        Notes
+        -----
+        Using helper functions, this method will:
+        * Add the structure to the internal dict
+        * Set the parent of all incoming Cell instances
+          to the value of the property `parent`
+        * Add any encountered Cell instance child
+          to the reverse lookup dictionary
+        * Add any incoming Cell instance to the
+          flat list of all children
+
+        Parameters
+        ----------
+        name: str
+            The name to give the child, which can be referenced
+            later
+        childStructure: (Cell || list || list(list))
+            A Cell instance, list of Cell instances, or
+            n-dimensional (list of list, etc) list of
+            Cell instances
+        """
         if name in self.namedChildren:
             self.removeChildNamed(name)
         if childStructure is None:
@@ -14,10 +106,47 @@ class Children():
         self.namedChildren[name] = self._addChildStructure(childStructure, name)
 
     def addFromDict(self, childrenDict):
+        """Adds all elements from an incoming dict.
+
+        Will overwrite any existing entries, which
+        is normal behavior for `addChildNamed`.
+
+        Parameters
+        ----------
+        childrenDict: dict
+            A dictionary mapping names to children.
+        """
         for key, val in childrenDict.items():
             self[key] = val
 
     def removeChildNamed(self, name):
+        """Removes the child or child structure of the given name.
+
+        If there is no child with the given name, it
+        will return False. Likewise, if removal fails
+        for some reason, it will also return False.
+
+        Makes a recursive call to `_removechildStructure`
+        in order to deal with the possibility of
+        multidimensional child structures.
+
+        Notes
+        -----
+        Using helper functions, this method will:
+        * Remove the given entry from the internal dict
+        * Set the parent of all removed Cell instances
+          to None
+        * Remove the removed Cell instances from the
+          reverse lookup dictionary
+        * Remove the removed Cell instances from the
+          flat list of children (`allChildren`)
+
+        Parameters
+        ----------
+        name: str
+            The key to lookup for which all children
+            should be removed.
+        """
         if not name in self.namedChildren:
             return False
         found = self.namedChildren[name]
@@ -28,35 +157,103 @@ class Children():
         return True
 
     def removeAll(self):
+        """Removes all children and child structures.
+
+        Will set parent of all removed Cell instances to None.
+        """
         for child in self.allChildren:
             self._unsetParent(child)
         self.namedChildren = {}
         self.allChildren = []
 
     def dimensionsForChildNamed(self, name):
+        """Returns the number of dimensions for a named entry.
+
+        Notes
+        -----
+        Some named children are lists of Cells or n-dimension
+        nested (ie list of list of list etc) of Cells. This
+        method will return the number of dimensions for a given
+        child entry in the Children collection.
+
+        Parameters
+        ----------
+        name: str
+            The key name of the child.
+
+        Returns
+        -------
+        int: The number of dimensions
+        """
         found = self.namedChildren[name]
         return self._getDimensions(found)
 
     def hasChild(self, child):
+        """Returns true if child Cell is in this Children.
+
+        Parameters
+        ----------
+        child: Cell
+            The child Cell instance to look for.
+
+        Returns
+        -------
+        Boolean: True if the Cell is a child present in this
+            Children.
+        """
         return child in self.allChildren
 
     def hasChildNamed(self, name):
+        """Returns True if this instance has a child with the name.
+
+        Parameters
+        ----------
+        name: str
+            The name of the child (key) to lookup.
+
+        Returns
+        -------
+        Boolean: True if the name is in the internal dict
+            (and therefore child is present)
+        """
         return name in self.namedChildren
 
     def findNameFor(self, child):
+        """Returns the name for a given child Cell, if present.
+
+        Parameters
+        ----------
+        child: Cell
+            A Cell instance to lookup
+
+        Returns
+        -------
+        str | None: Returns the string of the name (key)
+            where the instance resides in the internal dict,
+            or None if it is not found.
+        """
         if child in self._reverseLookup:
             return self._reverseLookup[child]
         return None
 
     def items(self):
+        """Wrapper for internal dict's `items()` method"""
         return self.namedChildren.items()
 
     def _getDimensions(self, item, dimensions=0):
+        """Recursively counts the num of dimensions
+        for a multidimensional child structure.
+        """
         if isinstance(item, list):
             return self._getDimensions(item[0], dimensions + 1)
         return dimensions
 
     def _removeChildStructure(self, structure):
+        """Recursively iterates through a possible
+        multidimensional child structure, removing any found
+        Cell instances to the various internal collections
+        and setting each parent to None.
+        """
         if isinstance(structure, list):
             return [self._removeChildStructure(s) for s in structure]
         else:
@@ -66,6 +263,11 @@ class Children():
             return True
 
     def _addChildStructure(self, structure, name):
+        """Recursively iterates through a possible
+        multidimensional child structure, adding any found
+        Cell instances to the various internal collections
+        and setting each parent to Children's parent.
+        """
         if isinstance(structure, list):
             return [self._addChildStructure(item, name) for item in structure]
         else:
@@ -75,23 +277,31 @@ class Children():
             return structure
 
     def _setParent(self, child):
+        """Sets the `parent` property of the incoming Cell
+        instance to that of this Children instance.
+        """
         try:
             child.parent = self.parent
         except:
             pass
 
     def _unsetParent(self, child):
+        """Sets the `parent` property of the incoming Cell
+        to None"""
         try:
             child.parent = None
         except:
             pass
 
     def __getitem__(self, key):
+        """Override that wraps access to namedChildren"""
         return self.namedChildren[key]
 
     def __setitem__(self, key, value):
+        """Override that wraps `addChildNamed`"""
         self.addChildNamed(key, value)
 
     def __delitem__(self, key):
+        """Override that wraps `removeChildNamed`"""
         if key in self.namedChildren:
             self.removeChildNamed(key)

--- a/object_database/web/cells/children_test.py
+++ b/object_database/web/cells/children_test.py
@@ -1,0 +1,226 @@
+import unittest
+from object_database.web.cells.children import Children
+
+class DummyObject():
+    def __init__(self):
+        self.parent = None
+
+
+class CellChildrenTests(unittest.TestCase):
+
+    def test_get_dimensions_zero(self):
+        item = DummyObject()
+        children = Children()
+        result = children._getDimensions(item)
+        self.assertEqual(result, 0)
+
+    def test_get_dimensions_one(self):
+        item = [DummyObject() for d in range(20)]
+        children = Children()
+        result = children._getDimensions(item)
+        self.assertEqual(result, 1)
+
+    def test_get_dimensions_two(self):
+        item = [
+            [DummyObject() for d in range(20)] for c in range(20)
+        ]
+        children = Children()
+        result = children._getDimensions(item)
+        self.assertEqual(result, 2)
+
+    def test_get_dimensions_three(self):
+        item = [
+            [
+                [DummyObject() for a in range(20)] for b in range(20)
+            ] for c in range(20)
+        ]
+        children = Children()
+        result = children._getDimensions(item)
+        self.assertEqual(result, 3)
+
+    def test_add_child_zero_dm(self):
+        child = DummyObject()
+        children = Children()
+        children.addChildNamed('first', child)
+        self.assertTrue('first' in children.namedChildren)
+        self.assertTrue(child in children.allChildren)
+        self.assertEqual(child, children.namedChildren['first'])
+
+    def test_basic_add_child_one_dm(self):
+        child = [
+            DummyObject(),
+            DummyObject(),
+            DummyObject()
+        ]
+        children = Children()
+        children.addChildNamed('first', child)
+        self.assertEqual(len(children.allChildren), 3)
+        for item in children.allChildren:
+            self.assertIsInstance(item, DummyObject)
+
+    def test_add_child_one_dm(self):
+        child = [DummyObject() for d in range(20)]
+        children = Children()
+        children.addChildNamed('first', child)
+        self.assertTrue('first' in children.namedChildren)
+        for item in child:
+            self.assertTrue(item in children.allChildren)
+        self.assertEqual(child, children.namedChildren['first'])
+        self.assertEqual(len(children.allChildren), 20)
+        for item in children.allChildren:
+            self.assertIsInstance(item, DummyObject)
+
+    def test_add_child_two_dm(self):
+        child = [
+            [DummyObject() for d in range(20)] for c in range(30)
+        ]
+        children = Children()
+        children.addChildNamed('first', child)
+        self.assertTrue('first' in children.namedChildren)
+        for outerItem in child:
+            for innerItem in outerItem:
+                self.assertTrue(innerItem in children.allChildren)
+        self.assertEqual(child, children.namedChildren['first'])
+        self.assertEqual(len(children.allChildren), 600)
+
+    def test_remove_child_zero_dm(self):
+        child = DummyObject()
+        children = Children()
+        children.addChildNamed('first', child)
+        self.assertEqual(len(children.allChildren), 1)
+        children.removeChildNamed('first')
+        self.assertEqual(len(children.allChildren), 0)
+        self.assertFalse('first' in children.namedChildren)
+
+    def test_remove_child_one_dm(self):
+        child = [DummyObject() for d in range(10)]
+        children = Children()
+        children.addChildNamed('first', child)
+        self.assertEqual(len(children.allChildren), 10)
+        children.removeChildNamed('first')
+        self.assertEqual(len(children.allChildren), 0)
+        self.assertFalse('first' in children.namedChildren)
+
+    def test_remove_child_two_dm(self):
+        child = [
+            [DummyObject() for d in range(5)] for c in range(10)
+        ]
+        children = Children()
+        children.addChildNamed('first', child)
+        self.assertEqual(len(children.allChildren), 50)
+        children.removeChildNamed('first')
+        self.assertEqual(len(children.allChildren), 0)
+        self.assertFalse('first' in children.namedChildren)
+
+    def test_setitem_zero_dm(self):
+        child = DummyObject()
+        children = Children()
+        children['first'] = child
+        self.assertTrue('first' in children.namedChildren)
+        self.assertEqual(children.namedChildren['first'], child)
+        self.assertEqual(len(children.allChildren), 1)
+        self.assertEqual(children.dimensionsForChildNamed('first'), 0)
+
+    def test_setitem_one_dm(self):
+        child = [DummyObject() for d in range(10)]
+        children = Children()
+        children['first'] = child
+        self.assertTrue('first' in children.namedChildren)
+        self.assertEqual(child, children.namedChildren['first'])
+        self.assertEqual(len(children.allChildren), 10)
+        self.assertEqual(children.dimensionsForChildNamed('first'), 1)
+
+    def test_setitem_two_dm(self):
+        child = [
+            [DummyObject() for d in range(10)] for c in range(10)
+        ]
+        children = Children()
+        children['first'] = child
+        self.assertTrue('first' in children.namedChildren)
+        self.assertEqual(len(children.allChildren), 100)
+        self.assertEqual(child, children.namedChildren['first'])
+        self.assertEqual(children.dimensionsForChildNamed('first'), 2)
+
+    def test_set_parent_zero_dm(self):
+        parent = DummyObject()
+        children = Children(parent)
+        child = DummyObject()
+        children['test'] = child
+        self.assertEqual(child.parent, parent)
+        self.assertEqual(children.allChildren[0].parent, parent)
+
+    def test_set_parent_one_dm(self):
+        parent = DummyObject()
+        children = Children(parent)
+        child = [DummyObject() for d in range(10)]
+        children['test'] = child
+        for item in child:
+            self.assertEqual(item.parent, parent)
+        for item in children.allChildren:
+            self.assertEqual(item.parent, parent)
+
+    def test_set_parent_two_dm(self):
+        parent = DummyObject()
+        children = Children(parent)
+        child = [
+            [DummyObject() for d in range(5)] for c in range(5)
+        ]
+        children['test'] = child
+        for outerItem in child:
+            for innerItem in outerItem:
+                self.assertEqual(innerItem.parent, parent)
+        for item in children.allChildren:
+            self.assertEqual(item.parent, parent)
+
+    def test_set_parent_three_dm(self):
+        parent = DummyObject()
+        children = Children(parent)
+        child = [
+            [
+                [DummyObject() for d in range(5)] for c in range(5)
+            ] for b in range(4)
+        ]
+        children['test'] = child
+        for outer in child:
+            for middle in outer:
+                for inner in middle:
+                    self.assertIsNotNone(inner.parent)
+                    self.assertEqual(inner.parent, parent)
+        for item in children.allChildren:
+            self.assertIsNotNone(item.parent)
+            self.assertEqual(item.parent, parent)
+
+    def test_unset_parent_zero_dm(self):
+        parent = DummyObject()
+        children = Children(parent)
+        child = DummyObject()
+        children['test'] = child
+        self.assertEqual(child.parent, parent)
+        del children['test']
+        self.assertIsNone(child.parent)
+
+    def test_unset_parent_one_dm(self):
+        parent = DummyObject()
+        children = Children(parent)
+        child = [DummyObject() for d in range(4)]
+        children['test'] = child
+        for item in child:
+            self.assertEqual(item.parent, parent)
+        del children['test']
+        for item in child:
+            self.assertIsNone(item.parent)
+
+    def test_unset_parent_two_dm(self):
+        parent = DummyObject()
+        children = Children(parent)
+        child = [
+            [DummyObject() for d in range(5)] for c in range(5)
+        ]
+        children['test'] = child
+        for outer in child:
+            for inner in outer:
+                self.assertEqual(inner.parent, parent)
+        del children['test']
+        for outer in child:
+            for inner in outer:
+                self.assertIsNone(inner.parent)

--- a/object_database/web/cells/children_test.py
+++ b/object_database/web/cells/children_test.py
@@ -224,3 +224,38 @@ class CellChildrenTests(unittest.TestCase):
         for outer in child:
             for inner in outer:
                 self.assertIsNone(inner.parent)
+
+    def test_add_reverse_lookup_zero_dm(self):
+        children = Children()
+        child = DummyObject()
+        otherChild = DummyObject()
+        children['test'] = child
+        children['other_test'] = otherChild
+        self.assertTrue(child in children._reverseLookup)
+        self.assertEqual(children._reverseLookup[child], 'test')
+        self.assertTrue(otherChild in children._reverseLookup)
+        self.assertEqual(children._reverseLookup[otherChild], 'other_test')
+
+    def test_add_reverse_lookup_one_dm(self):
+        children = Children()
+        child = [DummyObject() for d in range(5)]
+        children['test'] = child
+        other_child = [DummyObject() for d in range(6)]
+        children['other_test'] = other_child
+        for item in child:
+            self.assertTrue(item in children._reverseLookup)
+            self.assertEqual(children._reverseLookup[item], 'test')
+        for item in other_child:
+            self.assertTrue(item in children._reverseLookup)
+            self.assertEqual(children._reverseLookup[item], 'other_test')
+
+    def test_add_reverse_lookup_two_dm(self):
+        children = Children()
+        child = [
+            [DummyObject() for d in range(5)] for c in range(10)
+        ]
+        children['test'] = child
+        for outer in child:
+            for inner in outer:
+                self.assertTrue(inner in children._reverseLookup)
+                self.assertEqual(children._reverseLookup[inner], 'test')

--- a/object_database/web/cells/children_test.py
+++ b/object_database/web/cells/children_test.py
@@ -259,3 +259,29 @@ class CellChildrenTests(unittest.TestCase):
             for inner in outer:
                 self.assertTrue(inner in children._reverseLookup)
                 self.assertEqual(children._reverseLookup[inner], 'test')
+
+    def test_remove_all(self):
+        # One dimensional child
+        zero_dm = DummyObject()
+
+        # Two dimensional child
+        one_dm = [DummyObject() for d in range(10)]
+
+        # Three dimensional child
+        two_dm = [
+            [DummyObject() for d in range(10)] for c in range(10)
+        ]
+
+        # Add the children
+        children = Children()
+        children['zero'] = zero_dm
+        children['one'] = one_dm
+        children['two'] = two_dm
+        self.assertEqual(len(children.allChildren), 111)
+        self.assertEqual(len(children.namedChildren.keys()), 3)
+
+        # Now remove all and ensure children
+        # is zeroed out
+        children.removeAll()
+        self.assertEqual(len(children.allChildren), 0)
+        self.assertEqual(len(children.namedChildren.keys()), 0)

--- a/object_database/web/cells/views/page_view.py
+++ b/object_database/web/cells/views/page_view.py
@@ -29,11 +29,8 @@ class PageView(Cell):
         self.updateChildren()
 
     def updateChildren(self):
-        self.children['____main__'] = self.main
-        self.namedChildren['main'] = self.main
+        self.children['main'] = self.main
         if self.header:
-            self.children['____header__'] = self.header
-            self.namedChildren['header'] = self.header
+            self.children['header'] = self.header
         if self.footer:
-            self.children['____footer__'] = self.footer
-            self.namedChildren['footer'] = self.footer
+            self.children['footer'] = self.footer

--- a/object_database/web/cells/views/resizable_panel.py
+++ b/object_database/web/cells/views/resizable_panel.py
@@ -24,23 +24,14 @@ class ResizablePanel(Cell):
         self.second = second
         self.split = split
         self.exportData['split'] = split
-        self.updateReplacements()
         self.updateNamedChildren()
-        self.contents = "____first__ ____second__"
 
     def recalculate(self):
         self.updateNamedChildren()
-        self.updateReplacements()
         self.exportData['split'] = self.split
 
-    def updateReplacements(self):
-        self.children = {
-            '____first__': Cell.makeCell(self.first),
-            '____second__': Cell.makeCell(self.second)
-        }
-
     def updateNamedChildren(self):
-        self.namedChildren = {
+        self.children.addFromDict({
             'first': Cell.makeCell(self.first),
             'second': Cell.makeCell(self.second)
-        }
+        })

--- a/object_database/web/cells/views/split_view.py
+++ b/object_database/web/cells/views/split_view.py
@@ -59,20 +59,12 @@ class SplitView(Cell):
         self.childrenTuples = childrenTuples
         self.split = split
 
-        self.updateReplacements()
         self.updateNamedChildren()
         self.updateProportionInfo()
 
     def recalculate(self):
-        self.updateReplacements()
         self.updateNamedChildren()
         self.updateProportionInfo()
-
-        # For now, we have to put something in contents
-        # to avoid the Cell/Cells infrastructure
-        # from throwing an error about replacements
-        # not being used.
-        self.contents = "\n".join(self.children.keys())
 
     def updateProportionInfo(self):
         """
@@ -88,14 +80,9 @@ class SplitView(Cell):
         self.exportData['proportions'] = proportions
         self.exportData['split'] = self.split
 
-    def updateReplacements(self):
-        for i in range(len(self.childrenTuples)):
-            childTuple = self.childrenTuples[i]
-            self.children["____element_{}__".format(i)] = Cell.makeCell(childTuple[0])
-
     def updateNamedChildren(self):
         newChildren = []
         for i in range(len(self.childrenTuples)):
             childTuple = self.childrenTuples[i]
             newChildren.append(Cell.makeCell(childTuple[0]))
-        self.namedChildren['elements'] = newChildren
+        self.children['elements'] = newChildren


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The PR implements changes to Cell children objects and how they behave.

## Motivation and Context
<!-- Why is this change required? -->
Until now, we have kept track of two different "children" collections
for each Cell: `namedChildren` and `children`. The two collections served
different purposes, but their respective functionality could be combined
into a single kind of collection. The advantages are:
  
* Easier to add / modify how the Cells infrastructure deals with
lifecycle operations, especially where child/parent relationships are
involved
* Reduction in code size
* Single, uniform child collection behavior that functions nearly the same on the front and back ends.
  
Because the Cells infrastructure has, until now, still relied upon the "old" `children` dictionary, we should re-emphasize why we needed `namedChildren` in the first place and what it does.
  
### The Need for `namedChildren` ###
On the frontend, we have components that need to know where to render different parts of a given Cell object in some hierarchical tree of DOM elements. For the many different kinds of Children that can appear in a complex component (like Table or similar), we need to be able to reference potential child Cells or lists of child Cells by name. Therefore we introduced `namedChildren`.
  
`namedChildren` is a little like the "old" `children` dictionary, except that:
  
1. `namedChildren` takes keys that are usable words (ie not replacement strings as in the old child collections) and that are not indexed (given an index number, like old child strings)
2. `namedChildren` values can be either a Cell instance, a list of Cell instances, or (for the moment) an n-dimensional (ie list of list of list etc) list of Cell instances.
  
When we communicate with the frontend via our message passing protocol (see `Messenger.py`), we pass serialized versions of the `namedChildren` structure. Components know how and where to render their specific `namedChildren` in their own internal DOM structures.
  
### The Need for Unified Children ###
`Cell` class definitions are complex enough that we don't need the trouble of maintaining two separate collections that deal with Cell children across the entire framework. Furthermore, having a unified kind of collection for children will allow us to tack on more OO-friendly patterns when refactoring and adding features to the ecosystem in the future (doing so also reduces lines of code).

<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
### New Class: `Children` ###
We introduce a new class called `Children`, whose definition you can see [here](https://github.com/APrioriInvestments/object_database/blob/eric-dev-cells-children-refac/object_database/web/cells/children.py).
  
`Children` aims to me "semi-polymorphic" with a collection like Dictionary. By "semi-polymorphic", we mean that it implements __some__ of the same behavior as Dictionary, while maintaining its own unique capabilities.
  
#### Implementation ####
Internally, all `Children` instances maintain three internal collections:
  
1. `namedChildren` -- This is identical to the current `namedChildren`. It maps unique names to either a Cell instance, a list of Cell instances, or n-dimensional collection of Cell instances. The `__setitem__` and `__getitem__` overrides simply forward method calls to this internal dictionary.
2. `allChildren` -- This is just an absolute, flat list of all Cell instances that are currently "in" the `Children` instance. This is what gets used when updated Cells on the backend and for looping through all children of a given Cell regardless of the named structures in which a given child is present.
3. `_reverseLookup` -- Maps Cell instances to the string names where the instance appears in `namedChildren`.
  
The various add/remove methodsof `Children` handle keeping these internal collections in sync with each other.
  
#### Parent Setting ####
When initializing a `Children`, you can optionally pass a Cell instance that will serve as the `parent` to all children that subsequently get added to the collection.
  
Anytime a child is added to `Children`, it sets the `parent` property of the child Cell to the `Children` instance's parent property value. Likewise, anytime a Cell child is removed from the collection, it sets that property to `None` for each Cell.
  
#### Overrides ####
We override some important methods in order to maintain the "semi-polymorphism" discussed above. For now these include:
  
* `__setitem__`: Wraps `addChildNamed()`, which assigns a key/val pair to the internal `namedChildren` and performs all syncing needed;
* `__getitem__`: Wraps a simple lookup on the internal `namedChildren`;
* `__del__`: Wraps `removeChildNamed`, which removes the given child from all internal collections and sets each removed child Cell instance's `parent` property back to `None`.
  

<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
We have created a test suite for `Children` and all tests are passing. Likewise, after updating the relevant code in `cells.py`, all normal Cells tests are also passing.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
