### PR TITLE
Re-enable codecov (and improve .travis.yaml)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 dist: xenial
 
+
 language: python
+
 
 compiler: g++
 
+
 python:
   - 3.6
+
 
 env:
   global:
@@ -13,24 +17,24 @@ env:
     - PYTHONPATH=$(pwd)
     - COVERAGE_PROCESS_START="$(pwd)/tox.ini"
 
+
 cache:
   directories:
     - $HOME/.cache/pip
-
-install:
-  - pip install pipenv
 
 
 jobs:
   include:
     - stage: "Tests"
       name: "Lint"
+      install:
+        - pip install flake8
       script:
-        - pipenv lock --dev --requirements > dev-reqs.txt
-        - pip install -r dev-reqs.txt
         - make lint
 
     - name: "pipenv check"
+      install:
+        - pip install pipenv
       script:
         # `pipenv check` is occasionally flaky and depends on network connectivity,
         # so try up to 3 times, waiting 60 seconds between tries
@@ -39,13 +43,14 @@ jobs:
     - name: "Unit Tests"
       before_script:
         - ulimit -c unlimited -S       # enable core dumps
-      script:
-        - pip install codecov
+      install:
+        - pip install pipenv codecov
         - pipenv lock --dev --requirements > dev-reqs.txt
-        - pip install -r dev-reqs.txt
-        - pip install -e .  # install object_database in 'editable' form.
-        - sudo apt-get install -y gdb  # install gdb
+        - pip install --requirement dev-reqs.txt
+        - pip install --editable .  # install object_database in 'editable' form.
+        - sudo apt-get install --assume-yes gdb  # install gdb
         - make testcert.cert
+      script:
         - coverage erase
         - pytest
         - ls -la


### PR DESCRIPTION
## Motivation and Context
After the split of our `nativepython` mono-repo into `typed_python` and `object_database`, the `codecov` integration got broken. This PR makes sure `codecov` works again.

## Approach & Testing
I went into the `codecov` profile and made sure I added `object_database` to the repos being checked. Then checked that subsequent TravisCI builds (e.g., the ones for this PR) did trigger the `codecov` integration. In the process, I made some (mostly aesthetic) improvements to `.travis.yaml`.
