### PR TITLE
pytest configuration for better logging

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,10 @@ testpaths =
 norecursedirs =
     object_database/web/content
 
+log_level = INFO
+log_format = [%(asctime)s.%(msecs)03d] %(levelname)8s %(filename)30s:%(lineno)4s | %(threadName)10s | %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+
 
 # The pycodestyle section is used by autopep8
 [pycodestyle]


### PR DESCRIPTION
## Motivation and Context
Configure pytest to log by default the same way we configure our app logging when debugging, plus convenient thread names to distinguish logs coming from the same process but from different threads

## Approach
Configuration in tox.ini

## How Has This Been Tested?
Manually checked that it works and has the desired format

