### PR TITLE
Black config & code-base formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,12 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-# -   repo: https://github.com/ambv/black
-#     rev: 19.3b0
-#     hooks:
-#     -   id: black
+-   repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+    -   id: black
+        args: [ --target-version=py36, --line-length=95]
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
       install:
         - pip install flake8
       script:
-        - make lint
+        - make lint-local
 
     - name: "pipenv check"
       install:
@@ -39,6 +39,12 @@ jobs:
         # `pipenv check` is occasionally flaky and depends on network connectivity,
         # so try up to 3 times, waiting 60 seconds between tries
         - pipenv check || (sleep 60; pipenv check) || (sleep 60; pipenv check)
+
+    - name: "black check"
+      install:
+        - pip install black
+      script:
+        - make black-check-local
 
     - name: "Unit Tests"
       before_script:

--- a/Makefile
+++ b/Makefile
@@ -52,23 +52,28 @@ TESTTYPES2 = $(DT_SRC_PATH)/ClientToServer0.hpp
 #  MAIN RULES
 
 .PHONY: install
-install: $(VIRTUAL_ENV) testcert.cert testcert.key
+install: $(VIRTUAL_ENV) testcert.cert testcert.key pre-commit-install
 	. $(VIRTUAL_ENV)/bin/activate; \
-		pip3 install pipenv==2018.11.26; \
+		pip install pipenv==2018.11.26; \
 		pipenv install --dev --deploy; \
-		pip3 install -e .; \
-		nodeenv -p --prebuilt --node=10.15.3 $(NODE_ENV); \
-		npm install -g webpack webpack-cli; \
+		pip install -e .; \
+		nodeenv --python-virtualenv --prebuilt --node=10.15.3 $(NODE_ENV); \
+		npm install --global webpack webpack-cli; \
 		cd object_database/web/content; \
 		npm install; \
 	 	webpack
+
+.PHONY: pre-commit-install
+pre-commit-install: $(VIRTUAL_ENV)
+	pip install pre-commit
+	pre-commit install
 
 .PHONY: node-install
 node-install:
 	pip3 install nodeenv; \
 	nodeenv --prebuilt --node=10.15.3 $(NODE_ENV); \
 	. $(NODE_ENV)/bin/activate; \
-	npm install -g webpack webpack-cli; \
+	npm install --global webpack webpack-cli; \
 	cd object_database/web/content; \
 	npm install
 
@@ -82,11 +87,11 @@ build-js:
 install_local: $(VIRTUAL_ENV)
 	. $(VIRTUAL_ENV)/bin/activate; \
 		pip install pipenv==2018.11.26; \
-		pip install -e ../typed_python; \
-		pip install -e .
+		pip install --editable ../typed_python; \
+		pip install --editable .
 
 .PHONY: test
-test: testcert.cert testcert.key js-test
+test: $(VIRTUAL_ENV) testcert.cert testcert.key js-test
 	. $(VIRTUAL_ENV)/bin/activate; pytest
 
 .PHONY:
@@ -193,7 +198,3 @@ testcert.cert testcert.key:
 	openssl req -x509 -newkey rsa:2048 -keyout testcert.key -nodes \
 		-out testcert.cert -sha256 -days 1000 \
 		-subj '/C=US/ST=New York/L=New York/CN=localhost'
-
-
-
-

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,15 @@ black: $(VIRTUAL_ENV)
 	. $(VIRTUAL_ENV)/bin/activate; \
 		black --target-version=py36  --line-length=95  .
 
+.PHONY: black-check
+black-check: $(VIRTUAL_ENV)
+	. $(VIRTUAL_ENV)/bin/activate; \
+		make black-check-local
+
+.PHONY: black-check-local
+black-check-local:
+	black --check --target-version=py36  --line-length=95  .
+
 .PHONY: lib
 lib: object_database/_types.cpython-36m-x86_64-linux-gnu.so
 

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ js-test:
 
 .PHONY: lint-local
 lint-local:
-	flake8 --show-source
+	flake8
 
 .PHONY: lint
 lint: $(VIRTUAL_ENV)

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,8 @@ build-js:
 	cd object_database/web/content; \
 	npm run build
 
-.PHONY: install_local
-install_local: $(VIRTUAL_ENV)
+.PHONY: install-local
+install-local: $(VIRTUAL_ENV)
 	. $(VIRTUAL_ENV)/bin/activate; \
 		pip install pipenv==2018.11.26; \
 		pip install --editable ../typed_python; \
@@ -99,14 +99,14 @@ test: $(VIRTUAL_ENV) testcert.cert testcert.key js-test
 js-test:
 	cd object_database/web/content/; npm test
 
-.PHONY: lint
-lint:
+.PHONY: lint-local
+lint-local:
 	flake8 --show-source
 
-.PHONY: vlint
-vlint: $(VIRTUAL_ENV)
+.PHONY: lint
+lint: $(VIRTUAL_ENV)
 	. $(VIRTUAL_ENV)/bin/activate; \
-		make lint
+		make lint-local
 
 .PHONY: black
 black: $(VIRTUAL_ENV)

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ TESTTYPES2 = $(DT_SRC_PATH)/ClientToServer0.hpp
 install: $(VIRTUAL_ENV) testcert.cert testcert.key pre-commit-install
 	. $(VIRTUAL_ENV)/bin/activate; \
 		pip install pipenv==2018.11.26; \
+		pip install black; \
 		pipenv install --dev --deploy; \
 		pip install -e .; \
 		nodeenv --python-virtualenv --prebuilt --node=10.15.3 $(NODE_ENV); \
@@ -106,6 +107,11 @@ lint:
 vlint: $(VIRTUAL_ENV)
 	. $(VIRTUAL_ENV)/bin/activate; \
 		make lint
+
+.PHONY: black
+black: $(VIRTUAL_ENV)
+	. $(VIRTUAL_ENV)/bin/activate; \
+		black --target-version=py36  --line-length=95  .
 
 .PHONY: lib
 lib: object_database/_types.cpython-36m-x86_64-linux-gnu.so

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ coverage = "*"
 pytest = "*"
 flaky = "*"
 nodeenv = "*"
+pre-commit = "*"
 
 [packages]
 boto3 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "54311051a6410272cae9aaf08c3790a55032ba33990e85c222428faeb3f1fe6c"
+            "sha256": "36aa25da017b1442432ce3bee3da0700837f338a1f04887306212fff3d3ce2f1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -457,6 +457,13 @@
         }
     },
     "develop": {
+        "aspy.yaml": {
+            "hashes": [
+                "sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc",
+                "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"
+            ],
+            "version": "==1.3.0"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
@@ -486,6 +493,13 @@
             ],
             "index": "pypi",
             "version": "==4.8.1"
+        },
+        "cfgv": {
+            "hashes": [
+                "sha256:edb387943b665bf9c434f717bf630fa78aecd53d5900d2e05da6ad6048553144",
+                "sha256:fbd93c9ab0a523bf7daec408f3be2ed99a980e20b2d19b50fc184ca6b820d289"
+            ],
+            "version": "==2.0.1"
         },
         "coverage": {
             "hashes": [
@@ -548,6 +562,13 @@
             "index": "pypi",
             "version": "==3.6.1"
         },
+        "identify": {
+            "hashes": [
+                "sha256:4f1fe9a59df4e80fcb0213086fcf502bc1765a01ea4fe8be48da3b65afd2a017",
+                "sha256:d8919589bd2a5f99c66302fec0ef9027b12ae150b0b0213999ad3f695fc7296e"
+            ],
+            "version": "==1.4.7"
+        },
         "importlib-metadata": {
             "hashes": [
                 "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
@@ -555,6 +576,14 @@
             ],
             "markers": "python_version < '3.8'",
             "version": "==0.23"
+        },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b",
+                "sha256:d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"
+            ],
+            "markers": "python_version < '3.7'",
+            "version": "==1.0.2"
         },
         "mccabe": {
             "hashes": [
@@ -590,6 +619,14 @@
                 "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
             "version": "==0.13.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:1d3c0587bda7c4e537a46c27f2c84aa006acc18facf9970bf947df596ce91f3f",
+                "sha256:fa78ff96e8e9ac94c748388597693f18b041a181c94a4f039ad20f45287ba44a"
+            ],
+            "index": "pypi",
+            "version": "==1.18.3"
         },
         "py": {
             "hashes": [
@@ -627,6 +664,25 @@
             "index": "pypi",
             "version": "==5.2.1"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+            ],
+            "index": "pypi",
+            "version": "==5.1.2"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
@@ -640,6 +696,20 @@
                 "sha256:b91d676b330a0ebd5b21719cb6e9b57c57d433671f65b9c28dd3461d9a1ed0b6"
             ],
             "version": "==1.9.4"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:11cb4608930d5fd3afb545ecf8db83fa50e1f96fc4fca80c94b07d2c83146589",
+                "sha256:d257bb3773e48cac60e475a19b608996c73f4d333b3ba2e4e57d5ac6134e0136"
+            ],
+            "version": "==16.7.7"
         },
         "wcwidth": {
             "hashes": [

--- a/object_database/RedisTestHelper.py
+++ b/object_database/RedisTestHelper.py
@@ -28,8 +28,17 @@ class RedisTestHelper:
                 redis_path = "/usr/local/bin/redis-server"
 
             self.redisProcess = subprocess.Popen(
-                [redis_path, '--port', str(self.port), '--logfile', os.path.join(self.tempDirName, "log.txt"),
-                    "--dbfilename", "db.rdb", "--dir", os.path.join(self.tempDirName)]
+                [
+                    redis_path,
+                    "--port",
+                    str(self.port),
+                    "--logfile",
+                    os.path.join(self.tempDirName, "log.txt"),
+                    "--dbfilename",
+                    "db.rdb",
+                    "--dir",
+                    os.path.join(self.tempDirName),
+                ]
             )
 
             t0 = time.time()

--- a/object_database/VersionedIdSet_test.py
+++ b/object_database/VersionedIdSet_test.py
@@ -33,41 +33,41 @@ class VersionedIdSetTest(unittest.TestCase):
 
         s.add(tid, oid)
 
-        self.assertFalse(s.isActive(tid-1, oid))
+        self.assertFalse(s.isActive(tid - 1, oid))
         self.assertTrue(s.isActive(tid, oid))
-        self.assertTrue(s.isActive(tid+1, oid))
+        self.assertTrue(s.isActive(tid + 1, oid))
 
         self.assertEqual(s.transactionCount(), 1)
         self.assertEqual(s.transactionCount(), 1)
 
-        self.assertEqual(s.lookupOne(tid-1), -1)
+        self.assertEqual(s.lookupOne(tid - 1), -1)
         self.assertEqual(s.lookupOne(tid), oid)
-        self.assertEqual(s.lookupOne(tid+1), oid)
+        self.assertEqual(s.lookupOne(tid + 1), oid)
 
-        self.assertEqual(s.lookupFirst(tid-1), -1)
+        self.assertEqual(s.lookupFirst(tid - 1), -1)
         self.assertEqual(s.lookupFirst(tid), oid)
-        self.assertEqual(s.lookupFirst(tid+1), oid)
+        self.assertEqual(s.lookupFirst(tid + 1), oid)
 
-        self.assertEqual(s.lookupNext(tid-1, oid), -1)
+        self.assertEqual(s.lookupNext(tid - 1, oid), -1)
         self.assertEqual(s.lookupNext(tid, oid), -1)
-        self.assertEqual(s.lookupNext(tid+1, oid), -1)
+        self.assertEqual(s.lookupNext(tid + 1, oid), -1)
 
         s.add(tid, oid2)
-        self.assertEqual(s.lookupOne(tid-1), -1)
+        self.assertEqual(s.lookupOne(tid - 1), -1)
         self.assertEqual(s.lookupOne(tid), -1)
-        self.assertEqual(s.lookupOne(tid+1), -1)
+        self.assertEqual(s.lookupOne(tid + 1), -1)
 
-        self.assertEqual(s.lookupFirst(tid-1), -1)
+        self.assertEqual(s.lookupFirst(tid - 1), -1)
         self.assertEqual(s.lookupFirst(tid), oid)
-        self.assertEqual(s.lookupFirst(tid+1), oid)
+        self.assertEqual(s.lookupFirst(tid + 1), oid)
 
-        self.assertEqual(s.lookupNext(tid-1, oid), -1)
+        self.assertEqual(s.lookupNext(tid - 1, oid), -1)
         self.assertEqual(s.lookupNext(tid, oid), oid2)
-        self.assertEqual(s.lookupNext(tid+1, oid), oid2)
+        self.assertEqual(s.lookupNext(tid + 1, oid), oid2)
 
-        self.assertEqual(s.lookupNext(tid-1, oid2), -1)
+        self.assertEqual(s.lookupNext(tid - 1, oid2), -1)
         self.assertEqual(s.lookupNext(tid, oid2), -1)
-        self.assertEqual(s.lookupNext(tid+1, oid2), -1)
+        self.assertEqual(s.lookupNext(tid + 1, oid2), -1)
 
     def test_add_and_remove(self):
         s = VersionedIdSet()
@@ -109,7 +109,7 @@ class VersionedIdSetTest(unittest.TestCase):
 
             s2.moveGuaranteedLowestIdForward(tid - 10)
 
-            for tid in range(tid-10, tid+10):
+            for tid in range(tid - 10, tid + 10):
                 activeCount = 0
 
                 for oid in oids:

--- a/object_database/__init__.py
+++ b/object_database/__init__.py
@@ -36,6 +36,6 @@ from object_database.view import (
     RevisionConflictException,
     DisconnectedException,
     current_transaction,
-    MaskView
+    MaskView,
 )
 from object_database.inmem_server import InMemServer

--- a/object_database/algebraic_protocol.py
+++ b/object_database/algebraic_protocol.py
@@ -20,7 +20,7 @@ import traceback
 
 from typed_python import serialize, deserialize
 
-sizeType = '<L'
+sizeType = "<L"
 longLength = struct.calcsize(sizeType)
 
 
@@ -43,7 +43,11 @@ class AlgebraicProtocol(asyncio.Protocol):
 
     def sendMessage(self, msg):
         try:
-            assert isinstance(msg, self.sendType), "message %s is of type %s != %s" % (msg, type(msg), self.sendType)
+            assert isinstance(msg, self.sendType), "message %s is of type %s != %s" % (
+                msg,
+                type(msg),
+                self.sendType,
+            )
 
             dataToSend = serialize(self.sendType, msg)
             dataToSend = longToString(len(dataToSend)) + dataToSend
@@ -72,15 +76,17 @@ class AlgebraicProtocol(asyncio.Protocol):
         while len(self.buffer) >= longLength:
             bytesToRead = stringToLong(self.buffer[:longLength])
             if bytesToRead + longLength <= len(self.buffer):
-                toConsume = self.buffer[longLength:bytesToRead + longLength]
+                toConsume = self.buffer[longLength : bytesToRead + longLength]
 
-                self.buffer = self.buffer[bytesToRead + longLength:]
+                self.buffer = self.buffer[bytesToRead + longLength :]
 
                 if toConsume:
                     try:
                         self.messageReceived(deserialize(self.receiveType, bytes(toConsume)))
                     except Exception:
-                        self._logger.error("Error in AlgebraicProtocol: %s", traceback.format_exc())
+                        self._logger.error(
+                            "Error in AlgebraicProtocol: %s", traceback.format_exc()
+                        )
                         self.transport.close()
             else:
                 return

--- a/object_database/algebraic_protocol_test.py
+++ b/object_database/algebraic_protocol_test.py
@@ -21,11 +21,7 @@ import ssl
 import unittest
 
 
-Message = Alternative(
-    "Message",
-    Ping={},
-    Pong={}
-)
+Message = Alternative("Message", Ping={}, Pong={})
 
 
 class PingPongProtocol(AlgebraicProtocol):
@@ -65,16 +61,14 @@ class AlgebraicProtocolTests(unittest.TestCase):
         loop = self.loop
 
         # Each client connection will create a new protocol instance
-        serverCoro = loop.create_server(PingPongProtocol, '127.0.0.1', 8888)
+        serverCoro = loop.create_server(PingPongProtocol, "127.0.0.1", 8888)
 
         server = loop.run_until_complete(serverCoro)
 
         q = queue.Queue()
 
         clientCoro = loop.create_connection(
-            lambda: SendAndReturn(Message.Ping(), q),
-            '127.0.0.1',
-            8888
+            lambda: SendAndReturn(Message.Ping(), q), "127.0.0.1", 8888
         )
         loop.run_until_complete(clientCoro)
 
@@ -93,16 +87,13 @@ class AlgebraicProtocolTests(unittest.TestCase):
         #
         # use 'localhost' as Common Name (CN)
         loop = self.loop
-        host = 'localhost'
+        host = "localhost"
         port = 8888
 
         srv_ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        srv_ssl_ctx.load_cert_chain('testcert.cert', 'testcert.key')
+        srv_ssl_ctx.load_cert_chain("testcert.cert", "testcert.key")
         # Each client connection will create a new protocol instance
-        serverCoro = loop.create_server(
-            PingPongProtocol, host, port,
-            ssl=srv_ssl_ctx,
-        )
+        serverCoro = loop.create_server(PingPongProtocol, host, port, ssl=srv_ssl_ctx)
 
         server = loop.run_until_complete(serverCoro)
 
@@ -110,10 +101,7 @@ class AlgebraicProtocolTests(unittest.TestCase):
 
         def pingServer(ssl_ctx):
             clientCoro = loop.create_connection(
-                lambda: SendAndReturn(Message.Ping(), q),
-                host,
-                port,
-                ssl=ssl_ctx
+                lambda: SendAndReturn(Message.Ping(), q), host, port, ssl=ssl_ctx
             )
             try:
                 loop.run_until_complete(clientCoro)
@@ -123,8 +111,7 @@ class AlgebraicProtocolTests(unittest.TestCase):
         # This is how to use SSL for encryption AND auth
         # In this scenario, the client NEEDS to have the self-signed cert
         cli_ssl_ctx = ssl.create_default_context(
-            ssl.Purpose.SERVER_AUTH,
-            cafile='testcert.cert'
+            ssl.Purpose.SERVER_AUTH, cafile="testcert.cert"
         )
         pingServer(cli_ssl_ctx)
 

--- a/object_database/bytecount_limited_queue.py
+++ b/object_database/bytecount_limited_queue.py
@@ -22,6 +22,7 @@ class BytecountLimitedQueue(object):
     We parametrize the Queue with a function that decides how many bytes are in a
     given message.
     """
+
     def __init__(self, bytecountFunction, maxBytes=None):
         self._bytecountFunction = bytecountFunction
         self._canPushCondition = threading.Condition(threading.Lock())

--- a/object_database/database_connection.py
+++ b/object_database/database_connection.py
@@ -92,7 +92,7 @@ class DatabaseConnection:
 
         self._pendingSubscriptions = {}
 
-        # from (schema, typename, fieldname_and_val) -> {'values', 'index_values', 'identities'}
+        # (schema, typename, fieldname_and_val) -> {'values', 'index_values', 'identities'}
         # where (fieldname_and_val) is OneOf(None, (str, IndexValue))
         self._subscription_buildup = {}
 
@@ -673,9 +673,9 @@ class DatabaseConnection:
                     self._max_tid_by_schema_and_type[fieldDef.schema, fieldDef.typename] = tid
 
     def _indexValuesToSetAdds(self, indexValues):
-        # indexValues contains (schema:typename:identity:fieldname -> indexHashVal) which builds
-        # up the indices we need. We need to transpose to a dictionary ordered by the hash values,
-        # not the identities
+        # indexValues contains (schema:typename:identity:fieldname -> indexHashVal)
+        # which builds up the indices we need. We need to transpose to a
+        # dictionary ordered by the hash values, not the identities.
 
         t0 = time.time()
         heartbeatInterval = getHeartbeatInterval()

--- a/object_database/database_connection_state_test.py
+++ b/object_database/database_connection_state_test.py
@@ -30,7 +30,7 @@ class DatabaseConnectionStateTests(unittest.TestCase):
                 i,
                 {ObjectFieldId(objId=0, fieldId=0, isIndexValue=False): b" " * 10000},
                 {IndexId(fieldId=0, indexValue=b" " * 10000): (i,)},
-                {IndexId(fieldId=0, indexValue=b" " * 10000): (i-1,)} if i > 0 else {},
+                {IndexId(fieldId=0, indexValue=b" " * 10000): (i - 1,)} if i > 0 else {},
             )
 
         self.assertLess(currentMemUsageMb() - m0, 1)
@@ -45,7 +45,7 @@ class DatabaseConnectionStateTests(unittest.TestCase):
                 i,
                 {ObjectFieldId(objId=0, fieldId=0, isIndexValue=False): b" " * i},
                 {IndexId(fieldId=0, indexValue=b" " * i): (0,)},
-                {IndexId(fieldId=0, indexValue=b" " * (i-1)): (0,)} if i > 0 else {},
+                {IndexId(fieldId=0, indexValue=b" " * (i - 1)): (0,)} if i > 0 else {},
             )
 
         self.assertLess(currentMemUsageMb() - m0, 1)

--- a/object_database/database_frontend_test.py
+++ b/object_database/database_frontend_test.py
@@ -27,23 +27,31 @@ class ObjectDatabaseFrontEnd(unittest.TestCase):
     def test_can_run_throughput_test(self):
         try:
             token = genToken()
-            server = subprocess.Popen([
-                sys.executable,
-                os.path.join(own_dir, "frontends", "database_server.py"),
-                "localhost", "8889",
-                "--service-token", token,
-                "--inmem"]
+            server = subprocess.Popen(
+                [
+                    sys.executable,
+                    os.path.join(own_dir, "frontends", "database_server.py"),
+                    "localhost",
+                    "8889",
+                    "--service-token",
+                    token,
+                    "--inmem",
+                ]
             )
 
             time.sleep(2.5)
 
-            client = subprocess.run([
-                sys.executable,
-                os.path.join(own_dir, "frontends", "database_throughput_test.py"),
-                "localhost", "8889",
-                "--service-token", token,
-                "1"
-            ])
+            client = subprocess.run(
+                [
+                    sys.executable,
+                    os.path.join(own_dir, "frontends", "database_throughput_test.py"),
+                    "localhost",
+                    "8889",
+                    "--service-token",
+                    token,
+                    "1",
+                ]
+            )
 
             self.assertEqual(client.returncode, 0)
         finally:

--- a/object_database/database_ring_invariant_test.py
+++ b/object_database/database_ring_invariant_test.py
@@ -72,7 +72,7 @@ class Ring:
 class RingInvariantTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        configureLogging('database_ring_invariant_test')
+        configureLogging("database_ring_invariant_test")
 
     def setUp(self):
         self.token = genToken()
@@ -94,7 +94,7 @@ class RingInvariantTest(unittest.TestCase):
             r = Ring.New()
             for i in range(10):
                 r.insert(i)
-                self.assertEqual(r.check(), (i+2, 0))
+                self.assertEqual(r.check(), (i + 2, 0))
 
     def test_ring_invariants_reader_writer(self):
         db = self.createNewDb()
@@ -127,12 +127,12 @@ class RingInvariantTest(unittest.TestCase):
         for i in range(100):
             writeSome()
 
-            isLazy = (i%2) == 0
+            isLazy = (i % 2) == 0
 
             k = None if i % 5 != 3 or not isLazy else numpy.random.choice(10)
 
-            print("Pass ", i, 'isLazy=', isLazy, 'k=', k)
+            print("Pass ", i, "isLazy=", isLazy, "k=", k)
 
             count, sum = checkSome(isLazy, k)
-            self.assertEqual(count, i+2)
+            self.assertEqual(count, i + 2)
             self.assertEqual(sum, 0)

--- a/object_database/database_test.py
+++ b/object_database/database_test.py
@@ -18,7 +18,11 @@ from typed_python.SerializationContext import SerializationContext
 
 from object_database.schema import Indexed, Index, Schema, SubscribeLazilyByDefault
 from object_database.core_schema import core_schema
-from object_database.view import RevisionConflictException, DisconnectedException, ObjectDoesntExistException
+from object_database.view import (
+    RevisionConflictException,
+    DisconnectedException,
+    ObjectDoesntExistException,
+)
 from object_database.database_connection import DatabaseConnection
 from object_database.tcp_server import TcpServer
 from object_database.inmem_server import InMemServer
@@ -60,7 +64,7 @@ class BlockingCallback:
 
 expr = Alternative(
     "Expr",
-    Constant={'value': int},
+    Constant={"value": int},
     # Add = {'l': expr, 'r': expr},
     # Sub = {'l': expr, 'r': expr},
     # Mul = {'l': expr, 'r': expr}
@@ -172,14 +176,14 @@ class ThingWithObjectIndex:
     value = Indexed(object)
     name = str
 
-    name_and_value = Index('name', 'value')
+    name_and_value = Index("name", "value")
 
 
 class ObjectDatabaseTests:
     @classmethod
     def setUpClass(cls):
         configureLogging("database_test")
-        cls.PERFORMANCE_FACTOR = 1.0 if os.environ.get('TRAVIS_CI', None) is None else 2.0
+        cls.PERFORMANCE_FACTOR = 1.0 if os.environ.get("TRAVIS_CI", None) is None else 2.0
 
     def test_object_indices(self):
         db = self.createNewDb()
@@ -195,7 +199,9 @@ class ObjectDatabaseTests:
             z.name = "name"
             self.assertEqual(ThingWithObjectIndex.lookupAny(value=z), None)
             self.assertEqual(ThingWithObjectIndex.lookupAny(value="hello"), z)
-            self.assertEqual(ThingWithObjectIndex.lookupAny(name_and_value=("name", "hello")), z)
+            self.assertEqual(
+                ThingWithObjectIndex.lookupAny(name_and_value=("name", "hello")), z
+            )
 
     def test_assigning_dicts(self):
         db = self.createNewDb()
@@ -203,7 +209,7 @@ class ObjectDatabaseTests:
 
         with db.transaction():
             z = ThingWithDicts()
-            z.x = {'a': b'b'}
+            z.x = {"a": b"b"}
 
         with db.transaction():
             z2 = ThingWithDicts()
@@ -216,7 +222,7 @@ class ObjectDatabaseTests:
         with db.transaction():
             x = ThingWithInit()
             y = ThingWithInit(1, y=1000)
-            z = ThingWithInitAndInitializableRef() # noqa
+            z = ThingWithInitAndInitializableRef()  # noqa
 
         with db.view():
             self.assertEqual(x.x, 0)
@@ -350,7 +356,9 @@ class ObjectDatabaseTests:
                 super().__init__(x)
                 self.y = y
 
-        db.setSerializationContext(SerializationContext({'ABC': ArbitraryBaseClass, 'SUB': ArbitrarySubclass}))
+        db.setSerializationContext(
+            SerializationContext({"ABC": ArbitraryBaseClass, "SUB": ArbitrarySubclass})
+        )
 
         schema = Schema("test_schema")
 
@@ -476,8 +484,8 @@ class ObjectDatabaseTests:
 
         self.assertTrue(
             db1.waitForCondition(
-                lambda: not db2Connection.exists(),
-                timeout=2.0*self.PERFORMANCE_FACTOR)
+                lambda: not db2Connection.exists(), timeout=2.0 * self.PERFORMANCE_FACTOR
+            )
         )
 
     def checkCallbackTriggersLazyLoad(self, callback, shouldExist=True):
@@ -517,7 +525,7 @@ class ObjectDatabaseTests:
         self.checkCallbackTriggersLazyLoad(lambda c: self.assertEqual(c.k, 2))
 
     def test_lazy_subscriptions_write(self):
-        self.checkCallbackTriggersLazyLoad(lambda c: setattr(c, 'k', 20))
+        self.checkCallbackTriggersLazyLoad(lambda c: setattr(c, "k", 20))
 
     def test_lazy_subscriptions_exists(self):
         self.checkCallbackTriggersLazyLoad(lambda c: c.exists())
@@ -651,6 +659,7 @@ class ObjectDatabaseTests:
             t = Test(i=1)
 
         schema2 = Schema("schema")
+
         @schema2.define
         class Test:
             i = int
@@ -724,8 +733,7 @@ class ObjectDatabaseTests:
             FINISHED.append(True)
 
             db.waitForCondition(
-                lambda: len(FINISHED) == threadCount,
-                10.0*self.PERFORMANCE_FACTOR
+                lambda: len(FINISHED) == threadCount, 10.0 * self.PERFORMANCE_FACTOR
             )
             db.flush()
 
@@ -733,7 +741,7 @@ class ObjectDatabaseTests:
                 actuallyVisible = len(Counter.lookupAll())
 
             if actuallyVisible != count * threadCount:
-                print("TOTAL is ", actuallyVisible, " != ", count*threadCount)
+                print("TOTAL is ", actuallyVisible, " != ", count * threadCount)
             else:
                 OK.append(True)
 
@@ -747,7 +755,7 @@ class ObjectDatabaseTests:
         db1 = self.createNewDb()
         db1.subscribeToSchema(schema)
         with db1.view():
-            self.assertEqual(len(Counter.lookupAll()), count*threadCount)
+            self.assertEqual(len(Counter.lookupAll()), count * threadCount)
 
         db2 = self.createNewDb()
 
@@ -755,7 +763,7 @@ class ObjectDatabaseTests:
             db2.subscribeToIndex(Counter, k=i)
         db2.flush()
         with db2.view():
-            self.assertEqual(len(Counter.lookupAll()), count*threadCount)
+            self.assertEqual(len(Counter.lookupAll()), count * threadCount)
 
         self.assertEqual(len(OK), 10)
 
@@ -1084,7 +1092,7 @@ class ObjectDatabaseTests:
                     counter = counters[int(random.random() * len(counters))]
 
                     if counter.exists():
-                        if random.random() < .001:
+                        if random.random() < 0.001:
                             counter.delete()
                         else:
                             counter.k = int(random.random() * 100)
@@ -1092,12 +1100,14 @@ class ObjectDatabaseTests:
                         didOne = True
 
                 if didOne:
-                    counter_vals_by_tn[db._cur_transaction_num + 1] = {c: c.k for c in counters if c.exists()}
+                    counter_vals_by_tn[db._cur_transaction_num + 1] = {
+                        c: c.k for c in counters if c.exists()
+                    }
 
             if didOne:
                 views_by_tn[db._cur_transaction_num] = db.view()
 
-            while views_by_tn and random.random() < .5 or len(views_by_tn) > 10:
+            while views_by_tn and random.random() < 0.5 or len(views_by_tn) > 10:
                 # pick a random view and check that it's consistent
                 all_tids = list(views_by_tn)
                 tid = all_tids[int(random.random() * len(all_tids))]
@@ -1111,7 +1121,7 @@ class ObjectDatabaseTests:
 
                 del views_by_tn[tid]
 
-            if random.random() < .05 and views_by_tn:
+            if random.random() < 0.05 and views_by_tn:
                 with db.view():
                     curCounterVals = {c: c.k for c in counters if c.exists()}
 
@@ -1151,7 +1161,7 @@ class ObjectDatabaseTests:
         # database doesn't have this
         t0 = time.time()
         while time.time() - t0 < 1.0 and self.mem_store.storedStringCount() >= 2:
-            time.sleep(.01)
+            time.sleep(0.01)
 
         self.assertLess(self.mem_store.storedStringCount(), 4)
 
@@ -1296,14 +1306,13 @@ class ObjectDatabaseTests:
         with db.transaction():
             while obs:
                 # delete a middle object in the list
-                obs.pop(len(obs)//2).delete()
+                obs.pop(len(obs) // 2).delete()
 
                 getId = lambda o: o._identity
 
                 # in-view version of this should be correct
                 self.assertEqual(
-                    sorted(Counter.lookupAll(), key=getId),
-                    sorted(obs, key=getId)
+                    sorted(Counter.lookupAll(), key=getId), sorted(obs, key=getId)
                 )
 
     def test_index_consistency(self):
@@ -1316,8 +1325,8 @@ class ObjectDatabaseTests:
             x = int
             y = int
 
-            pair = Index('x', 'y')
-            single = Index('x')
+            pair = Index("x", "y")
+            single = Index("x")
 
         db.subscribeToSchema(schema)
 
@@ -1391,7 +1400,7 @@ class ObjectDatabaseTests:
         class Object:
             k = Indexed(int)
 
-            pair_index = Index('k', 'k')
+            pair_index = Index("k", "k")
 
         db.subscribeToSchema(schema)
 
@@ -1574,8 +1583,8 @@ class ObjectDatabaseTests:
             c2_0 = Counter(k=0)
             c2_1 = Counter(k=1)
 
-        db1.waitForCondition(lambda: c2_0.exists(), 2*self.PERFORMANCE_FACTOR)
-        db2.waitForCondition(lambda: c2_1.exists(), 2*self.PERFORMANCE_FACTOR)
+        db1.waitForCondition(lambda: c2_0.exists(), 2 * self.PERFORMANCE_FACTOR)
+        db2.waitForCondition(lambda: c2_1.exists(), 2 * self.PERFORMANCE_FACTOR)
 
         with db2.view():
             self.assertFalse(c2_0.exists())
@@ -1586,15 +1595,15 @@ class ObjectDatabaseTests:
         with db_all.transaction():
             c2_0.k = 1
 
-        db1.waitForCondition(lambda: c2_0.exists(), 2*self.PERFORMANCE_FACTOR)
-        db2.waitForCondition(lambda: c2_0.exists(), 2*self.PERFORMANCE_FACTOR)
+        db1.waitForCondition(lambda: c2_0.exists(), 2 * self.PERFORMANCE_FACTOR)
+        db2.waitForCondition(lambda: c2_0.exists(), 2 * self.PERFORMANCE_FACTOR)
 
         # now, we should see it get subscribed to in both
         with db_all.transaction():
             c2_0.x = 40
 
-        db1.waitForCondition(lambda: c2_0.x == 40, 2*self.PERFORMANCE_FACTOR)
-        db2.waitForCondition(lambda: c2_0.x == 40, 2*self.PERFORMANCE_FACTOR)
+        db1.waitForCondition(lambda: c2_0.x == 40, 2 * self.PERFORMANCE_FACTOR)
+        db2.waitForCondition(lambda: c2_0.x == 40, 2 * self.PERFORMANCE_FACTOR)
 
         # but if we make a new database connection and subscribe, we won't see it
         db3 = self.createNewDb()
@@ -1667,7 +1676,7 @@ class ObjectDatabaseTests:
         r1.start()
 
         try:
-            time.sleep(.10)
+            time.sleep(0.10)
             self.assertEqual(executed[0], 0)
 
             with db.transaction():
@@ -1746,7 +1755,7 @@ class ObjectDatabaseTests:
         db.subscribeToSchema(s)
 
         with db.transaction():
-            someThings = [Thing(nextUpdate=t0+0.001, timesUpdated=0) for _ in range(10)]
+            someThings = [Thing(nextUpdate=t0 + 0.001, timesUpdated=0) for _ in range(10)]
 
         def incrementor():
             with db.transaction():
@@ -1767,7 +1776,11 @@ class ObjectDatabaseTests:
         self.assertTrue(time.time() - t0 < 1.2)
 
         r1.start()
-        self.assertTrue(db.waitForCondition(lambda: sum(x.timesUpdated for x in Thing.lookupAll()) >= 2000, timeout=2.0))
+        self.assertTrue(
+            db.waitForCondition(
+                lambda: sum(x.timesUpdated for x in Thing.lookupAll()) >= 2000, timeout=2.0
+            )
+        )
         self.assertTrue(time.time() - t0 < 2.2)
         r1.stop()
 
@@ -1788,15 +1801,15 @@ class ObjectDatabaseTests:
 
         r1 = Reactor(db, incrementor)
 
-        self.assertEqual(r1.next(timeout=.01), 0)
-        self.assertIs(r1.next(timeout=.01), object_database.reactor.Timeout)
+        self.assertEqual(r1.next(timeout=0.01), 0)
+        self.assertIs(r1.next(timeout=0.01), object_database.reactor.Timeout)
 
         with db.transaction():
             c = Counter(k=0, x=100)
 
-        self.assertEqual(r1.next(timeout=.01), 1)
-        self.assertEqual(r1.next(timeout=.01), 0)
-        self.assertIs(r1.next(timeout=.01), object_database.reactor.Timeout)
+        self.assertEqual(r1.next(timeout=0.01), 1)
+        self.assertEqual(r1.next(timeout=0.01), 0)
+        self.assertIs(r1.next(timeout=0.01), object_database.reactor.Timeout)
 
         with db.view():
             self.assertEqual(c.k, 100)
@@ -1805,9 +1818,9 @@ class ObjectDatabaseTests:
         with db.transaction():
             c.x += 2
 
-        self.assertEqual(r1.next(timeout=.01), 1)
-        self.assertEqual(r1.next(timeout=.01), 0)
-        self.assertIs(r1.next(timeout=.01), object_database.reactor.Timeout)
+        self.assertEqual(r1.next(timeout=0.01), 1)
+        self.assertEqual(r1.next(timeout=0.01), 0)
+        self.assertIs(r1.next(timeout=0.01), object_database.reactor.Timeout)
 
         with db.view():
             self.assertEqual(c.k, 102)
@@ -1849,7 +1862,7 @@ class ObjectDatabaseTests:
         with db.transaction():
             c = Counter(k=0, x=10)
 
-        self.assertFalse(checker.blockUntilTrue(timeout=.00001))
+        self.assertFalse(checker.blockUntilTrue(timeout=0.00001))
         self.assertTrue(checker.blockUntilTrue(timeout=1.0))
 
         self.assertTrue(incrementCount[0] >= 10)
@@ -1858,7 +1871,7 @@ class ObjectDatabaseTests:
         with db.transaction():
             c.x += 5
 
-        self.assertFalse(checker.blockUntilTrue(timeout=.00001))
+        self.assertFalse(checker.blockUntilTrue(timeout=0.00001))
         self.assertTrue(checker.blockUntilTrue(timeout=1.0))
 
         self.assertTrue(incrementCount[0] >= 15)
@@ -1904,7 +1917,7 @@ class ObjectDatabaseTests:
         blocker.releaseCallback()
 
         for e in subscriptionEvents:
-            assert e.wait(timeout=2.0*pfactor)
+            assert e.wait(timeout=2.0 * pfactor)
 
         with db2.transaction():
             # verify we see the write on c1
@@ -1954,7 +1967,7 @@ class ObjectDatabaseTests:
         blocker.releaseCallback()
 
         for e in subscriptionEvents:
-            assert e.wait(timeout=2.0*self.PERFORMANCE_FACTOR)
+            assert e.wait(timeout=2.0 * self.PERFORMANCE_FACTOR)
 
         with db2.transaction():
             # verify we see the write on c1
@@ -2085,7 +2098,7 @@ class ObjectDatabaseTests:
 
             # make sure that the main db sees it
             for thing in things:
-                db.waitForCondition(lambda: thing.exists(), 10*self.PERFORMANCE_FACTOR)
+                db.waitForCondition(lambda: thing.exists(), 10 * self.PERFORMANCE_FACTOR)
 
             # verify the main db sees something quadratic in the number of transactions plus a constant
             self.assertLess(db._messages_received, (len(schemas) + 1) * (len(schemas) + 2) + 8)
@@ -2110,7 +2123,7 @@ class ObjectDatabaseTests:
 
         m1 = numpy.mean(times[:1000])
         m2 = numpy.mean(times[-1000:])
-        self.assertTrue(abs(m2/m1-1) < 1, (m1, m2))
+        self.assertTrue(abs(m2 / m1 - 1) < 1, (m1, m2))
 
     def test_memory_growth(self):
         db1 = self.createNewDb()
@@ -2129,7 +2142,7 @@ class ObjectDatabaseTests:
                 with db1.transaction():
                     x.delete()
 
-            self.server._garbage_collect(intervalOverride=.1)
+            self.server._garbage_collect(intervalOverride=0.1)
             print(passIx, currentMemUsageMb())
             self.assertLess(currentMemUsageMb() - m0, 10.0)
 
@@ -2144,13 +2157,15 @@ class ObjectDatabaseTests:
 
         self.assertLess(db1._connection_state.objectCount(), 10)
 
-        self.assertEqual(db1._connection_state.objectCount(), db2._connection_state.objectCount())
+        self.assertEqual(
+            db1._connection_state.objectCount(), db2._connection_state.objectCount()
+        )
 
-        time.sleep(.1)
+        time.sleep(0.1)
 
         self.assertTrue(len(self.server._version_numbers) > 10)
 
-        self.server._garbage_collect(intervalOverride=.1)
+        self.server._garbage_collect(intervalOverride=0.1)
 
         self.assertTrue(len(self.server._version_numbers) < 10)
 
@@ -2250,7 +2265,7 @@ class ObjectDatabaseOverChannelTestsWithRedis(unittest.TestCase, ObjectDatabaseT
         self.tempDirName = self.tempDir.__enter__()
         self.auth_token = genToken()
 
-        if hasattr(self, 'redisProcess') and self.redisProcess:
+        if hasattr(self, "redisProcess") and self.redisProcess:
             self.redisProcess.tearDown()
 
         self.redisProcess = RedisTestHelper(port=1115)
@@ -2258,7 +2273,7 @@ class ObjectDatabaseOverChannelTestsWithRedis(unittest.TestCase, ObjectDatabaseT
         try:
             self.mem_store = RedisPersistence(port=1115)
             self.server = InMemServer(self.mem_store, self.auth_token)
-            self.server._gc_interval = .1
+            self.server._gc_interval = 0.1
             self.server.start()
         except Exception:
             self.redisProcess.tearDown()
@@ -2319,7 +2334,7 @@ class ObjectDatabaseOverChannelTestsInMemory(unittest.TestCase, ObjectDatabaseTe
 
         self.mem_store = InMemoryPersistence()
         self.server = InMemServer(self.mem_store, self.auth_token)
-        self.server._gc_interval = .1
+        self.server._gc_interval = 0.1
         self.server.start()
         self.allConnections = []
 
@@ -2338,7 +2353,7 @@ class ObjectDatabaseOverChannelTestsInMemory(unittest.TestCase, ObjectDatabaseTe
         db = DatabaseConnection(self.server.getChannel())
 
         old_interval = messages.getHeartbeatInterval()
-        messages.setHeartbeatInterval(.25)
+        messages.setHeartbeatInterval(0.25)
 
         try:
             with self.assertRaises(DisconnectedException):
@@ -2349,7 +2364,7 @@ class ObjectDatabaseOverChannelTestsInMemory(unittest.TestCase, ObjectDatabaseTe
 
     def test_heartbeats(self):
         old_interval = messages.getHeartbeatInterval()
-        messages.setHeartbeatInterval(.25)
+        messages.setHeartbeatInterval(0.25)
 
         try:
             db1 = self.createNewDb()
@@ -2370,7 +2385,7 @@ class ObjectDatabaseOverChannelTestsInMemory(unittest.TestCase, ObjectDatabaseTe
 
             db2.waitForCondition(
                 lambda: len(core_schema.Connection.lookupAll()) == 1,
-                5.0 * self.PERFORMANCE_FACTOR
+                5.0 * self.PERFORMANCE_FACTOR,
             )
 
             with db2.view():
@@ -2399,7 +2414,7 @@ class ObjectDatabaseOverChannelTestsInMemory(unittest.TestCase, ObjectDatabaseTe
         def readerthread(db):
             c = None
             while not shouldStop[0]:
-                if numpy.random.uniform() < .5:
+                if numpy.random.uniform() < 0.5:
                     if c is None:
                         with db.transaction():
                             c = Counter(k=0)
@@ -2413,7 +2428,10 @@ class ObjectDatabaseOverChannelTestsInMemory(unittest.TestCase, ObjectDatabaseTe
 
             isOK.append(True)
 
-        threads = [threading.Thread(target=readerthread, args=(db1 if threadcount % 2 else db2,)) for _ in range(threadcount)]
+        threads = [
+            threading.Thread(target=readerthread, args=(db1 if threadcount % 2 else db2,))
+            for _ in range(threadcount)
+        ]
         for t in threads:
             t.start()
 
@@ -2437,13 +2455,16 @@ class ObjectDatabaseOverSocketTests(unittest.TestCase, ObjectDatabaseTests):
         self.auth_token = genToken()
 
         sc = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        sc.load_cert_chain('testcert.cert', 'testcert.key')
+        sc.load_cert_chain("testcert.cert", "testcert.key")
 
         self.server = TcpServer(
-            host="localhost", port=8888, mem_store=self.mem_store,
-            ssl_context=sc, auth_token=self.auth_token
+            host="localhost",
+            port=8888,
+            mem_store=self.mem_store,
+            ssl_context=sc,
+            auth_token=self.auth_token,
         )
-        self.server._gc_interval = .1
+        self.server._gc_interval = 0.1
         self.server.start()
 
     def createNewDb(self, useSecondaryLoop=False):
@@ -2456,7 +2477,7 @@ class ObjectDatabaseOverSocketTests(unittest.TestCase, ObjectDatabaseTests):
 
     def test_very_large_subscriptions(self):
         old_interval = messages.getHeartbeatInterval()
-        messages.setHeartbeatInterval(.1)
+        messages.setHeartbeatInterval(0.1)
 
         try:
             db1 = self.createNewDb()
@@ -2505,12 +2526,13 @@ class ObjectDatabaseOverSocketTests(unittest.TestCase, ObjectDatabaseTests):
                 self.assertEqual(len(Counter.lookupAll(k=1)), 5000)
                 self.assertEqual(len(Counter.lookupAll(k=2)), 5000)
                 self.assertEqual(
-                    sorted(set([c.x for c in Counter.lookupAll(k=1)])),
-                    sorted(range(5000))
+                    sorted(set([c.x for c in Counter.lookupAll(k=1)])), sorted(range(5000))
                 )
 
             # we should never have had a really long latency
-            self.assertTrue(maxLatency[0] < subscriptionTime / 10.0, (maxLatency[0], subscriptionTime))
+            self.assertTrue(
+                maxLatency[0] < subscriptionTime / 10.0, (maxLatency[0], subscriptionTime)
+            )
 
         finally:
             messages.setHeartbeatInterval(old_interval)

--- a/object_database/database_test.py
+++ b/object_database/database_test.py
@@ -1137,7 +1137,8 @@ class ObjectDatabaseTests:
                 views_by_tn = {}
                 counter_vals_by_tn = {}
 
-        # we may have one or two for connection objects, and we have two values for every indexed thing
+        # we may have one or two for connection objects,
+        # and we have two values for every indexed thing
         self.assertLess(self.mem_store.storedStringCount(), 203)
         self.assertTrue(total_writes > 500, total_writes)
 
@@ -2100,7 +2101,8 @@ class ObjectDatabaseTests:
             for thing in things:
                 db.waitForCondition(lambda: thing.exists(), 10 * self.PERFORMANCE_FACTOR)
 
-            # verify the main db sees something quadratic in the number of transactions plus a constant
+            # verify the main db sees something quadratic in the number of
+            # transactions plus a constant
             self.assertLess(db._messages_received, (len(schemas) + 1) * (len(schemas) + 2) + 8)
 
             # each database sees two transactions each pass

--- a/object_database/direct_types/generate_alternative.py
+++ b/object_database/direct_types/generate_alternative.py
@@ -18,10 +18,10 @@ def return_type(set_of_types):
     """
     list_of_types = list(set_of_types)
     if len(list_of_types) == 0:
-        return 'None'  # shouldn't happen
+        return "None"  # shouldn't happen
     if len(list_of_types) == 1:
         return list_of_types[0]
-    return 'OneOf<' + ','.join(list_of_types) + '>'
+    return "OneOf<" + ",".join(list_of_types) + ">"
 
 
 def gen_alternative_type(full_name, d):
@@ -34,7 +34,7 @@ def gen_alternative_type(full_name, d):
     Returns:
         A list of strings, containing c++ code implementing this wrapper.
     """
-    name = full_name.rsplit('.', 1)[-1]
+    name = full_name.rsplit(".", 1)[-1]
 
     nts = d.keys()
     members = dict()  # set of possible types for each member
@@ -45,147 +45,180 @@ def gen_alternative_type(full_name, d):
             else:
                 members[a] = {t}
     ret = list()
-    ret.append(f'// Generated Alternative {name}=')
+    ret.append(f"// Generated Alternative {name}=")
     for nt in nts:
-        ret.append('//     {}=({})'.format(nt, ", ".join([f'{a}={t}' for a, t in d[nt]])))
-    ret.append('')
+        ret.append("//     {}=({})".format(nt, ", ".join([f"{a}={t}" for a, t in d[nt]])))
+    ret.append("")
     for nt in nts:
-        ret.append(f'class {name}_{nt};')
-    ret.append('')
-    ret.append(f'class {name} {{')
-    ret.append('public:')
-    ret.append('    enum class kind {{ {} }};'.format(
-        ", ".join([f'{nt}={i}' for i, nt in enumerate(nts)])))
-    ret.append('')
-    ret.append('    static Alternative* getType() {')
-    ret.append('        PyObject* resolver = getOrSetTypeResolver();')
-    ret.append('        if (!resolver)')
+        ret.append(f"class {name}_{nt};")
+    ret.append("")
+    ret.append(f"class {name} {{")
+    ret.append("public:")
+    ret.append(
+        "    enum class kind {{ {} }};".format(
+            ", ".join([f"{nt}={i}" for i, nt in enumerate(nts)])
+        )
+    )
+    ret.append("")
+    ret.append("    static Alternative* getType() {")
+    ret.append("        PyObject* resolver = getOrSetTypeResolver();")
+    ret.append("        if (!resolver)")
     ret.append(f'            throw std::runtime_error("{name}: no resolver");')
-    ret.append(f'        PyObject* res = PyObject_CallMethod(resolver, "resolveTypeByName", "s", "{full_name}");')
-    ret.append('        if (!res)')
+    ret.append(
+        f'        PyObject* res = PyObject_CallMethod(resolver, "resolveTypeByName", "s", "{full_name}");'
+    )
+    ret.append("        if (!res)")
     ret.append(f'            throw std::runtime_error("{full_name}: did not resolve");')
-    ret.append('        return (Alternative*)PyInstance::unwrapTypeArgToTypePtr(res);')
-    ret.append('    }')
+    ret.append("        return (Alternative*)PyInstance::unwrapTypeArgToTypePtr(res);")
+    ret.append("    }")
 
-    ret.append(f'    static {name} fromPython(PyObject* p) {{')
-    ret.append('        Alternative::layout* l = nullptr;')
-    ret.append('        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);')
-    ret.append(f'        return {name}(l);')
-    ret.append('    }')
-    ret.append('')
-    ret.append('    PyObject* toPython() {')
-    ret.append('        return PyInstance::extractPythonObject((instance_ptr)&mLayout, getType());')
-    ret.append('    }')
-    ret.append('')
+    ret.append(f"    static {name} fromPython(PyObject* p) {{")
+    ret.append("        Alternative::layout* l = nullptr;")
+    ret.append(
+        "        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);"
+    )
+    ret.append(f"        return {name}(l);")
+    ret.append("    }")
+    ret.append("")
+    ret.append("    PyObject* toPython() {")
+    ret.append(
+        "        return PyInstance::extractPythonObject((instance_ptr)&mLayout, getType());"
+    )
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    ~{name}() {{ getType()->destroy((instance_ptr)&mLayout); }}')
-    ret.append(f'    {name}():mLayout(0) {{ getType()->constructor((instance_ptr)&mLayout); }}')
-    ret.append(f'    {name}(kind k):mLayout(0) {{ '
-               'ConcreteAlternative::Make(getType(), (int64_t)k)->constructor((instance_ptr)&mLayout); }')
-    ret.append(f'    {name}(const {name}& in) '
-               '{ getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&in.mLayout); }')
-    ret.append(f'    {name}& operator=(const {name}& other) '
-               '{ getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout); return *this; }')
-    ret.append('')
+    ret.append(f"    ~{name}() {{ getType()->destroy((instance_ptr)&mLayout); }}")
+    ret.append(
+        f"    {name}():mLayout(0) {{ getType()->constructor((instance_ptr)&mLayout); }}"
+    )
+    ret.append(
+        f"    {name}(kind k):mLayout(0) {{ "
+        "ConcreteAlternative::Make(getType(), (int64_t)k)->constructor((instance_ptr)&mLayout); }"
+    )
+    ret.append(
+        f"    {name}(const {name}& in) "
+        "{ getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&in.mLayout); }"
+    )
+    ret.append(
+        f"    {name}& operator=(const {name}& other) "
+        "{ getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout); return *this; }"
+    )
+    ret.append("")
     for nt in nts:
-        ret.append(f'    static {name} {nt}('
-                   + ", ".join([f'const {t}& {a}' for a, t in d[nt]])
-                   + ');')
-    ret.append('')
-    ret.append('    kind which() const { return (kind)mLayout->which; }')
-    ret.append('')
-    ret.append('    template <class F>')
-    ret.append('    auto check(const F& f) {')
+        ret.append(
+            f"    static {name} {nt}("
+            + ", ".join([f"const {t}& {a}" for a, t in d[nt]])
+            + ");"
+        )
+    ret.append("")
+    ret.append("    kind which() const { return (kind)mLayout->which; }")
+    ret.append("")
+    ret.append("    template <class F>")
+    ret.append("    auto check(const F& f) {")
     for nt in nts:
-        ret.append(f'        if (is{nt}()) {{ return f(*({name}_{nt}*)this); }}')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"        if (is{nt}()) {{ return f(*({name}_{nt}*)this); }}")
+    ret.append("    }")
+    ret.append("")
     for nt in nts:
-        ret.append(f'    bool is{nt}() const {{ return which() == kind::{nt}; }}')
-    ret.append('')
-    ret.append('    // Accessors for members')
+        ret.append(f"    bool is{nt}() const {{ return which() == kind::{nt}; }}")
+    ret.append("")
+    ret.append("    // Accessors for members")
     for m in members:
         m_type = return_type(members[m])
-        ret.append(f'    {m_type} {m}() const;')
-    ret.append('')
-    ret.append('    Alternative::layout* getLayout() const { return mLayout; }')
-    ret.append('protected:')
-    ret.append(f'    explicit {name}(Alternative::layout* l): mLayout(l) {{}}')
-    ret.append('    Alternative::layout *mLayout;')
-    ret.append('};')
-    ret.append('')
-    ret.append('template <>')
-    ret.append(f'class TypeDetails<{name}> {{')
-    ret.append('public:')
-    ret.append('    static Type* getType() {')
-    ret.append(f'        static Type* t = {name}::getType();')
-    ret.append('        if (t->bytecount() != bytecount) {')
-    ret.append(f'            throw std::runtime_error("{name} somehow we have the wrong bytecount!");')
-    ret.append('        }')
-    ret.append('        return t;')
-    ret.append('    }')
-    ret.append('    static const uint64_t bytecount = sizeof(void*);')
-    ret.append('};')
-    ret.append('')
+        ret.append(f"    {m_type} {m}() const;")
+    ret.append("")
+    ret.append("    Alternative::layout* getLayout() const { return mLayout; }")
+    ret.append("protected:")
+    ret.append(f"    explicit {name}(Alternative::layout* l): mLayout(l) {{}}")
+    ret.append("    Alternative::layout *mLayout;")
+    ret.append("};")
+    ret.append("")
+    ret.append("template <>")
+    ret.append(f"class TypeDetails<{name}> {{")
+    ret.append("public:")
+    ret.append("    static Type* getType() {")
+    ret.append(f"        static Type* t = {name}::getType();")
+    ret.append("        if (t->bytecount() != bytecount) {")
+    ret.append(
+        f'            throw std::runtime_error("{name} somehow we have the wrong bytecount!");'
+    )
+    ret.append("        }")
+    ret.append("        return t;")
+    ret.append("    }")
+    ret.append("    static const uint64_t bytecount = sizeof(void*);")
+    ret.append("};")
+    ret.append("")
     for nt in nts:
-        ret.append(f'class {name}_{nt} : public {name} {{')
-        ret.append('public:')
-        ret.append('    static ConcreteAlternative* getType() {')
+        ret.append(f"class {name}_{nt} : public {name} {{")
+        ret.append("public:")
+        ret.append("    static ConcreteAlternative* getType() {")
 
-        ret.append(f'        static ConcreteAlternative* t = ConcreteAlternative::Make({name}::getType(), static_cast<int>(kind::{nt}));')
-        ret.append('        return t;')
-        ret.append('    }')
-        ret.append(f'    static Alternative* getAlternative() {{ return {name}::getType(); }}')
+        ret.append(
+            f"        static ConcreteAlternative* t = ConcreteAlternative::Make({name}::getType(), static_cast<int>(kind::{nt}));"
+        )
+        ret.append("        return t;")
+        ret.append("    }")
+        ret.append(f"    static Alternative* getAlternative() {{ return {name}::getType(); }}")
         # ret.append(f'    static NamedTuple* elementType() {{ return {nt}_Type; }}')
-        ret.append('')
-        ret.append(f'    {name}_{nt}():{name}(kind::{nt}) {{}}')
+        ret.append("")
+        ret.append(f"    {name}_{nt}():{name}(kind::{nt}) {{}}")
         if len(d[nt]) > 0:
-            ret.append(f'    {name}_{nt}('
-                       + ", ".join([f' const {t}& {a}1' for a, t in d[nt]])
-                       + f'):{name}(kind::{nt}) {{')
+            ret.append(
+                f"    {name}_{nt}("
+                + ", ".join([f" const {t}& {a}1" for a, t in d[nt]])
+                + f"):{name}(kind::{nt}) {{"
+            )
             for a, _ in d[nt]:
-                ret.append(f'        {a}() = {a}1;')
-            ret.append('    }')
-        ret.append(f'    {name}_{nt}(const {name}_{nt}& other):{name}(kind::{nt}) {{')
-        ret.append(f'        getType()->copy_constructor((instance_ptr)&mLayout, '
-                   '(instance_ptr)&other.mLayout);')
-        ret.append('    }')
-        ret.append(f'    {name}_{nt}& operator=(const {name}_{nt}& other) {{')
-        ret.append('         getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);')
-        ret.append('         return *this;')
-        ret.append('    }')
-        ret.append(f'    ~{name}_{nt}() {{}}')
-        ret.append('')
+                ret.append(f"        {a}() = {a}1;")
+            ret.append("    }")
+        ret.append(f"    {name}_{nt}(const {name}_{nt}& other):{name}(kind::{nt}) {{")
+        ret.append(
+            f"        getType()->copy_constructor((instance_ptr)&mLayout, "
+            "(instance_ptr)&other.mLayout);"
+        )
+        ret.append("    }")
+        ret.append(f"    {name}_{nt}& operator=(const {name}_{nt}& other) {{")
+        ret.append(
+            "         getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);"
+        )
+        ret.append("         return *this;")
+        ret.append("    }")
+        ret.append(f"    ~{name}_{nt}() {{}}")
+        ret.append("")
         for i, (a, t) in enumerate(d[nt]):
-            offset = '' if i == 0 else ' + ' + ' + '.join([f'size' + str(j) for j in range(1, i + 1)])
-            ret.append(f'    {t}& {a}() const {{ return *({t}*)(mLayout->data{offset}); }}')
-        ret.append('private:')
+            offset = (
+                ""
+                if i == 0
+                else " + " + " + ".join([f"size" + str(j) for j in range(1, i + 1)])
+            )
+            ret.append(f"    {t}& {a}() const {{ return *({t}*)(mLayout->data{offset}); }}")
+        ret.append("private:")
         for i, (_, t) in list(enumerate(d[nt]))[:-1]:
-            ret.append(f'    static const int size{i + 1} = sizeof({t});')
-        ret.append('};')
-        ret.append('')
-        ret.append(f'{name} {name}::{nt}('
-                   + ", ".join([f'const {t}& {a}' for a, t in d[nt]])
-                   + ') {')
-        ret.append(f'    return {name}_{nt}('
-                   + ', '.join([a for a, _ in d[nt]])
-                   + ');')
-        ret.append('}')
-        ret.append('')
+            ret.append(f"    static const int size{i + 1} = sizeof({t});")
+        ret.append("};")
+        ret.append("")
+        ret.append(
+            f"{name} {name}::{nt}(" + ", ".join([f"const {t}& {a}" for a, t in d[nt]]) + ") {"
+        )
+        ret.append(f"    return {name}_{nt}(" + ", ".join([a for a, _ in d[nt]]) + ");")
+        ret.append("}")
+        ret.append("")
     for m in members:
         m_type = return_type(members[m])
-        multiple_types = (len(members[m]) > 1)
-        ret.append(f'{m_type} {name}::{m}() const {{')
+        multiple_types = len(members[m]) > 1
+        ret.append(f"{m_type} {name}::{m}() const {{")
         for nt in nts:
             if m in [e[0] for e in d[nt]]:
-                ret.append(f'    if (is{nt}())')
+                ret.append(f"    if (is{nt}())")
                 if multiple_types:
-                    ret.append(f'        return {m_type}((({name}_{nt}*)this)->{m}());')
+                    ret.append(f"        return {m_type}((({name}_{nt}*)this)->{m}());")
                 else:
-                    ret.append(f'        return (({name}_{nt}*)this)->{m}();')
-        ret.append(f'    throw std::runtime_error("\\"{name}\\" subtype does not contain \\"{m}\\"");')
-        ret.append('}')
-        ret.append('')
-    ret.append(f'// END Generated Alternative {name}')
-    ret.append('')
-    return [e + '\n' for e in ret]
+                    ret.append(f"        return (({name}_{nt}*)this)->{m}();")
+        ret.append(
+            f'    throw std::runtime_error("\\"{name}\\" subtype does not contain \\"{m}\\"");'
+        )
+        ret.append("}")
+        ret.append("")
+    ret.append(f"// END Generated Alternative {name}")
+    ret.append("")
+    return [e + "\n" for e in ret]

--- a/object_database/direct_types/generate_alternative.py
+++ b/object_database/direct_types/generate_alternative.py
@@ -28,9 +28,11 @@ def gen_alternative_type(full_name, d):
     """Generate direct c++ wrapper code for a particular Alternative type.
 
     Args:
-        full_name: fully specified dotted name from codebase, module.class.subclass. ... .typename
+        full_name: fully specified dotted name from codebase,
+            module.class.subclass. ... .typename
         d: dict, where keys are subtypes of this Alternative type,
-            and values are corresponding named tuples, represented as a list of (param, type) pairs
+            and values are corresponding named tuples, represented
+            as a list of (param, type) pairs
     Returns:
         A list of strings, containing c++ code implementing this wrapper.
     """
@@ -65,7 +67,8 @@ def gen_alternative_type(full_name, d):
     ret.append("        if (!resolver)")
     ret.append(f'            throw std::runtime_error("{name}: no resolver");')
     ret.append(
-        f'        PyObject* res = PyObject_CallMethod(resolver, "resolveTypeByName", "s", "{full_name}");'
+        "        PyObject* res = PyObject_CallMethod"
+        f'(resolver, "resolveTypeByName", "s", "{full_name}");'
     )
     ret.append("        if (!res)")
     ret.append(f'            throw std::runtime_error("{full_name}: did not resolve");')
@@ -75,7 +78,8 @@ def gen_alternative_type(full_name, d):
     ret.append(f"    static {name} fromPython(PyObject* p) {{")
     ret.append("        Alternative::layout* l = nullptr;")
     ret.append(
-        "        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);"
+        "        PyInstance::copyConstructFromPythonInstance"
+        "(getType(), (instance_ptr)&l, p, true);"
     )
     ret.append(f"        return {name}(l);")
     ret.append("    }")
@@ -93,7 +97,8 @@ def gen_alternative_type(full_name, d):
     )
     ret.append(
         f"    {name}(kind k):mLayout(0) {{ "
-        "ConcreteAlternative::Make(getType(), (int64_t)k)->constructor((instance_ptr)&mLayout); }"
+        "ConcreteAlternative::Make(getType(), (int64_t)k)"
+        "->constructor((instance_ptr)&mLayout); }"
     )
     ret.append(
         f"    {name}(const {name}& in) "
@@ -101,7 +106,8 @@ def gen_alternative_type(full_name, d):
     )
     ret.append(
         f"    {name}& operator=(const {name}& other) "
-        "{ getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout); return *this; }"
+        "{ getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);"
+        " return *this; }"
     )
     ret.append("")
     for nt in nts:
@@ -154,7 +160,8 @@ def gen_alternative_type(full_name, d):
         ret.append("    static ConcreteAlternative* getType() {")
 
         ret.append(
-            f"        static ConcreteAlternative* t = ConcreteAlternative::Make({name}::getType(), static_cast<int>(kind::{nt}));"
+            "        static ConcreteAlternative* t = ConcreteAlternative::Make"
+            f"({name}::getType(), static_cast<int>(kind::{nt}));"
         )
         ret.append("        return t;")
         ret.append("    }")

--- a/object_database/direct_types/generate_named_tuple.py
+++ b/object_database/direct_types/generate_named_tuple.py
@@ -23,122 +23,140 @@ def gen_named_tuple_type(full_name, **kwargs):
     Returns:
         A list of strings, containing c++ code implementing this wrapper.
     """
-    name = full_name.rsplit('.', 1)[-1]
+    name = full_name.rsplit(".", 1)[-1]
     items = kwargs.items()
     keys = kwargs.keys()
     revkeys = list(keys)[::-1]
     ret = list()
-    ret.append(f'// Generated NamedTuple {name}')
+    ret.append(f"// Generated NamedTuple {name}")
     for key, value in items:
-        ret.append(f'//    {key}={value}')
+        ret.append(f"//    {key}={value}")
 
-    ret.append(f'class {name} {{')
-    ret.append('public:')
+    ret.append(f"class {name} {{")
+    ret.append("public:")
     for key, value in items:
-        ret.append(f'    typedef {value} {key}_type;')
+        ret.append(f"    typedef {value} {key}_type;")
     for i, (key, value) in enumerate(items):
-        offset = '' if i == 0 else ' + ' + ' + '.join([f'size' + str(j) for j in range(1, i + 1)])
-        ret.append(f'    {key}_type& {key}() const {{ return *({key}_type*)(data{offset}); }}')
-    ret.append('    static NamedTuple* getType() {')
-    ret.append('        static NamedTuple* t = NamedTuple::Make({')
-    ret.append(',\n'.join(
-        [f'                TypeDetails<{name}::{key}_type>::getType()' for key in keys]))
-    ret.append('            },{')
-    ret.append(',\n'.join(
-        [f'                "{key}"' for key in keys]))
-    ret.append('            });')
-    ret.append('        return t;')
-    ret.append('        }')
-    ret.append('')
+        offset = (
+            "" if i == 0 else " + " + " + ".join([f"size" + str(j) for j in range(1, i + 1)])
+        )
+        ret.append(f"    {key}_type& {key}() const {{ return *({key}_type*)(data{offset}); }}")
+    ret.append("    static NamedTuple* getType() {")
+    ret.append("        static NamedTuple* t = NamedTuple::Make({")
+    ret.append(
+        ",\n".join(
+            [f"                TypeDetails<{name}::{key}_type>::getType()" for key in keys]
+        )
+    )
+    ret.append("            },{")
+    ret.append(",\n".join([f'                "{key}"' for key in keys]))
+    ret.append("            });")
+    ret.append("        return t;")
+    ret.append("        }")
+    ret.append("")
 
-    ret.append(f'    static {name} fromPython(PyObject* p) {{')
-    ret.append(f'        {name} l;')
-    ret.append('        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);')
-    ret.append('        return l;')
-    ret.append('    }')
-    ret.append('')
-    ret.append('    PyObject* toPython() {')
-    ret.append('        return PyInstance::extractPythonObject((instance_ptr)this, getType());')
-    ret.append('    }')
-    ret.append('')
+    ret.append(f"    static {name} fromPython(PyObject* p) {{")
+    ret.append(f"        {name} l;")
+    ret.append(
+        "        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);"
+    )
+    ret.append("        return l;")
+    ret.append("    }")
+    ret.append("")
+    ret.append("    PyObject* toPython() {")
+    ret.append(
+        "        return PyInstance::extractPythonObject((instance_ptr)this, getType());"
+    )
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    {name}& operator = (const {name}& other) {{')
+    ret.append(f"    {name}& operator = (const {name}& other) {{")
     for key in keys:
-        ret.append(f'        {key}() = other.{key}();')
-    ret.append('        return *this;')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"        {key}() = other.{key}();")
+    ret.append("        return *this;")
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    {name}(const {name}& other) {{')
+    ret.append(f"    {name}(const {name}& other) {{")
     for key in keys:
-        ret.append(f'        new (&{key}()) {key}_type(other.{key}());')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"        new (&{key}()) {key}_type(other.{key}());")
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    ~{name}() {{')
+    ret.append(f"    ~{name}() {{")
     for key in revkeys:
-        ret.append(f'        {key}().~{key}_type();')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"        {key}().~{key}_type();")
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    {name}() {{')
+    ret.append(f"    {name}() {{")
     for key in keys:
-        ret.append(f'        bool init{key} = false;')
-    ret.append('        try {')
+        ret.append(f"        bool init{key} = false;")
+    ret.append("        try {")
     for key in keys:
-        ret.append(f'            new (&{key}()) {key}_type();')
-        ret.append(f'            init{key} = true;')
-    ret.append('        } catch(...) {')
-    ret.append('            try {')
+        ret.append(f"            new (&{key}()) {key}_type();")
+        ret.append(f"            init{key} = true;")
+    ret.append("        } catch(...) {")
+    ret.append("            try {")
     for key in revkeys:
-        ret.append(f'                if (init{key}) {key}().~{key}_type();')
-    ret.append('            } catch(...) {')
-    ret.append('            }')
-    ret.append('            throw;')
-    ret.append('        }')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"                if (init{key}) {key}().~{key}_type();")
+    ret.append("            } catch(...) {")
+    ret.append("            }")
+    ret.append("            throw;")
+    ret.append("        }")
+    ret.append("    }")
+    ret.append("")
 
     if len(keys) > 0:
-        ret.append(f'    {name}(' + ', '.join([f'const {key}_type& {key}_val' for key in keys]) + ') {')
+        ret.append(
+            f"    {name}("
+            + ", ".join([f"const {key}_type& {key}_val" for key in keys])
+            + ") {"
+        )
         for key in keys:
-            ret.append(f'        bool init{key} = false;')
-        ret.append('        try {')
+            ret.append(f"        bool init{key} = false;")
+        ret.append("        try {")
         for key in keys:
-            ret.append(f'            new (&{key}()) {key}_type({key}_val);')
-            ret.append(f'            init{key} = true;')
-        ret.append('        } catch(...) {')
-        ret.append('            try {')
+            ret.append(f"            new (&{key}()) {key}_type({key}_val);")
+            ret.append(f"            init{key} = true;")
+        ret.append("        } catch(...) {")
+        ret.append("            try {")
         for key in revkeys:
-            ret.append(f'                if (init{key}) {key}().~{key}_type();')
-        ret.append('            } catch(...) {')
-        ret.append('            }')
-        ret.append('            throw;')
-        ret.append('        }')
-        ret.append('    }')
+            ret.append(f"                if (init{key}) {key}().~{key}_type();")
+        ret.append("            } catch(...) {")
+        ret.append("            }")
+        ret.append("            throw;")
+        ret.append("        }")
+        ret.append("    }")
 
-    ret.append('private:')
+    ret.append("private:")
     for i, key in enumerate(keys):
-        ret.append(f'    static const int size{i + 1} = sizeof({key}_type);')
-    ret.append('    uint8_t data[{}];'.format(' + '.join(['size' + str(i) for i in range(1, len(keys) + 1)])))
-    ret.append('};')
-    ret.append('')
+        ret.append(f"    static const int size{i + 1} = sizeof({key}_type);")
+    ret.append(
+        "    uint8_t data[{}];".format(
+            " + ".join(["size" + str(i) for i in range(1, len(keys) + 1)])
+        )
+    )
+    ret.append("};")
+    ret.append("")
 
-    ret.append('template <>')
-    ret.append(f'class TypeDetails<{name}> {{')
-    ret.append('public:')
-    ret.append('    static Type* getType() {')
-    ret.append(f'        static Type* t = {name}::getType();')
-    ret.append('        if (t->bytecount() != bytecount) {')
-    ret.append(f'            throw std::runtime_error("{name} somehow we have the wrong bytecount!");')
-    ret.append('        }')
-    ret.append('        return t;')
-    ret.append('    }')
-    ret.append('    static const uint64_t bytecount = ')
-    ret.append(' +\n'.join([f'        sizeof({name}::{key}_type)' for key in keys]) + ';')
-    ret.append('};')
-    ret.append('')
-    ret.append(f'// END Generated NamedTuple {name}')
-    ret.append('')
+    ret.append("template <>")
+    ret.append(f"class TypeDetails<{name}> {{")
+    ret.append("public:")
+    ret.append("    static Type* getType() {")
+    ret.append(f"        static Type* t = {name}::getType();")
+    ret.append("        if (t->bytecount() != bytecount) {")
+    ret.append(
+        f'            throw std::runtime_error("{name} somehow we have the wrong bytecount!");'
+    )
+    ret.append("        }")
+    ret.append("        return t;")
+    ret.append("    }")
+    ret.append("    static const uint64_t bytecount = ")
+    ret.append(" +\n".join([f"        sizeof({name}::{key}_type)" for key in keys]) + ";")
+    ret.append("};")
+    ret.append("")
+    ret.append(f"// END Generated NamedTuple {name}")
+    ret.append("")
 
-    return [e + '\n' for e in ret]
+    return [e + "\n" for e in ret]

--- a/object_database/direct_types/generate_named_tuple.py
+++ b/object_database/direct_types/generate_named_tuple.py
@@ -18,7 +18,8 @@ def gen_named_tuple_type(full_name, **kwargs):
     Generate direct c++ wrapper code for a particular NamedTuple type.
 
     Args:
-        full_name: fully specified dotted name from codebase, module.class.subclass. ... .typename
+        full_name: fully specified dotted name from codebase,
+            module.class.subclass. ... .typename
         **kwargs: keys are element names and values are corresponding python Types
     Returns:
         A list of strings, containing c++ code implementing this wrapper.
@@ -58,7 +59,8 @@ def gen_named_tuple_type(full_name, **kwargs):
     ret.append(f"    static {name} fromPython(PyObject* p) {{")
     ret.append(f"        {name} l;")
     ret.append(
-        "        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);"
+        "        PyInstance::copyConstructFromPythonInstance"
+        "(getType(), (instance_ptr)&l, p, true);"
     )
     ret.append("        return l;")
     ret.append("    }")

--- a/object_database/direct_types/generate_tuple.py
+++ b/object_database/direct_types/generate_tuple.py
@@ -18,7 +18,8 @@ def gen_tuple_type(full_name, *args):
     Generate direct c++ wrapper code for a particular Tuple type.
 
     Args:
-        full_name: fully specified dotted name from codebase, module.class.subclass. ... .typename
+        full_name: fully specified dotted name from codebase,
+            module.class.subclass. ... .typename
         *args: sequence of python Types
     Returns:
         A list of strings, containing c++ code implementing this wrapper.
@@ -57,7 +58,8 @@ def gen_tuple_type(full_name, *args):
     ret.append(f"    static {name} fromPython(PyObject* p) {{")
     ret.append(f"        {name} l;")
     ret.append(
-        "        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);"
+        "        PyInstance::copyConstructFromPythonInstance"
+        "(getType(), (instance_ptr)&l, p, true);"
     )
     ret.append("        return l;")
     ret.append("    }")

--- a/object_database/direct_types/generate_tuple.py
+++ b/object_database/direct_types/generate_tuple.py
@@ -23,119 +23,138 @@ def gen_tuple_type(full_name, *args):
     Returns:
         A list of strings, containing c++ code implementing this wrapper.
     """
-    name = full_name.rsplit('.', 1)[-1]
+    name = full_name.rsplit(".", 1)[-1]
     keys = ["a" + str(i) for i in range(len(args))]
     items = list(zip(keys, list(args)))
 
     revkeys = list(keys)[::-1]
     ret = list()
-    ret.append(f'// Generated Tuple {name}')
+    ret.append(f"// Generated Tuple {name}")
     for key, value in items:
-        ret.append(f'//    {key}={value}')
+        ret.append(f"//    {key}={value}")
 
-    ret.append(f'class {name} {{')
-    ret.append('public:')
+    ret.append(f"class {name} {{")
+    ret.append("public:")
     for key, value in items:
-        ret.append(f'    typedef {value} {key}_type;')
+        ret.append(f"    typedef {value} {key}_type;")
     for i, (key, value) in enumerate(items):
-        offset = '' if i == 0 else ' + ' + ' + '.join([f'size' + str(j) for j in range(1, i + 1)])
-        ret.append(f'    {key}_type& {key}() const {{ return *({key}_type*)(data{offset}); }}')
-    ret.append('    static Tuple* getType() {')
-    ret.append('        static Tuple* t = Tuple::Make({')
-    ret.append(',\n'.join(
-        [f'                TypeDetails<{name}::{key}_type>::getType()' for key in keys]))
-    ret.append('            });')
-    ret.append('        return t;')
-    ret.append('        }')
-    ret.append('')
+        offset = (
+            "" if i == 0 else " + " + " + ".join([f"size" + str(j) for j in range(1, i + 1)])
+        )
+        ret.append(f"    {key}_type& {key}() const {{ return *({key}_type*)(data{offset}); }}")
+    ret.append("    static Tuple* getType() {")
+    ret.append("        static Tuple* t = Tuple::Make({")
+    ret.append(
+        ",\n".join(
+            [f"                TypeDetails<{name}::{key}_type>::getType()" for key in keys]
+        )
+    )
+    ret.append("            });")
+    ret.append("        return t;")
+    ret.append("        }")
+    ret.append("")
 
-    ret.append(f'    static {name} fromPython(PyObject* p) {{')
-    ret.append(f'        {name} l;')
-    ret.append('        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);')
-    ret.append('        return l;')
-    ret.append('    }')
-    ret.append('')
-    ret.append('    PyObject* toPython() {')
-    ret.append('        return PyInstance::extractPythonObject((instance_ptr)this, getType());')
-    ret.append('    }')
-    ret.append('')
+    ret.append(f"    static {name} fromPython(PyObject* p) {{")
+    ret.append(f"        {name} l;")
+    ret.append(
+        "        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);"
+    )
+    ret.append("        return l;")
+    ret.append("    }")
+    ret.append("")
+    ret.append("    PyObject* toPython() {")
+    ret.append(
+        "        return PyInstance::extractPythonObject((instance_ptr)this, getType());"
+    )
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    {name}& operator = (const {name}& other) {{')
+    ret.append(f"    {name}& operator = (const {name}& other) {{")
     for key in keys:
-        ret.append(f'        {key}() = other.{key}();')
-    ret.append('        return *this;')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"        {key}() = other.{key}();")
+    ret.append("        return *this;")
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    {name}(const {name}& other) {{')
+    ret.append(f"    {name}(const {name}& other) {{")
     for key in keys:
-        ret.append(f'        new (&{key}()) {key}_type(other.{key}());')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"        new (&{key}()) {key}_type(other.{key}());")
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    ~{name}() {{')
+    ret.append(f"    ~{name}() {{")
     for key in revkeys:
-        ret.append(f'        {key}().~{key}_type();')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"        {key}().~{key}_type();")
+    ret.append("    }")
+    ret.append("")
 
-    ret.append(f'    {name}() {{')
+    ret.append(f"    {name}() {{")
     for key in keys:
-        ret.append(f'        bool init{key} = false;')
-    ret.append('        try {')
+        ret.append(f"        bool init{key} = false;")
+    ret.append("        try {")
     for key in keys:
-        ret.append(f'            new (&{key}()) {key}_type();')
-        ret.append(f'            init{key} = true;')
-    ret.append('        } catch(...) {')
-    ret.append('            try {')
+        ret.append(f"            new (&{key}()) {key}_type();")
+        ret.append(f"            init{key} = true;")
+    ret.append("        } catch(...) {")
+    ret.append("            try {")
     for key in revkeys:
-        ret.append(f'                if (init{key}) {key}().~{key}_type();')
-    ret.append('            } catch(...) {')
-    ret.append('            }')
-    ret.append('            throw;')
-    ret.append('        }')
-    ret.append('    }')
-    ret.append('')
+        ret.append(f"                if (init{key}) {key}().~{key}_type();")
+    ret.append("            } catch(...) {")
+    ret.append("            }")
+    ret.append("            throw;")
+    ret.append("        }")
+    ret.append("    }")
+    ret.append("")
 
     if len(keys) > 0:
-        ret.append(f'    {name}(' + ', '.join([f'const {key}_type& {key}_val' for key in keys]) + ') {')
+        ret.append(
+            f"    {name}("
+            + ", ".join([f"const {key}_type& {key}_val" for key in keys])
+            + ") {"
+        )
         for key in keys:
-            ret.append(f'        bool init{key} = false;')
-        ret.append('        try {')
+            ret.append(f"        bool init{key} = false;")
+        ret.append("        try {")
         for key in keys:
-            ret.append(f'            new (&{key}()) {key}_type({key}_val);')
-            ret.append(f'            init{key} = true;')
-        ret.append('        } catch(...) {')
-        ret.append('            try {')
+            ret.append(f"            new (&{key}()) {key}_type({key}_val);")
+            ret.append(f"            init{key} = true;")
+        ret.append("        } catch(...) {")
+        ret.append("            try {")
         for key in revkeys:
-            ret.append(f'                if (init{key}) {key}().~{key}_type();')
-        ret.append('            } catch(...) {')
-        ret.append('            }')
-        ret.append('            throw;')
-        ret.append('        }')
-        ret.append('    }')
-    ret.append('private:')
+            ret.append(f"                if (init{key}) {key}().~{key}_type();")
+        ret.append("            } catch(...) {")
+        ret.append("            }")
+        ret.append("            throw;")
+        ret.append("        }")
+        ret.append("    }")
+    ret.append("private:")
     for i, key in enumerate(keys):
-        ret.append(f'    static const int size{i + 1} = sizeof({key}_type);')
-    ret.append('    uint8_t data[{}];'.format(' + '.join(['size' + str(i) for i in range(1, len(keys) + 1)])))
-    ret.append('};')
-    ret.append('')
+        ret.append(f"    static const int size{i + 1} = sizeof({key}_type);")
+    ret.append(
+        "    uint8_t data[{}];".format(
+            " + ".join(["size" + str(i) for i in range(1, len(keys) + 1)])
+        )
+    )
+    ret.append("};")
+    ret.append("")
 
-    ret.append('template <>')
-    ret.append(f'class TypeDetails<{name}> {{')
-    ret.append('public:')
-    ret.append('    static Type* getType() {')
-    ret.append(f'        static Type* t = {name}::getType();')
-    ret.append('        if (t->bytecount() != bytecount) {')
-    ret.append(f'            throw std::runtime_error("{name} somehow we have the wrong bytecount!");')
-    ret.append('        }')
-    ret.append('        return t;')
-    ret.append('    }')
-    ret.append('    static const uint64_t bytecount = ')
-    ret.append(' +\n'.join([f'        sizeof({name}::{key}_type)' for key in keys]) + ';')
-    ret.append('};')
-    ret.append('')
-    ret.append(f'// END Generated Tuple {name}')
-    ret.append('')
+    ret.append("template <>")
+    ret.append(f"class TypeDetails<{name}> {{")
+    ret.append("public:")
+    ret.append("    static Type* getType() {")
+    ret.append(f"        static Type* t = {name}::getType();")
+    ret.append("        if (t->bytecount() != bytecount) {")
+    ret.append(
+        f'            throw std::runtime_error("{name} somehow we have the wrong bytecount!");'
+    )
+    ret.append("        }")
+    ret.append("        return t;")
+    ret.append("    }")
+    ret.append("    static const uint64_t bytecount = ")
+    ret.append(" +\n".join([f"        sizeof({name}::{key}_type)" for key in keys]) + ";")
+    ret.append("};")
+    ret.append("")
+    ret.append(f"// END Generated Tuple {name}")
+    ret.append("")
 
-    return [e + '\n' for e in ret]
+    return [e + "\n" for e in ret]

--- a/object_database/direct_types/generate_types.py
+++ b/object_database/direct_types/generate_types.py
@@ -50,16 +50,19 @@ def anon_name(py_type):
 # implementation comment:
 # this is an awkward way to keep track of prerequisites
 def cpp_type(py_type) -> TupleType[str, dict]:
-    """Given a python Type, returns the corresponding c++ type name (as a string) and a dict of prerequisites.
+    """ Given a python Type, returns its C++ type name and a dict of prerequisites.
 
     examples:
         given Int64 return "int64_t"
         given ListOf(Int64) return ListOf<int64_t>
+
     For generated types with given names, just use the name
     example:
         if Arb=NamedTuple(X=Int64,Y=Bool)
         given Arb return "Arb"
-    For types containing anonymous subtypes, keep track of them so they can be generated as prerequisites for this type
+
+    For types containing anonymous subtypes, keep track of them so they can be
+    generated as prerequisites for this type
 
     Args:
         py_type: Type subclass.
@@ -98,7 +101,8 @@ def cpp_type(py_type) -> TupleType[str, dict]:
         for e in result:
             prerequisites.update(e[1])
         cpp_name = "OneOf<{}>".format(", ".join([e[0] for e in result]))
-    # Forwards are no longer supported here: types must be fully defined (resolved) before generating direct c++ types
+    # Forwards are no longer supported here:
+    # types must be fully defined (resolved) before generating direct c++ types
     # elif cat == 'Forward':
     #    cpp_name = str(py_type)[8:-2] + '*'  # just for now!
     elif cat in ("Tuple", "NamedTuple", "Alternative"):
@@ -119,8 +123,7 @@ def cpp_type(py_type) -> TupleType[str, dict]:
 
 
 def avoid_cpp_keywords(w):
-    """Given a string, return the string unless it is a c++ keyword, in which case modify the string.
-    """
+    """ Return a modified word if it's a C++ keyword, or the word itself. """
     keywords = ["typename", "class"]
     if w in keywords:
         return w + "0"
@@ -265,7 +268,8 @@ def generate_cpp(codebase, t, cpp, seen, verbose=False, produce_code=True):
 def generate_from_codebase(codebase, dest, listOfItems=None, verbose=False):
     """Generates direct c++ type wrappers from a codebase.
 
-    Specifically, generates code for direct c++ wrappers of test Tuple, NamedTuple, and Alternative types.
+    Specifically, generates code for direct c++ wrappers of test Tuple,
+    NamedTuple, and Alternative types.
 
     Args:
         codebase: Codebase
@@ -324,8 +328,10 @@ AnonTest = Tuple(
 def generate_some_types(dest):
     """Generates direct c++ type wrappers for testing.
 
-    Specifically, generates code for direct c++ wrappers of test Tuple, NamedTuple, and Alternative types.
-    This function will produce Alternatives that are unusable, because Type resolution will fail without a codebase.
+    Specifically, generates code for direct c++ wrappers of test Tuple,
+    NamedTuple, and Alternative types.
+    This function will produce Alternatives that are unusable,
+    because Type resolution will fail without a codebase.
 
     Args:
         dest: filename to which to write generated code.

--- a/object_database/frontends/aws_config.py
+++ b/object_database/frontends/aws_config.py
@@ -23,49 +23,64 @@ from object_database import connect
 from object_database.util import configureLogging, formatTable, secondsToHumanReadable
 from object_database.service_manager.ServiceManager import ServiceManager
 from object_database.service_manager.ServiceSchema import service_schema
-from object_database.service_manager.aws.AwsWorkerBootService import AwsWorkerBootService, AwsApi
-from object_database.service_manager.aws.AwsWorkerBootService import schema as aws_worker_boot_schema
+from object_database.service_manager.aws.AwsWorkerBootService import (
+    AwsWorkerBootService,
+    AwsApi,
+)
+from object_database.service_manager.aws.AwsWorkerBootService import (
+    schema as aws_worker_boot_schema,
+)
 
 
 def main(argv):
     parser = argparse.ArgumentParser("Control the AWS service")
 
-    parser.add_argument("--hostname", default=os.getenv("ODB_HOST", "localhost"), required=False)
-    parser.add_argument("--port", type=int, default=int(os.getenv("ODB_PORT", 8000)), required=False)
-    parser.add_argument("--auth", type=str, default=os.getenv("ODB_AUTH_TOKEN"), required=False, help="Auth token to use to connect.")
+    parser.add_argument(
+        "--hostname", default=os.getenv("ODB_HOST", "localhost"), required=False
+    )
+    parser.add_argument(
+        "--port", type=int, default=int(os.getenv("ODB_PORT", 8000)), required=False
+    )
+    parser.add_argument(
+        "--auth",
+        type=str,
+        default=os.getenv("ODB_AUTH_TOKEN"),
+        required=False,
+        help="Auth token to use to connect.",
+    )
 
     subparsers = parser.add_subparsers()
 
-    config_parser = subparsers.add_parser('config', help='configure the service')
-    config_parser.set_defaults(command='config')
+    config_parser = subparsers.add_parser("config", help="configure the service")
+    config_parser.set_defaults(command="config")
 
-    config_parser.add_argument('--region', required=False)
-    config_parser.add_argument('--vpc_id', required=False)
-    config_parser.add_argument('--subnet', required=False)
-    config_parser.add_argument('--security_group', required=False)
-    config_parser.add_argument('--keypair', required=False)
-    config_parser.add_argument('--worker_name', required=False)
-    config_parser.add_argument('--worker_iam_role_name', required=False)
-    config_parser.add_argument('--docker_image', required=False)
-    config_parser.add_argument('--defaultStorageSize', required=False, type=int)
-    config_parser.add_argument('--max_to_boot', required=False, type=int)
+    config_parser.add_argument("--region", required=False)
+    config_parser.add_argument("--vpc_id", required=False)
+    config_parser.add_argument("--subnet", required=False)
+    config_parser.add_argument("--security_group", required=False)
+    config_parser.add_argument("--keypair", required=False)
+    config_parser.add_argument("--worker_name", required=False)
+    config_parser.add_argument("--worker_iam_role_name", required=False)
+    config_parser.add_argument("--docker_image", required=False)
+    config_parser.add_argument("--defaultStorageSize", required=False, type=int)
+    config_parser.add_argument("--max_to_boot", required=False, type=int)
 
-    install_parser = subparsers.add_parser('install', help='install the service')
-    install_parser.set_defaults(command='install')
+    install_parser = subparsers.add_parser("install", help="install the service")
+    install_parser.set_defaults(command="install")
 
-    list_parser = subparsers.add_parser('list', help='list machines')
-    list_parser.set_defaults(command='list')
+    list_parser = subparsers.add_parser("list", help="list machines")
+    list_parser.set_defaults(command="list")
 
-    boot_parser = subparsers.add_parser('boot', help='set the number of desired boxes')
-    boot_parser.set_defaults(command='boot')
+    boot_parser = subparsers.add_parser("boot", help="set the number of desired boxes")
+    boot_parser.set_defaults(command="boot")
     boot_parser.add_argument("instance_type")
     boot_parser.add_argument("count", type=int)
 
-    killall_parser = subparsers.add_parser('killall', help='kill everything')
-    killall_parser.set_defaults(command='killall')
+    killall_parser = subparsers.add_parser("killall", help="kill everything")
+    killall_parser.set_defaults(command="killall")
 
-    reset_parser = subparsers.add_parser('reset', help='kill everything')
-    reset_parser.set_defaults(command='reset')
+    reset_parser = subparsers.add_parser("reset", help="kill everything")
+    reset_parser.set_defaults(command="reset")
 
     configureLogging()
 
@@ -75,12 +90,12 @@ def main(argv):
     db.subscribeToSchema(service_schema, lazySubscription=True)
     db.subscribeToSchema(aws_worker_boot_schema)
 
-    if parsedArgs.command == 'reset':
+    if parsedArgs.command == "reset":
         with db.transaction():
             for s in aws_worker_boot_schema.State.lookupAll():
                 s.delete()
 
-    if parsedArgs.command == 'config':
+    if parsedArgs.command == "config":
         with db.transaction():
             AwsWorkerBootService.configure(
                 db_hostname=parsedArgs.hostname,
@@ -94,14 +109,16 @@ def main(argv):
                 worker_iam_role_name=parsedArgs.worker_iam_role_name,
                 docker_image=parsedArgs.docker_image,
                 defaultStorageSize=parsedArgs.defaultStorageSize,
-                max_to_boot=parsedArgs.max_to_boot
+                max_to_boot=parsedArgs.max_to_boot,
             )
 
-    if parsedArgs.command == 'install':
+    if parsedArgs.command == "install":
         with db.transaction():
-            ServiceManager.createOrUpdateService(AwsWorkerBootService, "AwsWorkerBootService", placement="Master")
+            ServiceManager.createOrUpdateService(
+                AwsWorkerBootService, "AwsWorkerBootService", placement="Master"
+            )
 
-    if parsedArgs.command == 'list':
+    if parsedArgs.command == "list":
         print()
         print()
 
@@ -113,11 +130,13 @@ def main(argv):
             table = [["Instance Type", "Booted", "Desired"]]
 
             for instance_type in sorted(set(list(booted) + list(targets))):
-                table.append([
-                    instance_type,
-                    booted.get(instance_type, 0),
-                    targets.get(instance_type, 0)
-                ])
+                table.append(
+                    [
+                        instance_type,
+                        booted.get(instance_type, 0),
+                        targets.get(instance_type, 0),
+                    ]
+                )
 
             print(formatTable(table))
 
@@ -128,22 +147,26 @@ def main(argv):
             api = AwsApi()
             table = [["InstanceID", "InstanceType", "IP", "Uptime"]]
             for instanceId, instance in api.allRunningInstances(spot=None).items():
-                table.append([
-                    instance['InstanceId'],
-                    instance['InstanceType'],
-                    instance['PrivateIpAddress'],
-                    secondsToHumanReadable(time.time() - instance['LaunchTime'].timestamp())
-                ])
+                table.append(
+                    [
+                        instance["InstanceId"],
+                        instance["InstanceType"],
+                        instance["PrivateIpAddress"],
+                        secondsToHumanReadable(
+                            time.time() - instance["LaunchTime"].timestamp()
+                        ),
+                    ]
+                )
             print(formatTable(table))
 
         print()
         print()
 
-    if parsedArgs.command == 'boot':
+    if parsedArgs.command == "boot":
         with db.transaction():
             AwsWorkerBootService.setBootState(parsedArgs.instance_type, parsedArgs.count)
 
-    if parsedArgs.command == 'killall':
+    if parsedArgs.command == "killall":
         with db.transaction():
             AwsWorkerBootService.shutdownAll()
 
@@ -159,5 +182,5 @@ def main(argv):
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/object_database/frontends/database_server.py
+++ b/object_database/frontends/database_server.py
@@ -29,12 +29,19 @@ def main(argv):
     parser.add_argument("host")
     parser.add_argument("port", type=int)
     parser.add_argument(
-        "--service-token", type=str, required=True,
-        help="the auth token to be used with this service"
+        "--service-token",
+        type=str,
+        required=True,
+        help="the auth token to be used with this service",
     )
-    parser.add_argument("--ssl-path", default=None, required=False, help="path to (self-signed) SSL certificate")
+    parser.add_argument(
+        "--ssl-path",
+        default=None,
+        required=False,
+        help="path to (self-signed) SSL certificate",
+    )
     parser.add_argument("--redis_port", type=int, default=None)
-    parser.add_argument("--inmem", default=False, action='store_true')
+    parser.add_argument("--inmem", default=False, action="store_true")
 
     parsedArgs = parser.parse_args(argv[1:])
 
@@ -49,7 +56,7 @@ def main(argv):
         parsedArgs.port,
         mem_store,
         ssl_context=ssl_ctx,
-        auth_token=parsedArgs.service_token
+        auth_token=parsedArgs.service_token,
     )
 
     databaseServer.start()
@@ -61,5 +68,5 @@ def main(argv):
         return
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(sys.argv)

--- a/object_database/frontends/database_throughput_test.py
+++ b/object_database/frontends/database_throughput_test.py
@@ -27,11 +27,13 @@ def main(argv):
     parser.add_argument("host")
     parser.add_argument("port")
     parser.add_argument(
-        "--service-token", type=str, required=True,
-        help="the auth token to be used with this service"
+        "--service-token",
+        type=str,
+        required=True,
+        help="the auth token to be used with this service",
     )
     parser.add_argument("seconds", type=float)
-    parser.add_argument("--threads", dest='threads', type=int, default=1)
+    parser.add_argument("--threads", dest="threads", type=int, default=1)
 
     parsedArgs = parser.parse_args(argv[1:])
 
@@ -71,5 +73,5 @@ def main(argv):
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -28,24 +28,16 @@ from object_database.service_manager.ServiceManager_test import (
     HappyService,
     # UninitializableService,
     DropdownTestService,
-    BigGridTestService
+    BigGridTestService,
 )
 
 from object_database.web.CellsTestService import CellsTestService
 
 from object_database.web.EditorDisplayService import EditorDisplayService
 
-from object_database.web.ActiveWebServiceSchema import (
-    active_webservice_schema,
-)
-from object_database.web.ActiveWebService import (
-    ActiveWebService
-)
-from object_database import (
-    connect,
-    core_schema,
-    service_schema,
-)
+from object_database.web.ActiveWebServiceSchema import active_webservice_schema
+from object_database.web.ActiveWebService import ActiveWebService
+from object_database import connect, core_schema, service_schema
 from object_database.frontends.service_manager import startServiceManagerProcess
 from object_database.util import genToken
 from object_database.web.LoginPlugin import LoginIpPlugin
@@ -60,29 +52,26 @@ def main(argv=None):
 
     token = genToken()
     port = 8020
-    loglevel_name = 'INFO'
+    loglevel_name = "INFO"
 
     with tempfile.TemporaryDirectory() as tmpDirName:
         try:
             server = startServiceManagerProcess(
-                tmpDirName, port, token,
-                loglevelName=loglevel_name,
-                logDir=False
+                tmpDirName, port, token, loglevelName=loglevel_name, logDir=False
             )
 
             database = connect("localhost", port, token, retry=True)
-            database.subscribeToSchema(core_schema, service_schema,
-                                       active_webservice_schema)
+            database.subscribeToSchema(core_schema, service_schema, active_webservice_schema)
 
             with database.transaction():
                 service = ServiceManager.createOrUpdateService(
-                    ActiveWebService, "ActiveWebService", target_count=0)
+                    ActiveWebService, "ActiveWebService", target_count=0
+                )
 
             ActiveWebService.configureFromCommandline(
-                database, service,
-                ['--port', '8000',
-                 '--host', '0.0.0.0',
-                 '--log-level', loglevel_name]
+                database,
+                service,
+                ["--port", "8000", "--host", "0.0.0.0", "--log-level", loglevel_name],
             )
 
             ActiveWebService.setLoginPlugin(
@@ -90,7 +79,7 @@ def main(argv=None):
                 service,
                 LoginIpPlugin,
                 [None],
-                config={'company_name': 'A Testing Company'}
+                config={"company_name": "A Testing Company"},
             )
 
             with database.transaction():
@@ -98,14 +87,12 @@ def main(argv=None):
 
             with database.transaction():
                 service = ServiceManager.createOrUpdateService(
-                    CellsTestService, "CellsTestService",
-                    target_count=1
+                    CellsTestService, "CellsTestService", target_count=1
                 )
 
             with database.transaction():
                 service = ServiceManager.createOrUpdateService(
-                    EditorDisplayService, "EditorDisplayService",
-                    target_count=1
+                    EditorDisplayService, "EditorDisplayService", target_count=1
                 )
 
             with database.transaction():
@@ -133,9 +120,11 @@ def main(argv=None):
 
             with database.transaction():
                 ServiceManager.createOrUpdateServiceWithCodebase(
-                    service_schema.Codebase.createFromFiles({
-                        'test_service/__init__.py': '',
-                        'test_service/service.py': textwrap.dedent("""
+                    service_schema.Codebase.createFromFiles(
+                        {
+                            "test_service/__init__.py": "",
+                            "test_service/service.py": textwrap.dedent(
+                                """
                             from object_database.service_manager.ServiceBase import ServiceBase
 
                             class TestService(ServiceBase):
@@ -151,17 +140,19 @@ def main(argv=None):
 
                                 def display(self, queryParams=None):
                                     return "test service display message"
-                        """)
-                    }),
+                        """
+                            ),
+                        }
+                    ),
                     "test_service.service.TestService",
                     "TestService",
-                    10
+                    10,
                 )
 
             print("SERVER IS BOOTED")
 
             while True:
-                time.sleep(.1)
+                time.sleep(0.1)
         finally:
             server.terminate()
             server.wait()
@@ -169,5 +160,5 @@ def main(argv=None):
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -46,6 +46,25 @@ from object_database.web.LoginPlugin import LoginIpPlugin
 ownDir = os.path.dirname(os.path.abspath(__file__))
 
 
+TEST_SERVICE = """
+    from object_database.service_manager.ServiceBase import ServiceBase
+
+    class TestService(ServiceBase):
+        gbRamUsed = 0
+        coresUsed = 0
+
+        def initialize(self):
+            with self.db.transaction():
+                self.runtimeConfig.serviceInstance.statusMessage = "Loaded"
+
+        def doWork(self, shouldStop):
+            shouldStop.wait()
+
+        def display(self, queryParams=None):
+            return "test service display message"
+    """
+
+
 def main(argv=None):
     if argv is not None:
         argv = sys.argv
@@ -123,25 +142,7 @@ def main(argv=None):
                     service_schema.Codebase.createFromFiles(
                         {
                             "test_service/__init__.py": "",
-                            "test_service/service.py": textwrap.dedent(
-                                """
-                            from object_database.service_manager.ServiceBase import ServiceBase
-
-                            class TestService(ServiceBase):
-                                gbRamUsed = 0
-                                coresUsed = 0
-
-                                def initialize(self):
-                                    with self.db.transaction():
-                                        self.runtimeConfig.serviceInstance.statusMessage = "Loaded"
-
-                                def doWork(self, shouldStop):
-                                    shouldStop.wait()
-
-                                def display(self, queryParams=None):
-                                    return "test service display message"
-                        """
-                            ),
+                            "test_service/service.py": textwrap.dedent(TEST_SERVICE),
                         }
                     ),
                     "test_service.service.TestService",

--- a/object_database/frontends/service_entrypoint.py
+++ b/object_database/frontends/service_entrypoint.py
@@ -42,7 +42,7 @@ def main(argv):
     parsedArgs = parser.parse_args(argv[1:])
 
     level = parsedArgs.log_level.upper()
-    level = validateLogLevel(level, fallback='INFO')
+    level = validateLogLevel(level, fallback="INFO")
 
     configureLogging(preamble=str(parsedArgs.instanceid), level=level)
 
@@ -52,12 +52,13 @@ def main(argv):
         "service_entrypoint.py connecting to %s:%s for %s",
         parsedArgs.host,
         parsedArgs.port,
-        parsedArgs.instanceid
+        parsedArgs.instanceid,
     )
 
     setCodebaseInstantiationDirectory(parsedArgs.sourceDir)
 
     try:
+
         def dbConnectionFactory():
             return connect(parsedArgs.host, parsedArgs.port, parsedArgs.authToken)
 
@@ -67,7 +68,7 @@ def main(argv):
             logger.info("Our ip explicitly specified as %s", parsedArgs.ip)
             ourIP = parsedArgs.ip
         else:
-            ourIP = mainDbConnection.getConnectionMetadata()['sockname'][0]
+            ourIP = mainDbConnection.getConnectionMetadata()["sockname"][0]
             logger.info("Our ip inferred from our connection back to the server as %s", ourIP)
 
         manager = ServiceWorker(
@@ -76,7 +77,7 @@ def main(argv):
             int(parsedArgs.instanceid),
             parsedArgs.storageRoot,
             parsedArgs.authToken,
-            ourIP
+            ourIP,
         )
 
         def shutdownCleanly(signalNumber, frame):
@@ -90,9 +91,11 @@ def main(argv):
 
         return 0
     except Exception:
-        logger.error("service_entrypoint failed with an exception:\n%s", traceback.format_exc())
+        logger.error(
+            "service_entrypoint failed with an exception:\n%s", traceback.format_exc()
+        )
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/object_database/frontends/service_manager.py
+++ b/object_database/frontends/service_manager.py
@@ -146,9 +146,8 @@ def autoconfigureAndStartServiceManagerProcess(
 
         if error or server.returncode:
             logging.getLogger(__name__).warning(
-                "Exited with an error. Leaving temporary directory around for inspection: {}".format(
-                    tempDirectoryName
-                )
+                "Exited with an error. Leaving temporary directory around for inspection: %s",
+                tempDirectoryName,
             )
         else:
             tempDirObj.cleanup()

--- a/object_database/inmem_server.py
+++ b/object_database/inmem_server.py
@@ -47,13 +47,18 @@ class InMemoryChannel:
                 try:
                     self._clientCallback(e)
                 except Exception:
-                    self._logger.error("Pump thread failed for %s: %s", self, traceback.format_exc())
+                    self._logger.error(
+                        "Pump thread failed for %s: %s", self, traceback.format_exc()
+                    )
                     return
 
     def pumpMessagesFromClient(self):
         lastHeartbeat = time.time()
         while not self._shouldStop:
-            if time.time() - lastHeartbeat > getHeartbeatInterval() and not self._stopHeartbeatingSet:
+            if (
+                time.time() - lastHeartbeat > getHeartbeatInterval()
+                and not self._stopHeartbeatingSet
+            ):
                 lastHeartbeat = time.time()
                 e = ClientToServer.Heartbeat()
             else:
@@ -109,11 +114,13 @@ class InMemoryChannel:
 
 
 class InMemServer(Server):
-    def __init__(self, kvstore=None, auth_token=''):
+    def __init__(self, kvstore=None, auth_token=""):
         Server.__init__(self, kvstore or InMemoryPersistence(), auth_token)
         self.channels = []
         self.stopped = threading.Event()
-        self.checkForDeadConnectionsLoopThread = threading.Thread(target=self.checkForDeadConnectionsLoop)
+        self.checkForDeadConnectionsLoopThread = threading.Thread(
+            target=self.checkForDeadConnectionsLoop
+        )
         self.checkForDeadConnectionsLoopThread.daemon = True
         self.checkForDeadConnectionsLoopThread.start()
 

--- a/object_database/message_bus.py
+++ b/object_database/message_bus.py
@@ -157,36 +157,48 @@ class MessageBus(object):
         """Initialize a MessageBus
 
         Args:
-            busIdentity - any object that identifies this message bus
-            endpoint - a (host, port) tuple that we're supposed to listen on, or None if we accept no incoming.
-            messageType - the wire-type of all messages. Can be 'object' in which case we'll require a serializationContext
-                to know how to serialize the names of types.
-            serializationContext - the serialization context to use for serializing things, or None to use naked serialization
+            busIdentity: any object that identifies this message bus
+            endpoint: a (host, port) tuple that we're supposed to listen on,
+                or None if we accept no incoming.
+            messageType: the wire-type of all messages. Can be 'object', in
+                which case we'll require a serializationContext to know how
+                to serialize the names of types.
+            serializationContext: the serialization context to use for
+                serializing things, or None to use naked serialization
                 from typed_python without any 'object'.
-            authToken - the authentication token that must be sent to us for the connection to succeed. If None, then don't
-                require authentication. MessageBus objects must have the same authToken to work together.
-            onEvent - a callback function recieving a stream of 'eventType' objects (MessageBusEvents).
-            certPath - (str or None) if we use SSL, an optional path to a cert file.
-            wantsSSL (bool) - should we encrypt our channel with SSL
+            authToken: the authentication token that must be sent to us for
+                the connection to succeed. If None, then don't require
+                authentication. MessageBus objects must have the same
+                authToken to work together.
+            onEvent: a callback function recieving a stream of 'eventType'
+                objects (MessageBusEvents).
+            certPath(str or None): if we use SSL, an optional path to a cert file.
+            wantsSSL(bool): should we encrypt our channel with SSL
 
-        The MessageBus listen for connection on the endpoint and calls onEvent from the read thread whenever
-        a new event occurs.
+        The MessageBus listens for connection on the endpoint and calls
+        onEvent from the read thread whenever a new event occurs.
 
-        Clients may establish connection to other MessageBus objects, and will receive a ConnectionId object
-        representing that channel. Other clients connecting in will produce their own 'ConnectionId's associated
-        with the incoming connection. ConnectionIds are unique for a given MessageBus instance.
+        Clients may establish connection to other MessageBus objects, and
+        will receive a ConnectionId object representing that channel.
+        Other clients connecting in will produce their own 'ConnectionId's
+        associated with the incoming connection. ConnectionIds are unique
+        for a given MessageBus instance.
 
-        Clients may send messages to outgoing connections that have been established or to other incoming connections.
-        The send function indicates whether the send _might_ succeed (meaning it returns False only if it's KNOWN that
-        the message channel on the other side is closed.)
+        Clients may send messages to outgoing connections that have been
+        established or to other incoming connections.
+        The send function indicates whether the send _might_ succeed,
+        meaning it returns False only if it's KNOWN that the message
+        channel on the other side is closed.
 
-        All event callbacks are fired from the same internal thread. This function should never throw,
-        and if it blocks, it will block execution across all threads.
+        All event callbacks are fired from the same internal thread.
+        This function should never throw, and if it blocks, it will
+        block execution across all threads.
 
-        Clients are expected to call 'start' to start the bus, and 'stop' to stop it and tear down threads.
+        Clients are expected to call 'start' to start the bus, and 'stop'
+        to stop it and tear down threads.
 
-        Clients can call 'connect' to get a connection id back, which they can pass to 'closeConnection' or
-        'sendMessage'.
+        Clients can call 'connect' to get a connection id back, which they
+        can pass to 'closeConnection' or 'sendMessage'.
         """
         if authToken is not None:
             assert isinstance(authToken, str)
@@ -552,7 +564,8 @@ class MessageBus(object):
                             bytesReceived = b""
                         except Exception as e:
                             logging.info(
-                                "MessageBus read socket shutting down because of exception: %s",
+                                "MessageBus read socket shutting down "
+                                "because of exception: %s",
                                 e,
                             )
                             bytesReceived = b""
@@ -752,7 +765,8 @@ class MessageBus(object):
                     connId, msg = connectionAndMsg
 
                     if msg is TriggerDisconnect:
-                        # take this message, and make sure we never put this socket in the selectloop again.
+                        # take this message, and make sure we never put this
+                        # socket in the selectloop again.
                         if connId in socketToBytes:
                             del socketToBytes[connId]
 

--- a/object_database/messages.py
+++ b/object_database/messages.py
@@ -37,7 +37,8 @@ ClientToServer = Alternative(
         "schema": str,
         "typename": OneOf(None, str),
         "fieldname_and_value": OneOf(None, Tuple(str, IndexValue)),
-        "isLazy": bool,  # load values when we first request them, instead of blocking on all the data.
+        # load values when we first request them, instead of blocking on all the data.
+        "isLazy": bool,
     },
     Flush={"guid": int},
     Authenticate={"token": str},

--- a/object_database/messages.py
+++ b/object_database/messages.py
@@ -1,5 +1,12 @@
 from typed_python import OneOf, Alternative, ConstDict, TupleOf, Tuple
-from object_database.schema import SchemaDefinition, ObjectId, ObjectFieldId, IndexId, IndexValue, FieldDefinition
+from object_database.schema import (
+    SchemaDefinition,
+    ObjectId,
+    ObjectFieldId,
+    IndexId,
+    IndexValue,
+    FieldDefinition,
+)
 
 _heartbeatInterval = [5.0]
 
@@ -20,70 +27,73 @@ ClientToServer = Alternative(
         "set_removes": ConstDict(IndexId, TupleOf(ObjectId)),
         "key_versions": TupleOf(ObjectFieldId),
         "index_versions": TupleOf(IndexId),
-        "transaction_guid": int
+        "transaction_guid": int,
     },
-    CompleteTransaction={
-        "as_of_version": int,
-        "transaction_guid": int
-    },
+    CompleteTransaction={"as_of_version": int, "transaction_guid": int},
     Heartbeat={},
-    DefineSchema={ 'name': str, 'definition': SchemaDefinition },
-    LoadLazyObject={ 'schema': str, 'typename': str, 'identity': ObjectId },
+    DefineSchema={"name": str, "definition": SchemaDefinition},
+    LoadLazyObject={"schema": str, "typename": str, "identity": ObjectId},
     Subscribe={
-        'schema': str,
-        'typename': OneOf(None, str),
-        'fieldname_and_value': OneOf(None, Tuple(str, IndexValue)),
-        'isLazy': bool  # load values when we first request them, instead of blocking on all the data.
+        "schema": str,
+        "typename": OneOf(None, str),
+        "fieldname_and_value": OneOf(None, Tuple(str, IndexValue)),
+        "isLazy": bool,  # load values when we first request them, instead of blocking on all the data.
     },
-    Flush={'guid': int},
-    Authenticate={'token': str}
+    Flush={"guid": int},
+    Authenticate={"token": str},
 )
 
 
 ServerToClient = Alternative(
     "ServerToClient",
-    Initialize={'transaction_num': int, 'connIdentity': ObjectId, 'identity_root': int},
-    TransactionResult={'transaction_guid': int, 'success': bool, 'badKey': OneOf(None, ObjectFieldId, IndexId, str) },
-    SchemaMapping={ 'schema': str, 'mapping': ConstDict(FieldDefinition, int) },
-    FlushResponse={'guid': int},
-    SubscriptionData={
-        'schema': str,
-        'typename': OneOf(None, str),
-        'fieldname_and_value': OneOf(None, Tuple(str, IndexValue)),
-        'values': ConstDict(ObjectFieldId, OneOf(None, bytes)),  # value
-        'index_values': ConstDict(ObjectFieldId, OneOf(None, IndexValue)),
-        'identities': OneOf(None, TupleOf(ObjectId)),  # the identities in play if this is an index-level subscription
+    Initialize={"transaction_num": int, "connIdentity": ObjectId, "identity_root": int},
+    TransactionResult={
+        "transaction_guid": int,
+        "success": bool,
+        "badKey": OneOf(None, ObjectFieldId, IndexId, str),
     },
-    LazyTransactionPriors={ 'writes': ConstDict(ObjectFieldId, OneOf(None, bytes)) },
+    SchemaMapping={"schema": str, "mapping": ConstDict(FieldDefinition, int)},
+    FlushResponse={"guid": int},
+    SubscriptionData={
+        "schema": str,
+        "typename": OneOf(None, str),
+        "fieldname_and_value": OneOf(None, Tuple(str, IndexValue)),
+        "values": ConstDict(ObjectFieldId, OneOf(None, bytes)),  # value
+        "index_values": ConstDict(ObjectFieldId, OneOf(None, IndexValue)),
+        "identities": OneOf(
+            None, TupleOf(ObjectId)
+        ),  # the identities in play if this is an index-level subscription
+    },
+    LazyTransactionPriors={"writes": ConstDict(ObjectFieldId, OneOf(None, bytes))},
     LazyLoadResponse={
-        'identity': ObjectId,
-        'values': ConstDict(ObjectFieldId, OneOf(None, bytes))
+        "identity": ObjectId,
+        "values": ConstDict(ObjectFieldId, OneOf(None, bytes)),
     },
     LazySubscriptionData={
-        'schema': str,
-        'typename': OneOf(None, str),
-        'fieldname_and_value': OneOf(None, Tuple(str, IndexValue)),
-        'identities': TupleOf(ObjectId),
-        'index_values': ConstDict(ObjectFieldId, OneOf(None, IndexValue))
+        "schema": str,
+        "typename": OneOf(None, str),
+        "fieldname_and_value": OneOf(None, Tuple(str, IndexValue)),
+        "identities": TupleOf(ObjectId),
+        "index_values": ConstDict(ObjectFieldId, OneOf(None, IndexValue)),
     },
     SubscriptionComplete={
-        'schema': str,
-        'typename': OneOf(None, str),
-        'fieldname_and_value': OneOf(None, Tuple(str, IndexValue)),
-        'tid': int  # marker transaction id
+        "schema": str,
+        "typename": OneOf(None, str),
+        "fieldname_and_value": OneOf(None, Tuple(str, IndexValue)),
+        "tid": int,  # marker transaction id
     },
     SubscriptionIncrease={
-        'schema': str,
-        'typename': str,
-        'fieldname_and_value': Tuple(str, IndexValue),
-        'identities': TupleOf(ObjectId),
-        'transaction_id': int
+        "schema": str,
+        "typename": str,
+        "fieldname_and_value": Tuple(str, IndexValue),
+        "identities": TupleOf(ObjectId),
+        "transaction_id": int,
     },
     Disconnected={},
     Transaction={
         "writes": ConstDict(ObjectFieldId, OneOf(None, bytes)),
         "set_adds": ConstDict(IndexId, TupleOf(ObjectId)),
         "set_removes": ConstDict(IndexId, TupleOf(ObjectId)),
-        "transaction_id": int
-    }
+        "transaction_id": int,
+    },
 )

--- a/object_database/persistence.py
+++ b/object_database/persistence.py
@@ -105,10 +105,14 @@ class InMemoryPersistence(object):
         new_sets, dropped_sets = set(), set()
 
         with self.lock:
-            for k in (adds or []):
-                assert not isinstance(self.values.get(k, None), str), k + " is already a string"
-            for k in (removes or []):
-                assert not isinstance(self.values.get(k, None), str), k + " is already a string"
+            for k in adds or []:
+                assert not isinstance(self.values.get(k, None), str), (
+                    k + " is already a string"
+                )
+            for k in removes or []:
+                assert not isinstance(self.values.get(k, None), str), (
+                    k + " is already a string"
+                )
 
             for k, v in kvs.items():
                 self.set(k, v)
@@ -143,7 +147,7 @@ class RedisPersistence(object):
         kwds = {}
 
         if port is not None:
-            kwds['port'] = port
+            kwds["port"] = port
 
         self.redis = redis.StrictRedis(db=db, **kwds)
         self.cache = {}

--- a/object_database/reactor.py
+++ b/object_database/reactor.py
@@ -217,7 +217,8 @@ class Reactor:
                         or exceptionsInARow % 100 == 0
                     ):
                         logging.error(
-                            "Unexpected exception in Reactor user code (%s occurrences in a row):\n%s",
+                            "Unexpected exception in Reactor user code "
+                            "(%s occurrences in a row):\n%s",
                             exceptionsInARow,
                             traceback.format_exc(),
                         )

--- a/object_database/reactor.py
+++ b/object_database/reactor.py
@@ -23,6 +23,7 @@ from object_database.view import RevisionConflictException, ViewWatcher
 
 class Timeout:
     """Singleton used to indicate that the reactor timed out."""
+
     pass
 
 
@@ -84,8 +85,10 @@ class Reactor:
         ...
 
     """
+
     class STOP:
         """singleton class to indicate that we should exit the loop."""
+
         pass
 
     def __init__(self, db, reactorFunction, maxSleepTime=None):
@@ -123,7 +126,7 @@ class Reactor:
         If this function returns False, then as soon as it would return True it wakes up
         again.
         """
-        curTime = getattr(_currentReactor, 'timestamp', None)
+        curTime = getattr(_currentReactor, "timestamp", None)
         if curTime is None:
             raise Exception("No reactor is running.")
 
@@ -182,11 +185,15 @@ class Reactor:
             raise Exception("Can't call 'next' if the reactor is being used in threaded mode.")
 
         if self._lastReadKeys is not None:
-            if not self._blockUntilRecalculate(self._lastReadKeys, self._nextWakeup, timeout=timeout):
+            if not self._blockUntilRecalculate(
+                self._lastReadKeys, self._nextWakeup, timeout=timeout
+            ):
                 return Timeout
 
         self._drainTransactionQueue()
-        result, self._lastReadKeys, self._nextWakeup = self._calculate(catchRevisionConflicts=False)
+        result, self._lastReadKeys, self._nextWakeup = self._calculate(
+            catchRevisionConflicts=False
+        )
 
         return result
 
@@ -203,11 +210,16 @@ class Reactor:
                     exceptionsInARow = 0
                 except Exception:
                     exceptionsInARow += 1
-                    if exceptionsInARow < 10 or exceptionsInARow < 100 and exceptionsInARow % 10 == 0 or exceptionsInARow % 100 == 0:
+                    if (
+                        exceptionsInARow < 10
+                        or exceptionsInARow < 100
+                        and exceptionsInARow % 10 == 0
+                        or exceptionsInARow % 100 == 0
+                    ):
                         logging.error(
                             "Unexpected exception in Reactor user code (%s occurrences in a row):\n%s",
                             exceptionsInARow,
-                            traceback.format_exc()
+                            traceback.format_exc(),
                         )
                     time.sleep(0.001 * exceptionsInARow)
 
@@ -227,7 +239,7 @@ class Reactor:
             raise Exception("Reactor would block forever.")
 
         curTime = time.time()
-        finalTime = curTime + (timeout if timeout is not None else 10**8)
+        finalTime = curTime + (timeout if timeout is not None else 10 ** 8)
         if nextWakeup is not None and finalTime > nextWakeup:
             finalTime = nextWakeup
 
@@ -284,13 +296,15 @@ class Reactor:
 
             with ViewWatcher(onViewClose):
                 try:
-                    origTimestamp = getattr(_currentReactor, 'timestamp', None)
-                    origWakeup = getattr(_currentReactor, 'nextWakeup', None)
+                    origTimestamp = getattr(_currentReactor, "timestamp", None)
+                    origWakeup = getattr(_currentReactor, "nextWakeup", None)
 
                     _currentReactor.timestamp = time.time()
                     _currentReactor.nextWakeup = None
 
-                    logging.getLogger(__name__).debug("Reactor %s recalculating", self.reactorFunction)
+                    logging.getLogger(__name__).debug(
+                        "Reactor %s recalculating", self.reactorFunction
+                    )
                     functionResult = self.reactorFunction()
 
                     nextWakeup = _currentReactor.nextWakeup
@@ -308,7 +322,8 @@ class Reactor:
                 raise
 
             logging.getLogger(__name__).info(
-                "Handled a revision conflict on key %s in %s. Retrying." % (e, self.reactorFunction.__name__)
+                "Handled a revision conflict on key %s in %s. Retrying."
+                % (e, self.reactorFunction.__name__)
             )
             return None, None, None
 

--- a/object_database/schema.py
+++ b/object_database/schema.py
@@ -73,11 +73,13 @@ class Schema:
         self._types_to_original = {}
 
     def toDefinition(self):
-        return SchemaDefinition({
-            tname: self.typeToDef(t)
-            for tname, t in self._types.items()
-            if getattr(t, "__is_database_object_type__", False)
-        })
+        return SchemaDefinition(
+            {
+                tname: self.typeToDef(t)
+                for tname, t in self._types.items()
+                if getattr(t, "__is_database_object_type__", False)
+            }
+        )
 
     def __repr__(self):
         return "Schema(%s)" % self.name
@@ -85,12 +87,12 @@ class Schema:
     def lookupFullyQualifiedTypeByName(self, name):
         if not name.startswith(self.name + "."):
             return None
-        return self._types.get(name[len(self.name)+1:])
+        return self._types.get(name[len(self.name) + 1 :])
 
     def typeToDef(self, t):
         return TypeDefinition(
             fields=sorted(self._field_types[t.__name__]),
-            indices=sorted(self._indices[t.__name__])
+            indices=sorted(self._indices[t.__name__]),
         )
 
     def getType(self, t):
@@ -116,7 +118,9 @@ class Schema:
 
     def freeze(self):
         if not self._frozen:
-            assert not self._undefinedTypes, "Still need definitions for %s" % (", ".join(self._undefinedTypes))
+            assert not self._undefinedTypes, "Still need definitions for %s" % (
+                ", ".join(self._undefinedTypes)
+            )
             self._frozen = True
 
     def __setattr__(self, typename, val):
@@ -131,7 +135,7 @@ class Schema:
         self._supportingTypes[typename] = val
 
     def __getattr__(self, typename):
-        assert '.' not in typename
+        assert "." not in typename
 
         if typename.startswith("_"):
             return self.__dict__[typename]
@@ -157,7 +161,9 @@ class Schema:
     def define(self, cls):
         typename = cls.__name__
 
-        assert not typename.startswith("_"), "Illegal to use _ for first character in database classnames."
+        assert not typename.startswith(
+            "_"
+        ), "Illegal to use _ for first character in database classnames."
         assert not self._frozen, "Schema is already frozen"
 
         # get a type stub
@@ -165,12 +171,12 @@ class Schema:
 
         # add the canonical ' exists' property, which we use under the hood to indicate
         # existence/deletion of an object.
-        self._field_types[typename][' exists'] = bool
-        self._indices[typename][' exists'] = (' exists',)
-        self._index_types[typename][' exists'] = bool
+        self._field_types[typename][" exists"] = bool
+        self._indices[typename][" exists"] = (" exists",)
+        self._index_types[typename][" exists"] = bool
 
-        t.addField(' exists', bool)
-        t.addIndex(' exists', (' exists',))
+        t.addField(" exists", bool)
+        t.addIndex(" exists", (" exists",))
 
         # make sure it's not defined yet
         assert typename in self._undefinedTypes, f"Type {typename} is not undefined."
@@ -222,13 +228,17 @@ class Schema:
                 self._indices[typename][name] = tuple(val.names)
 
                 if len(val.names) > 1:
-                    self._index_types[typename][name] = Tuple(*[self._field_types[typename][fieldname] for fieldname in val.names])
+                    self._index_types[typename][name] = Tuple(
+                        *[self._field_types[typename][fieldname] for fieldname in val.names]
+                    )
                 else:
-                    self._index_types[typename][name] = self._field_types[typename][val.names[0]]
+                    self._index_types[typename][name] = self._field_types[typename][
+                        val.names[0]
+                    ]
 
         t.finalize()
 
-        if hasattr(cls, '__object_database_lazy_subscription__'):
+        if hasattr(cls, "__object_database_lazy_subscription__"):
             t.markLazyByDefault()
 
         return t

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -467,7 +467,8 @@ class Server:
 
     def handleSubscriptionOnBackgroundThread(self, connectedChannel, msg):
         with Timer(
-            "Subscription requiring %s messages and produced %s objects for %s/%s/%s/isLazy=%s",
+            "Subscription requiring %s messages and produced %s objects "
+            "for %s/%s/%s/isLazy=%s",
             lambda: messageCount,
             lambda: len(identities),
             msg.schema,
@@ -506,9 +507,10 @@ class Server:
 
                     self._pendingSubscriptionRecheck = []
 
-                # we need to send everything we know about 'identities', keeping in mind that we have to
-                # check any new identities that get written to in the background to see if they belong
-                # in the new set
+                # we need to send everything we know about 'identities',
+                # keeping in mind that we have to check any new identities
+                # that get written to in the background to see if they
+                # belong in the new set
                 identities_left_to_send = set(identities)
 
                 messageCount = 0
@@ -648,7 +650,8 @@ class Server:
                     -1 if not isLazy else self._cur_transaction_num
                 )
             else:
-                # an object's identity cannot change, so we don't need to track our subscription to it
+                # an object's identity cannot change,
+                # so we don't need to track our subscription to it
                 assert not isLazy
         else:
             # this is a type-subscription
@@ -1077,8 +1080,9 @@ class Server:
 
         channelsTriggeredForPriors = set()
 
-        # check any index-level subscriptions that are going to increase as a result of this
-        # transaction and add the backing data to the relevant transaction.
+        # check any index-level subscriptions that are going to increase as a
+        # result of this transaction and add the backing data to the relevant
+        # transaction.
         for index_key, adds in list(set_adds.items()):
             if index_key in self._index_to_channel:
                 idsToAddToTransaction = set()
@@ -1088,8 +1092,9 @@ class Server:
                         index_key in channel.subscribedIndexKeys
                         and channel.subscribedIndexKeys[index_key] >= 0
                     ):
-                        # this is a lazy subscription. We're not using the transaction ID yet because
-                        # we don't store it on a per-object basis here. Instead, we're always sending
+                        # this is a lazy subscription. We're not using the
+                        # transaction ID yet because we don't store it on a
+                        # per-object basis here. Instead, we're always sending
                         # everything twice to lazy subscribers.
                         channelsTriggeredForPriors.add(channel)
 
@@ -1124,8 +1129,9 @@ class Server:
         for fieldId in fieldIdsWriting:
             for channel in self._field_id_to_channel.get(fieldId, ()):
                 if channel.subscribedFields[fieldId] >= 0:
-                    # this is a lazy subscription. We're not using the transaction ID yet because
-                    # we don't store it on a per-object basis here. Instead, we're always sending
+                    # this is a lazy subscription. We're not using the
+                    # transaction ID yet because we don't store it on a
+                    # per-object basis here. Instead, we're always sending
                     # everything twice to lazy subscribers.
                     channelsTriggeredForPriors.add(channel)
                 channelsTriggered.add(channel)

--- a/object_database/service_manager/Codebase.py
+++ b/object_database/service_manager/Codebase.py
@@ -42,9 +42,9 @@ def setCodebaseInstantiationDirectory(directory, forceReset=False):
         if _codebase_instantiation_dir == directory:
             return
 
-        assert _codebase_instantiation_dir is None, "Can't modify the codebase instantiation location. (%s != %s)" % (
-            _codebase_instantiation_dir,
-            directory
+        assert _codebase_instantiation_dir is None, (
+            "Can't modify the codebase instantiation location. (%s != %s)"
+            % (_codebase_instantiation_dir, directory)
         )
 
         _codebase_instantiation_dir = os.path.abspath(directory)
@@ -76,9 +76,7 @@ class Codebase:
 
     @staticmethod
     def createFromRootlevelPath(rootPath):
-        return Codebase.createFromCodebase(
-            TypedPythonCodebase.FromRootlevelPath(rootPath)
-        )
+        return Codebase.createFromCodebase(TypedPythonCodebase.FromRootlevelPath(rootPath))
 
     @staticmethod
     def createFromCodebase(codebase: TypedPythonCodebase):
@@ -111,18 +109,22 @@ class Codebase:
                         os.makedirs(codebase_dir_override)
                 except Exception as e:
                     logging.getLogger(__name__).warn(
-                        "Exception trying to make directory '%s'", codebase_dir_override)
-                    logging.getLogger(__name__).warn(
-                        "Exception: %s", e)
+                        "Exception trying to make directory '%s'", codebase_dir_override
+                    )
+                    logging.getLogger(__name__).warn("Exception: %s", e)
 
                 disk_path = os.path.join(codebase_dir_override, self.hash)
 
                 # preload the files, since they're lazy.
-                object_database.current_transaction().db().requestLazyObjects(set(self.files.values()))
+                object_database.current_transaction().db().requestLazyObjects(
+                    set(self.files.values())
+                )
 
                 fileContents = {fpath: file.contents for fpath, file in self.files.items()}
 
-                _codebase_cache[self.hash] = TypedPythonCodebase.Instantiate(fileContents, disk_path)
+                _codebase_cache[self.hash] = TypedPythonCodebase.Instantiate(
+                    fileContents, disk_path
+                )
 
             if module_name is None:
                 return _codebase_cache[self.hash]

--- a/object_database/service_manager/InProcessServiceManager.py
+++ b/object_database/service_manager/InProcessServiceManager.py
@@ -29,7 +29,11 @@ class InProcessServiceManager(ServiceManager):
         setCodebaseInstantiationDirectory(self.sourceRoot.name)
 
         ServiceManager.__init__(
-            self, dbConnectionFactory, self.sourceRoot.name, isMaster=True, ownHostname="localhost"
+            self,
+            dbConnectionFactory,
+            self.sourceRoot.name,
+            isMaster=True,
+            ownHostname="localhost",
         )
 
         self.serviceWorkers = {}
@@ -44,10 +48,12 @@ class InProcessServiceManager(ServiceManager):
             instanceIdentity,
             os.path.join(self.storageRoot.name, str(instanceIdentity)),
             self.auth_token,
-            '127.0.0.1'
+            "127.0.0.1",
         )
 
-        self.serviceWorkers[instanceIdentity] = self.serviceWorkers.get(service, ()) + (worker,)
+        self.serviceWorkers[instanceIdentity] = self.serviceWorkers.get(service, ()) + (
+            worker,
+        )
 
         worker.start()
 

--- a/object_database/service_manager/ServiceBase.py
+++ b/object_database/service_manager/ServiceBase.py
@@ -17,7 +17,14 @@ import object_database
 
 
 class ServiceRuntimeConfig:
-    def __init__(self, dbConnectionFactory, serviceTemporaryStorageRoot, authToken, ownIpAddress, serviceInstance):
+    def __init__(
+        self,
+        dbConnectionFactory,
+        serviceTemporaryStorageRoot,
+        authToken,
+        ownIpAddress,
+        serviceInstance,
+    ):
         self.dbConnectionFactory = dbConnectionFactory
         self.serviceTemporaryStorageRoot = serviceTemporaryStorageRoot
         self.authToken = authToken
@@ -53,7 +60,9 @@ class ServiceBase:
 
     @staticmethod
     def serviceDisplay(serviceObject, instance=None, objType=None, queryArgs=None):
-        return object_database.web.cells.Card("No details provided for service '%s'" % serviceObject.name)
+        return object_database.web.cells.Card(
+            "No details provided for service '%s'" % serviceObject.name
+        )
 
     @staticmethod
     def serviceHeaderToggles(serviceObject, instance=None):

--- a/object_database/service_manager/ServiceBase.py
+++ b/object_database/service_manager/ServiceBase.py
@@ -48,7 +48,9 @@ class ServiceBase:
 
     @staticmethod
     def configureFromCommandline(db, serviceObject, args):
-        """Subclasses should take the remaining args from the commandline and configure using them"""
+        """Subclasses should take the remaining args from the commandline
+        and configure using them
+        """
         pass
 
     def initialize(self):

--- a/object_database/service_manager/ServiceInstance.py
+++ b/object_database/service_manager/ServiceInstance.py
@@ -51,7 +51,9 @@ class CodebaseLockedException(Exception):
 class Service:
     name = Indexed(str)
     _codebase = OneOf(None, service_schema.Codebase)
-    _codebaseStatus = OneOf("PREPARED", "LOCKED", "UNLOCKED")  # protects _codebase from modification
+    _codebaseStatus = OneOf(
+        "PREPARED", "LOCKED", "UNLOCKED"
+    )  # protects _codebase from modification
 
     service_module_name = str
     service_class_name = str
@@ -114,12 +116,15 @@ class Service:
             self.deploy()
 
     def setCodebase(self, codebase, moduleName=None, className=None):
-        if (codebase != self.codebase or
-                (moduleName is not None and moduleName != self.service_module_name) or
-                (className is not None and className != self.service_class_name)):
+        if (
+            codebase != self.codebase
+            or (moduleName is not None and moduleName != self.service_module_name)
+            or (className is not None and className != self.service_class_name)
+        ):
             if self.isLocked:
                 raise CodebaseLockedException(
-                    "Cannot set codebase of locked service '{}'".format(self.name))
+                    "Cannot set codebase of locked service '{}'".format(self.name)
+                )
 
             self._setCodebase(codebase)
 
@@ -143,7 +148,9 @@ class Service:
 
     def getSerializationContext(self):
         if self.codebase is None:
-            return TypedPythonCodebase.FromRootlevelModule(object_database).serializationContext
+            return TypedPythonCodebase.FromRootlevelModule(
+                object_database
+            ).serializationContext
         else:
             return self.codebase.instantiate().serializationContext
 
@@ -176,6 +183,7 @@ class Service:
 
             return module.__dict__[typename]
         else:
+
             def _getobject(modname, attribute):
                 mod = __import__(modname, fromlist=[attribute])
                 return mod.__dict__[attribute]
@@ -186,8 +194,12 @@ class Service:
         return "/services/%s/%s/%s" % (
             self.name,
             type(obj).__schema__.name + "." + type(obj).__qualname__,
-            obj._identity
-        ) + ("" if not queryParams else "?" + urllib.parse.urlencode({k: str(v) for k, v in queryParams.items()}))
+            obj._identity,
+        ) + (
+            ""
+            if not queryParams
+            else "?" + urllib.parse.urlencode({k: str(v) for k, v in queryParams.items()})
+        )
 
     def findModuleSchemas(self):
         """Find all Schema objects in the same module as our type object."""
@@ -211,23 +223,24 @@ class Service:
             module = self.codebase.instantiate(self.service_module_name)
 
             if self.service_class_name not in module.__dict__:
-                raise Exception("Provided module %s at %s has no class %s. Options are:\n%s" % (
-                    self.service_module_name,
-                    module.__file__,
-                    self.service_class_name,
-                    "\n".join(["  " + x for x in sorted(module.__dict__)])
-                ))
+                raise Exception(
+                    "Provided module %s at %s has no class %s. Options are:\n%s"
+                    % (
+                        self.service_module_name,
+                        module.__file__,
+                        self.service_class_name,
+                        "\n".join(["  " + x for x in sorted(module.__dict__)]),
+                    )
+                )
 
             service_type = module.__dict__[self.service_class_name]
         else:
+
             def _getobject(modname, attribute):
                 mod = __import__(modname, fromlist=[attribute])
                 return mod.__dict__[attribute]
 
-            service_type = _getobject(
-                self.service_module_name,
-                self.service_class_name
-            )
+            service_type = _getobject(self.service_module_name, self.service_class_name)
 
         return service_type
 
@@ -265,9 +278,8 @@ class ServiceInstance:
         )
 
     def isNotActive(self):
-        return (
-            self.state in ("Stopped", "FailedToStart", "Crashed")
-            or (self.connection and not self.connection.exists())
+        return self.state in ("Stopped", "FailedToStart", "Crashed") or (
+            self.connection and not self.connection.exists()
         )
 
     def isActive(self):
@@ -278,8 +290,9 @@ class ServiceInstance:
             and (self.connection is None or self.connection.exists())
         )
 
-    state = Indexed(OneOf("Booting", "Initializing", "Running",
-                          "Stopped", "FailedToStart", "Crashed"))
+    state = Indexed(
+        OneOf("Booting", "Initializing", "Running", "Stopped", "FailedToStart", "Crashed")
+    )
 
     boot_timestamp = OneOf(None, float)
     start_timestamp = OneOf(None, float)

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -308,7 +308,8 @@ class ServiceManager(object):
 
             if needRedeploy:
                 self._logger.info(
-                    "The following services need to be stopped because their codebases are out of date: %s",
+                    "The following services need to be stopped "
+                    "because their codebases are out of date: %s",
                     "\n".join(
                         [
                             "  "

--- a/object_database/service_manager/ServiceManagerTestCommon.py
+++ b/object_database/service_manager/ServiceManagerTestCommon.py
@@ -22,20 +22,18 @@ import object_database
 from object_database.util import genToken
 from object_database.service_manager.ServiceManager import ServiceManager
 
-from object_database import (
-    core_schema, connect, service_schema,
-)
+from object_database import core_schema, connect, service_schema
 from object_database.frontends import service_manager
 
 ownDir = os.path.dirname(os.path.abspath(__file__))
 
 VERBOSE = True
 # Turn VERBOSE off on TravisCI because subprocess.PIPE seems to lock things up
-VERBOSE = False if os.environ.get('TRAVIS_CI', None) else VERBOSE
+VERBOSE = False if os.environ.get("TRAVIS_CI", None) else VERBOSE
 
 
 class ServiceManagerTestCommon(object):
-    ENVIRONMENT_WAIT_MULTIPLIER = 5 if os.environ.get('TRAVIS_CI', None) is not None else 1
+    ENVIRONMENT_WAIT_MULTIPLIER = 5 if os.environ.get("TRAVIS_CI", None) is not None else 1
 
     def schemasToSubscribeTo(self):
         """Subclasses can override to extend the schema set."""
@@ -44,11 +42,9 @@ class ServiceManagerTestCommon(object):
     def waitRunning(self, serviceName):
         self.assertTrue(
             ServiceManager.waitRunning(
-                self.database,
-                serviceName,
-                5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER
+                self.database, serviceName, 5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER
             ),
-            "Service " + serviceName + " never came up."
+            "Service " + serviceName + " never came up.",
         )
 
     def timeElapsed(self):
@@ -64,21 +60,21 @@ class ServiceManagerTestCommon(object):
             self.tempDirectoryName, forceReset=True
         )
 
-        os.makedirs(os.path.join(self.tempDirectoryName, 'source'))
-        os.makedirs(os.path.join(self.tempDirectoryName, 'storage'))
-        os.makedirs(os.path.join(self.tempDirectoryName, 'logs'))
+        os.makedirs(os.path.join(self.tempDirectoryName, "source"))
+        os.makedirs(os.path.join(self.tempDirectoryName, "storage"))
+        os.makedirs(os.path.join(self.tempDirectoryName, "logs"))
 
-        self.logDir = os.path.join(self.tempDirectoryName, 'logs')
+        self.logDir = os.path.join(self.tempDirectoryName, "logs")
 
-        logLevelName = logging.getLevelName(
-            logging.getLogger(__name__).getEffectiveLevel()
-        )
+        logLevelName = logging.getLevelName(logging.getLogger(__name__).getEffectiveLevel())
 
         self.server = service_manager.startServiceManagerProcess(
-            self.tempDirectoryName, 8023, self.token,
+            self.tempDirectoryName,
+            8023,
+            self.token,
             loglevelName=logLevelName,
-            sslPath=os.path.join(ownDir, '..', '..', 'testcert.cert'),
-            verbose=VERBOSE
+            sslPath=os.path.join(ownDir, "..", "..", "testcert.cert"),
+            verbose=VERBOSE,
         )
 
         try:
@@ -108,8 +104,6 @@ class ServiceManagerTestCommon(object):
             try:
                 self.server.wait(timeout=5.0)
             except subprocess.TimeoutExpired:
-                self.logger.error(
-                    f"Failed to kill service manager process."
-                )
+                self.logger.error(f"Failed to kill service manager process.")
 
         self.tempDirObj.cleanup()

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -210,7 +210,8 @@ class TextEditorService(ServiceBase):
                 if ed.getContents() != TextEditor.lookupAny().code:
                     ed.setContents(TextEditor.lookupAny().code)
 
-        # return Columns(ed, Card(Plot(makePlotData).height("100%").width("100%"))) + Subscribed(onCodeChange)
+        # return Columns(ed, Card(Plot(makePlotData).height("100%").width("100%")))
+        #        + Subscribed(onCodeChange)
         return SplitView([(ed, 1), (Card(Plot(makePlotData)), 1)]) + Subscribed(onCodeChange)
 
 
@@ -557,7 +558,13 @@ def getTestServiceModule(version):
         "test_service/__init__.py": "",
         "test_service/service.py": textwrap.dedent(
             """
-            from object_database import Schema, ServiceBase, Indexed, core_schema, service_schema
+            from object_database import (
+                Schema,
+                ServiceBase,
+                Indexed,
+                core_schema,
+                service_schema,
+            )
             import os
             import time
             import logging
@@ -577,7 +584,9 @@ def getTestServiceModule(version):
                     self.db.subscribeToSchema(core_schema, service_schema, schema)
 
                     with self.db.transaction():
-                        self.conn = MockServiceLastTimestamp(connection=self.db.connectionObject)
+                        self.conn = MockServiceLastTimestamp(
+                            connection=self.db.connectionObject
+                        )
                         self.conn.version = {version}
 
                 def doWork(self, shouldStop):
@@ -727,7 +736,8 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
 
         self.waitForCount(0)
 
-        # make sure we don't have a bunch of zombie processes hanging underneath the service manager
+        # make sure we don't have a bunch of zombie processes
+        # hanging underneath the service manager
         time.sleep(1.0)
         self.assertEqual(len(psutil.Process().children()[0].children()), 0)
 
@@ -748,7 +758,8 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
 
         self.assertLess(time.time() - t0, 2.0 * self.ENVIRONMENT_WAIT_MULTIPLIER)
 
-        # make sure we don't have a bunch of zombie processes hanging underneath the service manager
+        # make sure we don't have a bunch of zombie processes
+        # hanging underneath the service manager
         time.sleep(1.0)
         self.assertEqual(len(psutil.Process().children()[0].children()), 0)
 
@@ -1057,7 +1068,8 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
         prepare_helper()
         s = deploy_helper(3, 3, s)
 
-        # Trying to update the codebase a second time after preparing for deployment should fail
+        # Trying to update the codebase a second time
+        # after preparing for deployment should fail
         s = deploy_helper(4, 3)
 
         # Trying to update the codebase after unlocking should succeed

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -29,14 +29,36 @@ from object_database.service_manager.ServiceManager import ServiceManager
 from object_database.service_manager.ServiceBase import ServiceBase
 import object_database.service_manager.ServiceInstance as ServiceInstance
 from object_database.web.cells import (
-    Button, SubscribedSequence, Subscribed,
-    Text, Dropdown, Card, Plot, Code, Slot, CodeEditor, Tabs, Grid, Flex,
-    Sheet, ensureSubscribedType, SubscribeAndRetry, Expands, AsyncDropdown, ButtonGroup, Octicon, SplitView
+    Button,
+    SubscribedSequence,
+    Subscribed,
+    Text,
+    Dropdown,
+    Card,
+    Plot,
+    Code,
+    Slot,
+    CodeEditor,
+    Tabs,
+    Grid,
+    Flex,
+    Sheet,
+    ensureSubscribedType,
+    SubscribeAndRetry,
+    Expands,
+    AsyncDropdown,
+    ButtonGroup,
+    Octicon,
+    SplitView,
 )
 
 from object_database import (
-    Schema, Indexed, core_schema, Index,
-    service_schema, current_transaction
+    Schema,
+    Indexed,
+    core_schema,
+    Index,
+    service_schema,
+    current_transaction,
 )
 
 ownDir = os.path.dirname(os.path.abspath(__file__))
@@ -166,7 +188,12 @@ class TextEditorService(ServiceBase):
             if TextEditor.lookupAny() is not None:
                 TextEditor.lookupAny().code = buffer
 
-        ed = CodeEditor(keybindings={'Enter': onEnter}, noScroll=True, minLines=50, onTextChange=onTextChange)
+        ed = CodeEditor(
+            keybindings={"Enter": onEnter},
+            noScroll=True,
+            minLines=50,
+            onTextChange=onTextChange,
+        )
 
         def makePlotData():
             # data must be a list or dict here, but this is checked/asserted
@@ -176,7 +203,7 @@ class TextEditorService(ServiceBase):
                 data = ast.literal_eval(toEval.get())
             except (AttributeError, SyntaxError):
                 data = {}
-            return {'data': data}
+            return {"data": data}
 
         def onCodeChange():
             if TextEditor.lookupAny() is not None:
@@ -184,10 +211,7 @@ class TextEditorService(ServiceBase):
                     ed.setContents(TextEditor.lookupAny().code)
 
         # return Columns(ed, Card(Plot(makePlotData).height("100%").width("100%"))) + Subscribed(onCodeChange)
-        return SplitView([
-            (ed, 1),
-            (Card(Plot(makePlotData)), 1)
-        ]) + Subscribed(onCodeChange)
+        return SplitView([(ed, 1), (Card(Plot(makePlotData)), 1)]) + Subscribed(onCodeChange)
 
 
 class GraphDisplayService(ServiceBase):
@@ -208,7 +232,12 @@ class GraphDisplayService(ServiceBase):
         depth = Slot(50)
 
         def twinned():
-            data = {'PointsToShow': {'timestamp': [1500000000 + x for x in range(1000)], 'y': [numpy.sin(x) for x in range(1000)]}}
+            data = {
+                "PointsToShow": {
+                    "timestamp": [1500000000 + x for x in range(1000)],
+                    "y": [numpy.sin(x) for x in range(1000)],
+                }
+            }
             slot = Slot(None)
             p1 = Plot(lambda: data, xySlot=slot)
             p2 = Plot(lambda: data, xySlot=slot)
@@ -223,61 +252,65 @@ class GraphDisplayService(ServiceBase):
         return Tabs(
             Overlay=Card(
                 Plot(
-                    lambda:
-                        {
-                            'single_array': [1, 2, 3, 1, 2, 3],
-                            'xy': {
-                                'x': [1, 2, 3, 1, 2, 3],
-                                'y': [4, 5, 6, 7, 8, 9]
-                            },
-                        }
-                ).width(600).height(400) + Code("HI")
+                    lambda: {
+                        "single_array": [1, 2, 3, 1, 2, 3],
+                        "xy": {"x": [1, 2, 3, 1, 2, 3], "y": [4, 5, 6, 7, 8, 9]},
+                    }
+                )
+                .width(600)
+                .height(400)
+                + Code("HI")
             ),
             AGrid=Grid(
-                colFun=lambda: ['A', 'B', 'B'],
-                rowFun=lambda: ['1', '2', '2'],
+                colFun=lambda: ["A", "B", "B"],
+                rowFun=lambda: ["1", "2", "2"],
                 headerFun=lambda x: x,
                 rowLabelFun=None,
-                rendererFun=lambda row, col: row+col
+                rendererFun=lambda row, col: row + col,
             ),
             ASheet=Sheet(
                 ["A", "B", "C"],
                 1000000,
-                lambda rowIx: ["(%s) ts" % rowIx, rowIx, rowIx+1, rowIx+2]
-            ).width('calc(100vw - 70px)').height('calc(100vh - 150px)'),
+                lambda rowIx: ["(%s) ts" % rowIx, rowIx, rowIx + 1, rowIx + 2],
+            )
+            .width("calc(100vw - 70px)")
+            .height("calc(100vh - 150px)"),
             Timestamps=(
-                Button("Add a point!", GraphDisplayService.addAPoint) +
-                Card(Plot(GraphDisplayService.chartData)).width(600).height(400)
+                Button("Add a point!", GraphDisplayService.addAPoint)
+                + Card(Plot(GraphDisplayService.chartData)).width(600).height(400)
             ),
             Twinned=Subscribed(twinned),
             feigenbaum=(
                 Dropdown(
                     "Depth",
-                    [(val, depth.setter(val)) for val in [10, 50, 100, 250, 500, 750, 1000]]
-                ) +
-                Dropdown(
+                    [(val, depth.setter(val)) for val in [10, 50, 100, 250, 500, 750, 1000]],
+                )
+                + Dropdown(
                     "Polynomial",
                     [1.0, 1.5, 2.0],
-                    lambda polyVal: setattr(Feigenbaum.lookupAny(), 'y', float(polyVal))
-                ) +
-                Dropdown(
+                    lambda polyVal: setattr(Feigenbaum.lookupAny(), "y", float(polyVal)),
+                )
+                + Dropdown(
                     "Density",
                     list(range(100, 10000, 100)),
-                    lambda polyVal: setattr(Feigenbaum.lookupAny(), 'density', float(polyVal))
-                ) +
-                Card(
-                    Plot(
-                        lambda graph: GraphDisplayService.feigenbaum(graph, depth.get())
-                    )
-                ).width(600).height(400)
-            )
+                    lambda polyVal: setattr(Feigenbaum.lookupAny(), "density", float(polyVal)),
+                )
+                + Card(Plot(lambda graph: GraphDisplayService.feigenbaum(graph, depth.get())))
+                .width(600)
+                .height(400)
+            ),
         )
 
     @staticmethod
     def chartData(linePlot):
         points = sorted(PointsToShow.lookupAll(), key=lambda p: p.timestamp)
 
-        return {'PointsToShow': {'timestamp': [p.timestamp for p in points], 'y': [p.y for p in points]}}
+        return {
+            "PointsToShow": {
+                "timestamp": [p.timestamp for p in points],
+                "y": [p.y for p in points],
+            }
+        }
 
     @staticmethod
     def feigenbaum(linePlot, depth):
@@ -295,21 +328,29 @@ class GraphDisplayService(ServiceBase):
         y = Feigenbaum.lookupAny().y
 
         def feigenbaum(values):
-            x = numpy.ones(len(values)) * .5
+            x = numpy.ones(len(values)) * 0.5
             for _ in range(10000):
-                x = (values * x * (1-x)) ** ((y) ** .5)
+                x = (values * x * (1 - x)) ** ((y) ** 0.5)
 
             its = []
             for _ in range(depth):
-                x = (values * x * (1-x)) ** ((y) ** .5)
+                x = (values * x * (1 - x)) ** ((y) ** 0.5)
                 its.append(x)
 
             return numpy.concatenate(its)
 
         fvals = feigenbaum(values)
 
-        return {"feigenbaum": {'x': numpy.concatenate([values]*(len(fvals)//len(values))), 'y': fvals, 'type': 'scattergl',
-                'mode': 'markers', 'opacity': .5, 'marker': {'size': 2}}}
+        return {
+            "feigenbaum": {
+                "x": numpy.concatenate([values] * (len(fvals) // len(values))),
+                "y": fvals,
+                "type": "scattergl",
+                "mode": "markers",
+                "opacity": 0.5,
+                "marker": {"size": 2},
+            }
+        }
 
 
 class DropdownTestService(ServiceBase):
@@ -319,13 +360,13 @@ class DropdownTestService(ServiceBase):
     @staticmethod
     def serviceDisplay(serviceObject, instance=None, objType=None, queryArgs=None):
         return Card(
-            AsyncDropdown('Dropdown', DropdownTestService.delayAndDisplay, Text("LOADING..."))
+            AsyncDropdown("Dropdown", DropdownTestService.delayAndDisplay, Text("LOADING..."))
         )
 
     @staticmethod
     def delayAndDisplay():
         time.sleep(1)
-        return Text('NOW WE HAVE LOADED')
+        return Text("NOW WE HAVE LOADED")
 
 
 bigGrid = Schema("core.test.biggrid")
@@ -335,7 +376,7 @@ bigGrid = Schema("core.test.biggrid")
 class GridValue:
     row = int
     col = int
-    row_and_col = Index('row', 'col')
+    row_and_col = Index("row", "col")
 
     value = int
 
@@ -355,7 +396,9 @@ class BigGridTestService(ServiceBase):
             rowFun=lambda: list(range(ROW_COUNT)),
             headerFun=lambda x: x,
             rowLabelFun=None,
-            rendererFun=lambda row, col: Subscribed(lambda: GridValue.lookupAny(row_and_col=(row, col)).value)
+            rendererFun=lambda row, col: Subscribed(
+                lambda: GridValue.lookupAny(row_and_col=(row, col)).value
+            ),
         )
 
     def doWork(self, shouldStop):
@@ -371,7 +414,9 @@ class BigGridTestService(ServiceBase):
             #  print("WRITNG ", passIx)
             passIx += 1
             time.sleep(GRID_INTERVAL)
-            rows_and_cols = [(row, col) for row in range(ROW_COUNT) for col in range(COL_COUNT)]
+            rows_and_cols = [
+                (row, col) for row in range(ROW_COUNT) for col in range(COL_COUNT)
+            ]
             numpy.random.shuffle(rows_and_cols)
 
             for row, col in rows_and_cols:
@@ -403,28 +448,35 @@ class HappyService(ServiceBase):
         if instance:
             return instance.display(queryArgs)
 
-        return Card(
-            Subscribed(lambda: Text("There are %s happy objects <this should not have lessthans>" % len(Happy.lookupAll()))) +
-            Expands(Text("Closed"), Subscribed(lambda: HappyService.serviceDisplay(serviceObject)))
-        ) + Button("go to google", "http://google.com/") + Flex(SubscribedSequence(
-            lambda: Happy.lookupAll(),
-            lambda h: Button("go to the happy", serviceObject.urlForObject(h, x=10))
-        )) + Subscribed(
-            lambda:
-                ButtonGroup([
-                    Button(
-                        Octicon("list-unordered"),
-                        lambda: None,
-                        active=lambda: True),
-                    Button(
-                        Octicon("terminal"),
-                        lambda: None,
-                        active=lambda: True),
-                    Button(
-                        Octicon("graph"),
-                        lambda: None,
-                        active=lambda: True)
-                ]).nowrap()
+        return (
+            Card(
+                Subscribed(
+                    lambda: Text(
+                        "There are %s happy objects <this should not have lessthans>"
+                        % len(Happy.lookupAll())
+                    )
+                )
+                + Expands(
+                    Text("Closed"),
+                    Subscribed(lambda: HappyService.serviceDisplay(serviceObject)),
+                )
+            )
+            + Button("go to google", "http://google.com/")
+            + Flex(
+                SubscribedSequence(
+                    lambda: Happy.lookupAll(),
+                    lambda h: Button("go to the happy", serviceObject.urlForObject(h, x=10)),
+                )
+            )
+            + Subscribed(
+                lambda: ButtonGroup(
+                    [
+                        Button(Octicon("list-unordered"), lambda: None, active=lambda: True),
+                        Button(Octicon("terminal"), lambda: None, active=lambda: True),
+                        Button(Octicon("graph"), lambda: None, active=lambda: True),
+                    ]
+                ).nowrap()
+            )
         )
 
     def doWork(self, shouldStop):
@@ -435,10 +487,10 @@ class HappyService(ServiceBase):
             h = Happy(i=2)
 
         while not shouldStop.is_set():
-            time.sleep(.5)
+            time.sleep(0.5)
             with self.db.transaction():
                 h = Happy()
-            time.sleep(.5)
+            time.sleep(0.5)
             with self.db.transaction():
 
                 h.delete()
@@ -446,7 +498,9 @@ class HappyService(ServiceBase):
 
 class StorageTest(ServiceBase):
     def initialize(self):
-        with open(os.path.join(self.runtimeConfig.serviceTemporaryStorageRoot, "a.txt"), "w") as f:
+        with open(
+            os.path.join(self.runtimeConfig.serviceTemporaryStorageRoot, "a.txt"), "w"
+        ) as f:
             f.write("This exists")
 
         self.db.subscribeToSchema(core_schema, service_schema, schema)
@@ -464,7 +518,7 @@ class CrashingService(ServiceBase):
         assert False
 
     def doWork(self, shouldStop):
-        time.sleep(.5)
+        time.sleep(0.5)
         assert False
 
 
@@ -491,7 +545,7 @@ class WaitForService(ServiceBase):
 
     def doWork(self, shouldStop):
         while not shouldStop.is_set():
-            time.sleep(.5)
+            time.sleep(0.5)
 
         with self.db.transaction():
             assert Stopped.lookupAny() is None
@@ -500,8 +554,9 @@ class WaitForService(ServiceBase):
 
 def getTestServiceModule(version):
     return {
-        'test_service/__init__.py': '',
-        'test_service/service.py': textwrap.dedent("""
+        "test_service/__init__.py": "",
+        "test_service/service.py": textwrap.dedent(
+            """
             from object_database import Schema, ServiceBase, Indexed, core_schema, service_schema
             import os
             import time
@@ -537,7 +592,10 @@ def getTestServiceModule(version):
                                 os._exit(1)
 
                             self.conn.lastPing = time.time()
-            """.format(version=version))
+            """.format(
+                version=version
+            )
+        ),
     }
 
 
@@ -554,7 +612,7 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
         self.assertTrue(
             self.database.waitForCondition(
                 lambda: MockServiceLastTimestamp.aliveCount() == count,
-                timeout=timeout * self.ENVIRONMENT_WAIT_MULTIPLIER
+                timeout=timeout * self.ENVIRONMENT_WAIT_MULTIPLIER,
             )
         )
 
@@ -585,12 +643,14 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
 
     def test_starting_uninitializable_services(self):
         with self.database.transaction():
-            svc = ServiceManager.createOrUpdateService(UninitializableService, "UninitializableService", target_count=1)
+            svc = ServiceManager.createOrUpdateService(
+                UninitializableService, "UninitializableService", target_count=1
+            )
 
         self.assertTrue(
             self.database.waitForCondition(
                 lambda: svc.timesBootedUnsuccessfully == ServiceInstance.MAX_BAD_BOOTS,
-                timeout=10 * self.ENVIRONMENT_WAIT_MULTIPLIER
+                timeout=10 * self.ENVIRONMENT_WAIT_MULTIPLIER,
             )
         )
 
@@ -606,7 +666,7 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
         self.assertTrue(
             self.database.waitForCondition(
                 lambda: svc.timesBootedUnsuccessfully == ServiceInstance.MAX_BAD_BOOTS,
-                timeout=10 * self.ENVIRONMENT_WAIT_MULTIPLIER
+                timeout=10 * self.ENVIRONMENT_WAIT_MULTIPLIER,
             )
         )
 
@@ -654,7 +714,8 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
 
         for count in numpy.random.choice(6, size=20):
             logging.getLogger(__name__).info(
-                "Setting count for MockService to %s and waiting for it to be alive.", count)
+                "Setting count for MockService to %s and waiting for it to be alive.", count
+            )
 
             with self.database.transaction():
                 ServiceManager.startService("MockService", int(count))
@@ -673,9 +734,7 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
     def test_shutdown_hanging_services(self):
         with self.database.transaction():
             ServiceManager.createOrUpdateService(
-                HangingService,
-                "HangingService",
-                target_count=10
+                HangingService, "HangingService", target_count=10
             )
 
         self.waitForCount(10)
@@ -695,27 +754,35 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
 
     def test_conflicting_codebases(self):
         with self.database.transaction():
-            v1 = service_schema.Codebase.createFromFiles({
-                'test_service/__init__.py': '',
-                'test_service/helper/__init__.py': 'g = 1',
-                'test_service/service.py': textwrap.dedent("""
+            v1 = service_schema.Codebase.createFromFiles(
+                {
+                    "test_service/__init__.py": "",
+                    "test_service/helper/__init__.py": "g = 1",
+                    "test_service/service.py": textwrap.dedent(
+                        """
                     import test_service.helper as helper
                     def f():
                         assert helper.g == 1
                         return 1
-                """)
-            })
+                """
+                    ),
+                }
+            )
 
-            v2 = service_schema.Codebase.createFromFiles({
-                'test_service/__init__.py': '',
-                'test_service/helper/__init__.py': 'g = 2',
-                'test_service/service.py': textwrap.dedent("""
+            v2 = service_schema.Codebase.createFromFiles(
+                {
+                    "test_service/__init__.py": "",
+                    "test_service/helper/__init__.py": "g = 2",
+                    "test_service/service.py": textwrap.dedent(
+                        """
                     import test_service.helper as helper
                     def f():
                         assert helper.g == 2
                         return 2
-                """)
-            })
+                """
+                    ),
+                }
+            )
 
             i1 = v1.instantiate("test_service.service")
             i2 = v2.instantiate("test_service.service")
@@ -733,7 +800,9 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
     @flaky(max_runs=3, min_passes=1)
     def test_redeploy_hanging_services(self):
         with self.database.transaction():
-            ServiceManager.createOrUpdateService(HangingService, "HangingService", target_count=10)
+            ServiceManager.createOrUpdateService(
+                HangingService, "HangingService", target_count=10
+            )
 
         self.waitForCount(10)
 
@@ -748,16 +817,20 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
                 service_schema.Codebase.createFromFiles(getTestServiceModule(2)),
                 "test_service.service.Service",
                 "HangingService",
-                10
+                10,
             )
 
         # this should force a redeploy.
         maxProcessesEver = [0]
 
         def checkIfRedeployedSuccessfully():
-            maxProcessesEver[0] = max(maxProcessesEver[0], len(psutil.Process().children()[0].children()))
+            maxProcessesEver[0] = max(
+                maxProcessesEver[0], len(psutil.Process().children()[0].children())
+            )
 
-            if not all(x.codebase is not None for x in service_schema.ServiceInstance.lookupAll()):
+            if not all(
+                x.codebase is not None for x in service_schema.ServiceInstance.lookupAll()
+            ):
                 return False
 
             if len(service_schema.ServiceInstance.lookupAll()) != 10:
@@ -847,8 +920,7 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
             s.triggerSoftKill = True
 
         self.database.waitForCondition(
-            lambda: not s.connection.exists(),
-            timeout=5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER
+            lambda: not s.connection.exists(), timeout=5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER
         )
 
         self.waitForCount(1)
@@ -864,8 +936,7 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
             s.triggerHardKill = True
 
         self.database.waitForCondition(
-            lambda: not s.connection.exists(),
-            timeout=5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER
+            lambda: not s.connection.exists(), timeout=5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER
         )
 
         self.waitForCount(1)
@@ -879,7 +950,8 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
             self.database.waitForCondition(
                 lambda: len(os.listdir(self.logDir)) == 1,
                 timeout=5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER,
-                maxSleepTime=0.001)
+                maxSleepTime=0.001,
+            )
         )
         priorFilename = os.listdir(self.logDir)[0]
 
@@ -890,11 +962,11 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
             self.database.waitForCondition(
                 lambda: len(os.listdir(self.logDir)) == 2,
                 timeout=5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER,
-                maxSleepTime=0.001
+                maxSleepTime=0.001,
             )
         )
 
-        newFilename = [x for x in os.listdir(self.logDir) if x != 'old'][0]
+        newFilename = [x for x in os.listdir(self.logDir) if x != "old"][0]
 
         self.assertNotEqual(priorFilename, newFilename)
 
@@ -913,7 +985,9 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
                 test_service = __import__("test_service.service")
 
                 with self.database.transaction():
-                    ServiceManager.createOrUpdateService(test_service.service.Service, "MockService", target_count=1)
+                    ServiceManager.createOrUpdateService(
+                        test_service.service.Service, "MockService", target_count=1
+                    )
 
                 self.waitForCount(1)
             finally:
@@ -926,10 +1000,12 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
             with self.database.transaction():
                 try:
                     ServiceManager.createOrUpdateServiceWithCodebase(
-                        service_schema.Codebase.createFromFiles(getTestServiceModule(codebase_version)),
+                        service_schema.Codebase.createFromFiles(
+                            getTestServiceModule(codebase_version)
+                        ),
                         "test_service.service.Service",
                         serviceName,
-                        targetCount=1
+                        targetCount=1,
                     )
                 except Exception:
                     pass
@@ -938,7 +1014,7 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
                 self.assertTrue(
                     self.database.waitForCondition(
                         lambda: not existing_service.connection.exists(),
-                        timeout=5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER
+                        timeout=5.0 * self.ENVIRONMENT_WAIT_MULTIPLIER,
                     )
                 )
 

--- a/object_database/service_manager/ServiceWorker.py
+++ b/object_database/service_manager/ServiceWorker.py
@@ -25,7 +25,9 @@ import traceback
 
 
 class ServiceWorker:
-    def __init__(self, db, dbConnectionFactory, instance_id, storageRoot, authToken, ownIpAddress):
+    def __init__(
+        self, db, dbConnectionFactory, instance_id, storageRoot, authToken, ownIpAddress
+    ):
         self._logger = logging.getLogger(__name__)
         self.dbConnectionFactory = dbConnectionFactory
         self.db = db
@@ -38,7 +40,9 @@ class ServiceWorker:
 
         self.instance = service_schema.ServiceInstance.fromIdentity(instance_id)
 
-        self.runtimeConfig = ServiceRuntimeConfig(dbConnectionFactory, storageRoot, authToken, ownIpAddress, self.instance)
+        self.runtimeConfig = ServiceRuntimeConfig(
+            dbConnectionFactory, storageRoot, authToken, ownIpAddress, self.instance
+        )
 
         if not os.path.exists(storageRoot):
             os.makedirs(storageRoot)
@@ -71,8 +75,12 @@ class ServiceWorker:
         assert self.db.waitForCondition(lambda: self.instance.exists(), 5.0)
 
         with self.db.transaction():
-            assert self.instance.exists(), "Service Instance object %s doesn't exist" % self.instance._identity
-            assert self.instance.service.exists(), "Service object %s doesn't exist" % self.instance.service._identity
+            assert self.instance.exists(), (
+                "Service Instance object %s doesn't exist" % self.instance._identity
+            )
+            assert self.instance.service.exists(), (
+                "Service object %s doesn't exist" % self.instance.service._identity
+            )
             self.serviceName = self.instance.service.name
             self.instance.connection = self.db.connectionObject
             self.instance.codebase = self.instance.service.codebase
@@ -82,14 +90,22 @@ class ServiceWorker:
             try:
                 self.serviceObject = self._instantiateServiceObject()
             except Exception:
-                self._logger.error('Service thread for %s failed:\n%s', self.instance._identity, traceback.format_exc())
+                self._logger.error(
+                    "Service thread for %s failed:\n%s",
+                    self.instance._identity,
+                    traceback.format_exc(),
+                )
                 self.instance.markFailedToStart(traceback.format_exc())
                 return
         try:
             self._logger.info("Initializing service object for %s", self.instance._identity)
             self.serviceObject.initialize()
         except Exception:
-            self._logger.error('Service thread for %s failed:\n%s', self.instance._identity, traceback.format_exc())
+            self._logger.error(
+                "Service thread for %s failed:\n%s",
+                self.instance._identity,
+                traceback.format_exc(),
+            )
 
             self.serviceObject = None
 
@@ -113,14 +129,16 @@ class ServiceWorker:
             self.instance.state = "Running"
 
         try:
-            self._logger.info("Starting runloop for service object %s", self.instance._identity)
+            self._logger.info(
+                "Starting runloop for service object %s", self.instance._identity
+            )
             self.serviceObject.doWork(self.shouldStop)
         except Exception:
             self._logger.error(
                 "Service %s/%s failed: %s",
                 self.serviceName,
                 self.instance._identity,
-                traceback.format_exc()
+                traceback.format_exc(),
             )
 
             with self.db.transaction():
@@ -133,7 +151,7 @@ class ServiceWorker:
                 self._logger.info(
                     "Service %s/%s exited gracefully. Setting stopped flag.",
                     self.serviceName,
-                    self.instance._identity
+                    self.instance._identity,
                 )
 
                 self.instance.state = "Stopped"

--- a/object_database/service_manager/SubprocessServiceManager.py
+++ b/object_database/service_manager/SubprocessServiceManager.py
@@ -166,7 +166,8 @@ class SubprocessServiceManager(ServiceManager):
         if gracefully:
             if not self.stopAllServices(self.shutdownTimeout):
                 self._logger.error(
-                    f"Failed to gracefully stop all services within {self.shutdownTimeout} seconds"
+                    "Failed to gracefully stop all services "
+                    f"within {self.shutdownTimeout} seconds"
                 )
 
         ServiceManager.stop(self)
@@ -243,7 +244,8 @@ class SubprocessServiceManager(ServiceManager):
                         if workerProcess:
                             self._logger.warning(
                                 f"Worker Process '{identity}' failed to gracefully terminate"
-                                + f" within {self.shutdownTimeout} seconds. Sending KILL signal."
+                                + f" within {self.shutdownTimeout} seconds."
+                                + " Sending KILL signal."
                             )
                             self._killWorkerProcess(identity, workerProcess)
 
@@ -314,7 +316,8 @@ class SubprocessServiceManager(ServiceManager):
                                 shutil.rmtree(path)
                             except Exception:
                                 self._logger.error(
-                                    "Failed to remove storage at path %s for dead service:\n%s",
+                                    "Failed to remove storage at path %s "
+                                    "for dead service:\n%s",
                                     path,
                                     traceback.format_exc(),
                                 )
@@ -332,7 +335,8 @@ class SubprocessServiceManager(ServiceManager):
                                 shutil.rmtree(path)
                             except Exception:
                                 self._logger.error(
-                                    "Failed to remove source cache at path %s for dead service:\n%s",
+                                    "Failed to remove source cache at path %s "
+                                    "for dead service:\n%s",
                                     path,
                                     traceback.format_exc(),
                                 )

--- a/object_database/service_manager/Task.py
+++ b/object_database/service_manager/Task.py
@@ -36,7 +36,9 @@ class ResourceScope:
 
 
 class TaskContext(object):
-    """Placeholder for information about the current running task environment passed into tasks."""
+    """ Placeholder for information about the current running task environment
+    passed into tasks.
+    """
 
     def __init__(self, db, storageRoot, codebase):
         self.db = db
@@ -51,7 +53,11 @@ class RunningTask(object):
         pass
 
     def execute(self, taskContext, subtaskResults):
-        """Step the task forward. Should return a TaskStatusResult. If we asked for results, they are passed back in subtaskResults"""
+        """Step the task forward.
+
+        Should return a TaskStatusResult.
+        If we asked for results, they are passed back in subtaskResults.
+        """
         raise NotImplementedError()
 
 

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -29,138 +29,141 @@ from object_database.util import closest_N_in
 schema = Schema("core.AwsWorkerBootService")
 
 valid_instance_types = {
-    'm1.small': {'RAM': 1.7, 'CPU': 1, 'COST': 0.044},
-    'm1.medium': {'RAM': 3.75, 'CPU': 1, 'COST': 0.087},
-    'm1.large': {'RAM': 7.5, 'CPU': 2, 'COST': 0.175},
-    'm1.xlarge': {'RAM': 15, 'CPU': 4, 'COST': 0.35},
-    'c1.medium': {'RAM': 1.7, 'CPU': 2, 'COST': 0.13},
-    'c1.xlarge': {'RAM': 7, 'CPU': 8, 'COST': 0.52},
-    'cc2.8xlarge': {'RAM': 60.5, 'CPU': 32, 'COST': 2},
-    'm2.xlarge': {'RAM': 17.1, 'CPU': 2, 'COST': 0.245},
-    'm2.2xlarge': {'RAM': 34.2, 'CPU': 4, 'COST': 0.49},
-    'm2.4xlarge': {'RAM': 68.4, 'CPU': 8, 'COST': 0.98},
-    'hs1.8xlarge': {'RAM': 117, 'CPU': 16, 'COST': 4.6},
-    'm5.large': {'RAM': 8, 'CPU': 2, 'COST': 0.096},
-    'm5.xlarge': {'RAM': 16, 'CPU': 4, 'COST': 0.192},
-    'm5.2xlarge': {'RAM': 32, 'CPU': 8, 'COST': 0.384},
-    'm5.4xlarge': {'RAM': 64, 'CPU': 16, 'COST': 0.768},
-    'm5.12xlarge': {'RAM': 192, 'CPU': 48, 'COST': 2.304},
-    'm5.24xlarge': {'RAM': 384, 'CPU': 96, 'COST': 4.608},
-    'm4.large': {'RAM': 8, 'CPU': 2, 'COST': 0.1},
-    'm4.xlarge': {'RAM': 16, 'CPU': 4, 'COST': 0.2},
-    'm4.2xlarge': {'RAM': 32, 'CPU': 8, 'COST': 0.4},
-    'm4.4xlarge': {'RAM': 64, 'CPU': 16, 'COST': 0.8},
-    'm4.10xlarge': {'RAM': 160, 'CPU': 40, 'COST': 2},
-    'm4.16xlarge': {'RAM': 256, 'CPU': 64, 'COST': 3.2},
-    'c5.large': {'RAM': 4, 'CPU': 2, 'COST': 0.085},
-    'c5.xlarge': {'RAM': 8, 'CPU': 4, 'COST': 0.17},
-    'c5.2xlarge': {'RAM': 16, 'CPU': 8, 'COST': 0.34},
-    'c5.4xlarge': {'RAM': 32, 'CPU': 16, 'COST': 0.68},
-    'c5.9xlarge': {'RAM': 72, 'CPU': 36, 'COST': 1.53},
-    'c5.18xlarge': {'RAM': 144, 'CPU': 72, 'COST': 3.06},
-    'c4.large': {'RAM': 3.75, 'CPU': 2, 'COST': 0.1},
-    'c4.xlarge': {'RAM': 7.5, 'CPU': 4, 'COST': 0.199},
-    'c4.2xlarge': {'RAM': 15, 'CPU': 8, 'COST': 0.398},
-    'c4.4xlarge': {'RAM': 30, 'CPU': 16, 'COST': 0.796},
-    'c4.8xlarge': {'RAM': 60, 'CPU': 36, 'COST': 1.591},
-    'r5.large': {'RAM': 16, 'CPU': 2, 'COST': 0.126},
-    'r5.xlarge': {'RAM': 32, 'CPU': 4, 'COST': 0.252},
-    'r5.2xlarge': {'RAM': 64, 'CPU': 8, 'COST': 0.504},
-    'r5.4xlarge': {'RAM': 128, 'CPU': 16, 'COST': 1.008},
-    'r5.12xlarge': {'RAM': 384, 'CPU': 48, 'COST': 3.024},
-    'r5.24xlarge': {'RAM': 768, 'CPU': 96, 'COST': 6.047},
-    'r4.large': {'RAM': 15.25, 'CPU': 2, 'COST': 0.133},
-    'r4.xlarge': {'RAM': 30.5, 'CPU': 4, 'COST': 0.266},
-    'r4.2xlarge': {'RAM': 61, 'CPU': 8, 'COST': 0.532},
-    'r4.4xlarge': {'RAM': 122, 'CPU': 16, 'COST': 1.064},
-    'r4.8xlarge': {'RAM': 244, 'CPU': 32, 'COST': 2.128},
-    'r4.16xlarge': {'RAM': 488, 'CPU': 64, 'COST': 4.256},
-    'p3.2xlarge': {'RAM': 61, 'CPU': 8, 'COST': 3.06},
-    'p3.8xlarge': {'RAM': 244, 'CPU': 32, 'COST': 12.24},
-    'p3.16xlarge': {'RAM': 488, 'CPU': 64, 'COST': 24.48},
-    'p2.xlarge': {'RAM': 61, 'CPU': 4, 'COST': 0.9},
-    'p2.8xlarge': {'RAM': 488, 'CPU': 32, 'COST': 7.2},
-    'p2.16xlarge': {'RAM': 732, 'CPU': 64, 'COST': 14.4},
-    'g3.4xlarge': {'RAM': 122, 'CPU': 16, 'COST': 1.14},
-    'g3.8xlarge': {'RAM': 244, 'CPU': 32, 'COST': 2.28},
-    'g3.16xlarge': {'RAM': 488, 'CPU': 64, 'COST': 4.56},
-    'h1.2xlarge': {'RAM': 32, 'CPU': 8, 'COST': 0.468},
-    'h1.4xlarge': {'RAM': 64, 'CPU': 16, 'COST': 0.936},
-    'h1.8xlarge': {'RAM': 128, 'CPU': 32, 'COST': 1.872},
-    'h1.16xlarge': {'RAM': 256, 'CPU': 64, 'COST': 3.744},
-    'd2.xlarge': {'RAM': 30.5, 'CPU': 4, 'COST': 0.69},
-    'd2.2xlarge': {'RAM': 61, 'CPU': 8, 'COST': 1.38},
-    'd2.4xlarge': {'RAM': 122, 'CPU': 16, 'COST': 2.76},
-    'd2.8xlarge': {'RAM': 244, 'CPU': 36, 'COST': 5.52},
-    'm3.medium': {'RAM': 3.75, 'CPU': 1, 'COST': 0.067},
-    'm3.large': {'RAM': 7.5, 'CPU': 2, 'COST': 0.133},
-    'm3.xlarge': {'RAM': 15, 'CPU': 4, 'COST': 0.266},
-    'm3.2xlarge': {'RAM': 30, 'CPU': 8, 'COST': 0.532},
-    'c3.large': {'RAM': 3.75, 'CPU': 2, 'COST': 0.105},
-    'c3.xlarge': {'RAM': 7.5, 'CPU': 4, 'COST': 0.21},
-    'c3.2xlarge': {'RAM': 15, 'CPU': 8, 'COST': 0.42},
-    'c3.4xlarge': {'RAM': 30, 'CPU': 16, 'COST': 0.84},
-    'c3.8xlarge': {'RAM': 60, 'CPU': 32, 'COST': 1.68},
-    'g2.2xlarge': {'RAM': 15, 'CPU': 8, 'COST': 0.65},
-    'g2.8xlarge': {'RAM': 60, 'CPU': 32, 'COST': 2.6},
-    'cr1.8xlarge': {'RAM': 244, 'CPU': 32, 'COST': 3.5},
-    'x1.16xlarge': {'RAM': 976, 'CPU': 64, 'COST': 6.669},
-    'x1.32xlarge': {'RAM': 1952, 'CPU': 128, 'COST': 13.338},
-    'x1e.xlarge': {'RAM': 122, 'CPU': 4, 'COST': 0.834},
-    'x1e.2xlarge': {'RAM': 244, 'CPU': 8, 'COST': 1.668},
-    'x1e.4xlarge': {'RAM': 488, 'CPU': 16, 'COST': 3.336},
-    'x1e.8xlarge': {'RAM': 976, 'CPU': 32, 'COST': 6.672},
-    'x1e.16xlarge': {'RAM': 1952, 'CPU': 64, 'COST': 13.344},
-    'x1e.32xlarge': {'RAM': 3904, 'CPU': 128, 'COST': 26.688},
-    'r3.large': {'RAM': 15.25, 'CPU': 2, 'COST': 0.166},
-    'r3.xlarge': {'RAM': 30.5, 'CPU': 4, 'COST': 0.333},
-    'r3.2xlarge': {'RAM': 61, 'CPU': 8, 'COST': 0.665},
-    'r3.4xlarge': {'RAM': 122, 'CPU': 16, 'COST': 1.33},
-    'r3.8xlarge': {'RAM': 244, 'CPU': 32, 'COST': 2.66},
-    'i2.xlarge': {'RAM': 30.5, 'CPU': 4, 'COST': 0.853},
-    'i2.2xlarge': {'RAM': 61, 'CPU': 8, 'COST': 1.705},
-    'i2.4xlarge': {'RAM': 122, 'CPU': 16, 'COST': 3.41},
-    'i2.8xlarge': {'RAM': 244, 'CPU': 32, 'COST': 6.82},
-    'm5d.large': {'RAM': 8, 'CPU': 2, 'COST': 0.113},
-    'm5d.xlarge': {'RAM': 16, 'CPU': 4, 'COST': 0.226},
-    'm5d.2xlarge': {'RAM': 32, 'CPU': 8, 'COST': 0.452},
-    'm5d.4xlarge': {'RAM': 64, 'CPU': 16, 'COST': 0.904},
-    'm5d.12xlarge': {'RAM': 192, 'CPU': 48, 'COST': 2.712},
-    'm5d.24xlarge': {'RAM': 384, 'CPU': 96, 'COST': 5.424},
-    'c5d.large': {'RAM': 4, 'CPU': 2, 'COST': 0.096},
-    'c5d.xlarge': {'RAM': 8, 'CPU': 4, 'COST': 0.192},
-    'c5d.2xlarge': {'RAM': 16, 'CPU': 8, 'COST': 0.384},
-    'c5d.4xlarge': {'RAM': 32, 'CPU': 16, 'COST': 0.768},
-    'c5d.9xlarge': {'RAM': 72, 'CPU': 36, 'COST': 1.728},
-    'c5d.18xlarge': {'RAM': 144, 'CPU': 72, 'COST': 3.456},
-    'r5d.large': {'RAM': 16, 'CPU': 2, 'COST': 0.144},
-    'r5d.xlarge': {'RAM': 32, 'CPU': 4, 'COST': 0.288},
-    'r5d.2xlarge': {'RAM': 64, 'CPU': 8, 'COST': 0.576},
-    'r5d.4xlarge': {'RAM': 128, 'CPU': 16, 'COST': 1.152},
-    'r5d.12xlarge': {'RAM': 384, 'CPU': 48, 'COST': 3.456},
-    'r5d.24xlarge': {'RAM': 768, 'CPU': 96, 'COST': 6.912},
-    'z1d.large': {'RAM': 16, 'CPU': 2, 'COST': 0.186},
-    'z1d.xlarge': {'RAM': 32, 'CPU': 4, 'COST': 0.372},
-    'z1d.2xlarge': {'RAM': 64, 'CPU': 8, 'COST': 0.744},
-    'z1d.3xlarge': {'RAM': 96, 'CPU': 12, 'COST': 1.116},
-    'z1d.6xlarge': {'RAM': 192, 'CPU': 24, 'COST': 2.232},
-    'z1d.12xlarge': {'RAM': 384, 'CPU': 48, 'COST': 4.464},
-    'f1.2xlarge': {'RAM': 122, 'CPU': 8, 'COST': 1.65},
-    'f1.16xlarge': {'RAM': 976, 'CPU': 64, 'COST': 13.2},
-    'i3.large': {'RAM': 15.25, 'CPU': 2, 'COST': 0.156},
-    'i3.xlarge': {'RAM': 30.5, 'CPU': 4, 'COST': 0.312},
-    'i3.2xlarge': {'RAM': 61, 'CPU': 8, 'COST': 0.624},
-    'i3.4xlarge': {'RAM': 122, 'CPU': 16, 'COST': 1.248},
-    'i3.8xlarge': {'RAM': 244, 'CPU': 32, 'COST': 2.496},
-    'i3.16xlarge': {'RAM': 488, 'CPU': 64, 'COST': 4.992}
+    "m1.small": {"RAM": 1.7, "CPU": 1, "COST": 0.044},
+    "m1.medium": {"RAM": 3.75, "CPU": 1, "COST": 0.087},
+    "m1.large": {"RAM": 7.5, "CPU": 2, "COST": 0.175},
+    "m1.xlarge": {"RAM": 15, "CPU": 4, "COST": 0.35},
+    "c1.medium": {"RAM": 1.7, "CPU": 2, "COST": 0.13},
+    "c1.xlarge": {"RAM": 7, "CPU": 8, "COST": 0.52},
+    "cc2.8xlarge": {"RAM": 60.5, "CPU": 32, "COST": 2},
+    "m2.xlarge": {"RAM": 17.1, "CPU": 2, "COST": 0.245},
+    "m2.2xlarge": {"RAM": 34.2, "CPU": 4, "COST": 0.49},
+    "m2.4xlarge": {"RAM": 68.4, "CPU": 8, "COST": 0.98},
+    "hs1.8xlarge": {"RAM": 117, "CPU": 16, "COST": 4.6},
+    "m5.large": {"RAM": 8, "CPU": 2, "COST": 0.096},
+    "m5.xlarge": {"RAM": 16, "CPU": 4, "COST": 0.192},
+    "m5.2xlarge": {"RAM": 32, "CPU": 8, "COST": 0.384},
+    "m5.4xlarge": {"RAM": 64, "CPU": 16, "COST": 0.768},
+    "m5.12xlarge": {"RAM": 192, "CPU": 48, "COST": 2.304},
+    "m5.24xlarge": {"RAM": 384, "CPU": 96, "COST": 4.608},
+    "m4.large": {"RAM": 8, "CPU": 2, "COST": 0.1},
+    "m4.xlarge": {"RAM": 16, "CPU": 4, "COST": 0.2},
+    "m4.2xlarge": {"RAM": 32, "CPU": 8, "COST": 0.4},
+    "m4.4xlarge": {"RAM": 64, "CPU": 16, "COST": 0.8},
+    "m4.10xlarge": {"RAM": 160, "CPU": 40, "COST": 2},
+    "m4.16xlarge": {"RAM": 256, "CPU": 64, "COST": 3.2},
+    "c5.large": {"RAM": 4, "CPU": 2, "COST": 0.085},
+    "c5.xlarge": {"RAM": 8, "CPU": 4, "COST": 0.17},
+    "c5.2xlarge": {"RAM": 16, "CPU": 8, "COST": 0.34},
+    "c5.4xlarge": {"RAM": 32, "CPU": 16, "COST": 0.68},
+    "c5.9xlarge": {"RAM": 72, "CPU": 36, "COST": 1.53},
+    "c5.18xlarge": {"RAM": 144, "CPU": 72, "COST": 3.06},
+    "c4.large": {"RAM": 3.75, "CPU": 2, "COST": 0.1},
+    "c4.xlarge": {"RAM": 7.5, "CPU": 4, "COST": 0.199},
+    "c4.2xlarge": {"RAM": 15, "CPU": 8, "COST": 0.398},
+    "c4.4xlarge": {"RAM": 30, "CPU": 16, "COST": 0.796},
+    "c4.8xlarge": {"RAM": 60, "CPU": 36, "COST": 1.591},
+    "r5.large": {"RAM": 16, "CPU": 2, "COST": 0.126},
+    "r5.xlarge": {"RAM": 32, "CPU": 4, "COST": 0.252},
+    "r5.2xlarge": {"RAM": 64, "CPU": 8, "COST": 0.504},
+    "r5.4xlarge": {"RAM": 128, "CPU": 16, "COST": 1.008},
+    "r5.12xlarge": {"RAM": 384, "CPU": 48, "COST": 3.024},
+    "r5.24xlarge": {"RAM": 768, "CPU": 96, "COST": 6.047},
+    "r4.large": {"RAM": 15.25, "CPU": 2, "COST": 0.133},
+    "r4.xlarge": {"RAM": 30.5, "CPU": 4, "COST": 0.266},
+    "r4.2xlarge": {"RAM": 61, "CPU": 8, "COST": 0.532},
+    "r4.4xlarge": {"RAM": 122, "CPU": 16, "COST": 1.064},
+    "r4.8xlarge": {"RAM": 244, "CPU": 32, "COST": 2.128},
+    "r4.16xlarge": {"RAM": 488, "CPU": 64, "COST": 4.256},
+    "p3.2xlarge": {"RAM": 61, "CPU": 8, "COST": 3.06},
+    "p3.8xlarge": {"RAM": 244, "CPU": 32, "COST": 12.24},
+    "p3.16xlarge": {"RAM": 488, "CPU": 64, "COST": 24.48},
+    "p2.xlarge": {"RAM": 61, "CPU": 4, "COST": 0.9},
+    "p2.8xlarge": {"RAM": 488, "CPU": 32, "COST": 7.2},
+    "p2.16xlarge": {"RAM": 732, "CPU": 64, "COST": 14.4},
+    "g3.4xlarge": {"RAM": 122, "CPU": 16, "COST": 1.14},
+    "g3.8xlarge": {"RAM": 244, "CPU": 32, "COST": 2.28},
+    "g3.16xlarge": {"RAM": 488, "CPU": 64, "COST": 4.56},
+    "h1.2xlarge": {"RAM": 32, "CPU": 8, "COST": 0.468},
+    "h1.4xlarge": {"RAM": 64, "CPU": 16, "COST": 0.936},
+    "h1.8xlarge": {"RAM": 128, "CPU": 32, "COST": 1.872},
+    "h1.16xlarge": {"RAM": 256, "CPU": 64, "COST": 3.744},
+    "d2.xlarge": {"RAM": 30.5, "CPU": 4, "COST": 0.69},
+    "d2.2xlarge": {"RAM": 61, "CPU": 8, "COST": 1.38},
+    "d2.4xlarge": {"RAM": 122, "CPU": 16, "COST": 2.76},
+    "d2.8xlarge": {"RAM": 244, "CPU": 36, "COST": 5.52},
+    "m3.medium": {"RAM": 3.75, "CPU": 1, "COST": 0.067},
+    "m3.large": {"RAM": 7.5, "CPU": 2, "COST": 0.133},
+    "m3.xlarge": {"RAM": 15, "CPU": 4, "COST": 0.266},
+    "m3.2xlarge": {"RAM": 30, "CPU": 8, "COST": 0.532},
+    "c3.large": {"RAM": 3.75, "CPU": 2, "COST": 0.105},
+    "c3.xlarge": {"RAM": 7.5, "CPU": 4, "COST": 0.21},
+    "c3.2xlarge": {"RAM": 15, "CPU": 8, "COST": 0.42},
+    "c3.4xlarge": {"RAM": 30, "CPU": 16, "COST": 0.84},
+    "c3.8xlarge": {"RAM": 60, "CPU": 32, "COST": 1.68},
+    "g2.2xlarge": {"RAM": 15, "CPU": 8, "COST": 0.65},
+    "g2.8xlarge": {"RAM": 60, "CPU": 32, "COST": 2.6},
+    "cr1.8xlarge": {"RAM": 244, "CPU": 32, "COST": 3.5},
+    "x1.16xlarge": {"RAM": 976, "CPU": 64, "COST": 6.669},
+    "x1.32xlarge": {"RAM": 1952, "CPU": 128, "COST": 13.338},
+    "x1e.xlarge": {"RAM": 122, "CPU": 4, "COST": 0.834},
+    "x1e.2xlarge": {"RAM": 244, "CPU": 8, "COST": 1.668},
+    "x1e.4xlarge": {"RAM": 488, "CPU": 16, "COST": 3.336},
+    "x1e.8xlarge": {"RAM": 976, "CPU": 32, "COST": 6.672},
+    "x1e.16xlarge": {"RAM": 1952, "CPU": 64, "COST": 13.344},
+    "x1e.32xlarge": {"RAM": 3904, "CPU": 128, "COST": 26.688},
+    "r3.large": {"RAM": 15.25, "CPU": 2, "COST": 0.166},
+    "r3.xlarge": {"RAM": 30.5, "CPU": 4, "COST": 0.333},
+    "r3.2xlarge": {"RAM": 61, "CPU": 8, "COST": 0.665},
+    "r3.4xlarge": {"RAM": 122, "CPU": 16, "COST": 1.33},
+    "r3.8xlarge": {"RAM": 244, "CPU": 32, "COST": 2.66},
+    "i2.xlarge": {"RAM": 30.5, "CPU": 4, "COST": 0.853},
+    "i2.2xlarge": {"RAM": 61, "CPU": 8, "COST": 1.705},
+    "i2.4xlarge": {"RAM": 122, "CPU": 16, "COST": 3.41},
+    "i2.8xlarge": {"RAM": 244, "CPU": 32, "COST": 6.82},
+    "m5d.large": {"RAM": 8, "CPU": 2, "COST": 0.113},
+    "m5d.xlarge": {"RAM": 16, "CPU": 4, "COST": 0.226},
+    "m5d.2xlarge": {"RAM": 32, "CPU": 8, "COST": 0.452},
+    "m5d.4xlarge": {"RAM": 64, "CPU": 16, "COST": 0.904},
+    "m5d.12xlarge": {"RAM": 192, "CPU": 48, "COST": 2.712},
+    "m5d.24xlarge": {"RAM": 384, "CPU": 96, "COST": 5.424},
+    "c5d.large": {"RAM": 4, "CPU": 2, "COST": 0.096},
+    "c5d.xlarge": {"RAM": 8, "CPU": 4, "COST": 0.192},
+    "c5d.2xlarge": {"RAM": 16, "CPU": 8, "COST": 0.384},
+    "c5d.4xlarge": {"RAM": 32, "CPU": 16, "COST": 0.768},
+    "c5d.9xlarge": {"RAM": 72, "CPU": 36, "COST": 1.728},
+    "c5d.18xlarge": {"RAM": 144, "CPU": 72, "COST": 3.456},
+    "r5d.large": {"RAM": 16, "CPU": 2, "COST": 0.144},
+    "r5d.xlarge": {"RAM": 32, "CPU": 4, "COST": 0.288},
+    "r5d.2xlarge": {"RAM": 64, "CPU": 8, "COST": 0.576},
+    "r5d.4xlarge": {"RAM": 128, "CPU": 16, "COST": 1.152},
+    "r5d.12xlarge": {"RAM": 384, "CPU": 48, "COST": 3.456},
+    "r5d.24xlarge": {"RAM": 768, "CPU": 96, "COST": 6.912},
+    "z1d.large": {"RAM": 16, "CPU": 2, "COST": 0.186},
+    "z1d.xlarge": {"RAM": 32, "CPU": 4, "COST": 0.372},
+    "z1d.2xlarge": {"RAM": 64, "CPU": 8, "COST": 0.744},
+    "z1d.3xlarge": {"RAM": 96, "CPU": 12, "COST": 1.116},
+    "z1d.6xlarge": {"RAM": 192, "CPU": 24, "COST": 2.232},
+    "z1d.12xlarge": {"RAM": 384, "CPU": 48, "COST": 4.464},
+    "f1.2xlarge": {"RAM": 122, "CPU": 8, "COST": 1.65},
+    "f1.16xlarge": {"RAM": 976, "CPU": 64, "COST": 13.2},
+    "i3.large": {"RAM": 15.25, "CPU": 2, "COST": 0.156},
+    "i3.xlarge": {"RAM": 30.5, "CPU": 4, "COST": 0.312},
+    "i3.2xlarge": {"RAM": 61, "CPU": 8, "COST": 0.624},
+    "i3.4xlarge": {"RAM": 122, "CPU": 16, "COST": 1.248},
+    "i3.8xlarge": {"RAM": 244, "CPU": 32, "COST": 2.496},
+    "i3.16xlarge": {"RAM": 488, "CPU": 64, "COST": 4.992},
 }
 
 
-instance_types_to_show = set([
-    x for x in valid_instance_types
-    if ('xlarge' in x and '.xlarge' not in x)
-    and x.split(".")[0] in ['m4', 'm5', 'c4', 'c5', 'r4', 'r5', 'i3', 'g2', 'x1']
-])
+instance_types_to_show = set(
+    [
+        x
+        for x in valid_instance_types
+        if ("xlarge" in x and ".xlarge" not in x)
+        and x.split(".")[0] in ["m4", "m5", "c4", "c5", "r4", "r5", "i3", "g2", "x1"]
+    ]
+)
 
 
 @schema.define
@@ -206,49 +209,54 @@ class AwsApi:
         if not self.config:
             raise Exception("Please configure the aws service.")
 
-        self.ec2 = boto3.resource('ec2', region_name=self.config.region)
-        self.ec2_client = boto3.client('ec2', region_name=self.config.region)
-        self.s3 = boto3.resource('s3', region_name=self.config.region)
-        self.s3_client = boto3.client('s3', region_name=self.config.region)
+        self.ec2 = boto3.resource("ec2", region_name=self.config.region)
+        self.ec2_client = boto3.client("ec2", region_name=self.config.region)
+        self.s3 = boto3.resource("s3", region_name=self.config.region)
+        self.s3_client = boto3.client("s3", region_name=self.config.region)
 
     def allRunningInstances(self, includePending=True, spot=False):
-        filters = [{
-            'Name': 'tag:Name',
-            'Values': [self.config.worker_name]
-        }]
+        filters = [{"Name": "tag:Name", "Values": [self.config.worker_name]}]
 
         res = {}
 
-        for reservations in self.ec2_client.describe_instances(Filters=filters)["Reservations"]:
+        for reservations in self.ec2_client.describe_instances(Filters=filters)[
+            "Reservations"
+        ]:
             for instance in reservations["Instances"]:
-                if instance['State']['Name'] in ('running', 'pending') if includePending else ('running',):
-                    if (not spot and instance.get('InstanceLifecycle') != 'spot' or
-                            spot and instance.get('InstanceLifecycle') == 'spot'):
+                if (
+                    instance["State"]["Name"] in ("running", "pending")
+                    if includePending
+                    else ("running",)
+                ):
+                    if (
+                        not spot
+                        and instance.get("InstanceLifecycle") != "spot"
+                        or spot
+                        and instance.get("InstanceLifecycle") == "spot"
+                    ):
                         res[str(instance["InstanceId"])] = instance
 
         return res
 
     def allSpotRequests(self, allRequests=False):
-        filters = [{
-            'Name': 'tag:Name',
-            'Values': [self.config.worker_name]
-        }]
+        filters = [{"Name": "tag:Name", "Values": [self.config.worker_name]}]
 
         res = {}
 
-        for spot_request in self.ec2_client.describe_spot_instance_requests(Filters=filters)["SpotInstanceRequests"]:
-            if spot_request['State'] in ('open', 'active') or allRequests:
-                res[str(spot_request['SpotInstanceRequestId'])] = spot_request
+        for spot_request in self.ec2_client.describe_spot_instance_requests(Filters=filters)[
+            "SpotInstanceRequests"
+        ]:
+            if spot_request["State"] in ("open", "active") or allRequests:
+                res[str(spot_request["SpotInstanceRequestId"])] = spot_request
 
         return res
 
     def tagSpotRequest(self, instanceId):
         srs = self.allSpotRequests(allRequests=True)
         for srId, srVal in srs.items():
-            if srVal['InstanceId'] == instanceId:
+            if srVal["InstanceId"] == instanceId:
                 self.ec2_client.create_tags(
-                    Resources=[srId],
-                    Tags=[{'Key': 'Name', 'Value': self.config.worker_name}]
+                    Resources=[srId], Tags=[{"Key": "Name", "Value": self.config.worker_name}]
                 )
                 return True
             else:
@@ -259,13 +267,19 @@ class AwsApi:
     def isInstanceWeOwn(self, instance):
         # make sure this instance is definitely one we booted.
 
-        if not [t for t in instance.tags if t["Key"] == "Name" and t["Value"] == self.config.worker_name]:
+        if not [
+            t
+            for t in instance.tags
+            if t["Key"] == "Name" and t["Value"] == self.config.worker_name
+        ]:
             return False
 
         if instance.subnet.id != self.config.subnet:
             return False
 
-        if not [t for t in instance.security_groups if t['GroupId'] == self.config.security_group]:
+        if not [
+            t for t in instance.security_groups if t["GroupId"] == self.config.security_group
+        ]:
             return False
 
         if instance.key_pair.name != self.config.keypair:
@@ -286,17 +300,17 @@ class AwsApi:
         self._logger.info("Requesting spot price history...")
         results = {}
 
-        for x in self.ec2_client.get_paginator('describe_spot_price_history').paginate(
-            Filters=[{'Name': 'product-description', 'Values': ['Linux/UNIX']}],
-            StartTime=datetime.datetime.now() - datetime.timedelta(hours=1)
+        for x in self.ec2_client.get_paginator("describe_spot_price_history").paginate(
+            Filters=[{"Name": "product-description", "Values": ["Linux/UNIX"]}],
+            StartTime=datetime.datetime.now() - datetime.timedelta(hours=1),
         ):
-            for record in x['SpotPriceHistory']:
-                ts = record['Timestamp']
-                instance_type = record['InstanceType']
-                az = record['AvailabilityZone']
+            for record in x["SpotPriceHistory"]:
+                ts = record["Timestamp"]
+                instance_type = record["InstanceType"]
+                az = record["AvailabilityZone"]
 
                 try:
-                    price = float(record['SpotPrice'])
+                    price = float(record["SpotPrice"])
                 except Exception:
                     price = None
 
@@ -310,23 +324,22 @@ class AwsApi:
             to_return.append((instance_type, az, results[instance_type, az][1]))
         return to_return
 
-    def bootWorker(self,
-                   instanceType,
-                   authToken,
-                   clientToken=None,
-                   amiOverride=None,
-                   nameValueOverride=None,
-                   extraTags=None,
-                   wantsTerminateOnShutdown=True,
-                   spotPrice=None
-                   ):
-        boot_script = (
-            linux_bootstrap_script.format(
-                db_hostname=self.config.db_hostname,
-                db_port=self.config.db_port,
-                image=self.config.docker_image or "nativepython/cloud:latest",
-                worker_token=authToken
-            )
+    def bootWorker(
+        self,
+        instanceType,
+        authToken,
+        clientToken=None,
+        amiOverride=None,
+        nameValueOverride=None,
+        extraTags=None,
+        wantsTerminateOnShutdown=True,
+        spotPrice=None,
+    ):
+        boot_script = linux_bootstrap_script.format(
+            db_hostname=self.config.db_hostname,
+            db_port=self.config.db_port,
+            image=self.config.docker_image or "nativepython/cloud:latest",
+            worker_token=authToken,
         )
 
         if clientToken is None:
@@ -338,26 +351,23 @@ class AwsApi:
             ami = "ami-759bc50a"  # ubuntu 16.04 hvm-ssd
 
         def has_ephemeral_storage(instanceType):
-            for t in ['m3', 'c3', 'x1', 'r3', 'f1', 'h1', 'i3', 'd2']:
+            for t in ["m3", "c3", "x1", "r3", "f1", "h1", "i3", "d2"]:
                 if instanceType.startswith(t):
                     return True
             return False
 
         if has_ephemeral_storage(instanceType):
-            deviceMapping = {
-                'DeviceName': '/dev/xvdb',
-                'VirtualName': "ephemeral0"
-            }
+            deviceMapping = {"DeviceName": "/dev/xvdb", "VirtualName": "ephemeral0"}
         else:
             deviceMapping = {
-                'DeviceName': '/dev/xvdb',
-                'VirtualName': "ephemeral0",
+                "DeviceName": "/dev/xvdb",
+                "VirtualName": "ephemeral0",
                 "Ebs": {
                     "Encrypted": False,
                     "DeleteOnTermination": True,
                     "VolumeSize": self.config.defaultStorageSize,
-                    "VolumeType": "gp2"
-                }
+                    "VolumeType": "gp2",
+                },
             }
 
         nameValue = nameValueOverride or self.config.worker_name
@@ -371,27 +381,25 @@ class AwsApi:
             SecurityGroupIds=[self.config.security_group],
             SubnetId=self.config.subnet,
             ClientToken=clientToken,
-            InstanceInitiatedShutdownBehavior='terminate' if wantsTerminateOnShutdown else "stop",
-            IamInstanceProfile={'Name': self.config.worker_iam_role_name},
+            InstanceInitiatedShutdownBehavior="terminate"
+            if wantsTerminateOnShutdown
+            else "stop",
+            IamInstanceProfile={"Name": self.config.worker_iam_role_name},
             UserData=boot_script,  # base64.b64encode(boot_script.encode("ASCII")),
             BlockDeviceMappings=[deviceMapping],
             TagSpecifications=[
                 {
-                    'ResourceType': 'instance',
-                    'Tags': [{
-                        "Key": 'Name',
-                        "Value": nameValue
-                    }] + [{ "Key": k, "Value": v} for (k, v) in (extraTags or {}).items()]
-                }]
+                    "ResourceType": "instance",
+                    "Tags": [{"Key": "Name", "Value": nameValue}]
+                    + [{"Key": k, "Value": v} for (k, v) in (extraTags or {}).items()],
+                }
+            ],
         )
 
         if spotPrice:
-            ec2_args['InstanceMarketOptions'] = {
-                'MarketType': 'spot',
-                'SpotOptions': {
-                    'SpotInstanceType': 'one-time',
-                    'MaxPrice': str(spotPrice)
-                }
+            ec2_args["InstanceMarketOptions"] = {
+                "MarketType": "spot",
+                "SpotOptions": {"SpotInstanceType": "one-time", "MaxPrice": str(spotPrice)},
             }
 
         return str(self.ec2.create_instances(**ec2_args)[0].id)
@@ -417,10 +425,8 @@ class AwsWorkerBootService(ServiceBase):
     def setBootState(instance_type, target):
         if instance_type not in valid_instance_types:
             raise Exception(
-                "Instance type %s is not a valid instance type. Did you mean one of %s?" % (
-                    instance_type,
-                    closest_N_in(instance_type, valid_instance_types, 3)
-                )
+                "Instance type %s is not a valid instance type. Did you mean one of %s?"
+                % (instance_type, closest_N_in(instance_type, valid_instance_types, 3))
             )
 
         s = State.lookupAny(instance_type=instance_type)
@@ -435,7 +441,11 @@ class AwsWorkerBootService(ServiceBase):
 
     @staticmethod
     def shutOneDown(instance_type):
-        i = [x for x in AwsApi.allRunningInstances().values() if x['InstanceType'] == instance_type]
+        i = [
+            x
+            for x in AwsApi.allRunningInstances().values()
+            if x["InstanceType"] == instance_type
+        ]
         if not i:
             raise Exception("No instances of type %s are booted." % instance_type)
         else:
@@ -445,18 +455,18 @@ class AwsWorkerBootService(ServiceBase):
 
     @staticmethod
     def configure(
-            db_hostname,
-            db_port,
-            region,
-            vpc_id,
-            subnet,
-            security_group,
-            keypair,
-            worker_name,
-            worker_iam_role_name,
-            docker_image,
-            defaultStorageSize,
-            max_to_boot
+        db_hostname,
+        db_port,
+        region,
+        vpc_id,
+        subnet,
+        security_group,
+        keypair,
+        worker_name,
+        worker_iam_role_name,
+        docker_image,
+        defaultStorageSize,
+        max_to_boot,
     ):
         c = Configuration.lookupAny()
         if not c:
@@ -523,58 +533,91 @@ class AwsWorkerBootService(ServiceBase):
         def bootCountSetter(state, ct):
             def f():
                 state.desired = ct
+
             return f
 
         def bootCountSetterSpot(state, ct):
             def f():
                 state.spot_desired = ct
+
             return f
 
         return cells.Grid(
             colFun=lambda: [
-                'Instance Type', 'COST', 'RAM', 'CPU', 'Booted', 'Desired',
-                'SpotBooted', 'SpotDesired', 'ObservedLimit', 'CapacityConstrained',
-                'Spot-us-east-1', 'a', 'b', 'c', 'd', 'e', 'f'],
+                "Instance Type",
+                "COST",
+                "RAM",
+                "CPU",
+                "Booted",
+                "Desired",
+                "SpotBooted",
+                "SpotDesired",
+                "ObservedLimit",
+                "CapacityConstrained",
+                "Spot-us-east-1",
+                "a",
+                "b",
+                "c",
+                "d",
+                "e",
+                "f",
+            ],
             rowFun=lambda: sorted(
                 [x for x in State.lookupAll() if x.instance_type in instance_types_to_show],
-                key=lambda s: s.instance_type
+                key=lambda s: s.instance_type,
             ),
             headerFun=lambda x: x,
             rowLabelFun=None,
             rendererFun=lambda s, field: cells.Subscribed(
-                lambda:
-                s.instance_type if field == 'Instance Type' else
-                s.booted if field == 'Booted' else
-                cells.Dropdown(
+                lambda: s.instance_type
+                if field == "Instance Type"
+                else s.booted
+                if field == "Booted"
+                else cells.Dropdown(
                     s.desired,
-                    [(str(ct), bootCountSetter(s, ct)) for ct in list(range(10)) + list(range(10, 101, 10))]
-                ) if field == 'Desired' else
-                s.spot_booted if field == 'SpotBooted' else
-                cells.Dropdown(
+                    [
+                        (str(ct), bootCountSetter(s, ct))
+                        for ct in list(range(10)) + list(range(10, 101, 10))
+                    ],
+                )
+                if field == "Desired"
+                else s.spot_booted
+                if field == "SpotBooted"
+                else cells.Dropdown(
                     s.spot_desired,
-                    [(str(ct), bootCountSetterSpot(s, ct)) for ct in list(range(10)) + list(range(10, 101, 10))]
-                ) if field == 'SpotDesired' else
-                ("" if s.observedLimit is None else s.observedLimit) if field == 'ObservedLimit' else
-                ("Yes" if s.capacityConstrained else "") if field == 'CapacityConstrained' else
-                valid_instance_types[s.instance_type]['COST'] if field == 'COST' else
-                valid_instance_types[s.instance_type]['RAM'] if field == 'RAM' else
-                valid_instance_types[s.instance_type]['CPU'] if field == 'CPU' else
-                s.spotPrices.get('us-east-1' + field, "") if field in 'abcdef' else
-                ""
-            )
+                    [
+                        (str(ct), bootCountSetterSpot(s, ct))
+                        for ct in list(range(10)) + list(range(10, 101, 10))
+                    ],
+                )
+                if field == "SpotDesired"
+                else ("" if s.observedLimit is None else s.observedLimit)
+                if field == "ObservedLimit"
+                else ("Yes" if s.capacityConstrained else "")
+                if field == "CapacityConstrained"
+                else valid_instance_types[s.instance_type]["COST"]
+                if field == "COST"
+                else valid_instance_types[s.instance_type]["RAM"]
+                if field == "RAM"
+                else valid_instance_types[s.instance_type]["CPU"]
+                if field == "CPU"
+                else s.spotPrices.get("us-east-1" + field, "")
+                if field in "abcdef"
+                else ""
+            ),
         ) + cells.Card(
-            cells.Text("db_hostname = " + str(c.db_hostname)) +
-            cells.Text("db_port = " + str(c.db_port)) +
-            cells.Text("region = " + str(c.region)) +
-            cells.Text("vpc_id = " + str(c.vpc_id)) +
-            cells.Text("subnet = " + str(c.subnet)) +
-            cells.Text("security_group = " + str(c.security_group)) +
-            cells.Text("keypair = " + str(c.keypair)) +
-            cells.Text("worker_name = " + str(c.worker_name)) +
-            cells.Text("worker_iam_role_name = " + str(c.worker_iam_role_name)) +
-            cells.Text("docker_image = " + str(c.docker_image)) +
-            cells.Text("defaultStorageSize = " + str(c.defaultStorageSize)) +
-            cells.Text("max_to_boot = " + str(c.max_to_boot))
+            cells.Text("db_hostname = " + str(c.db_hostname))
+            + cells.Text("db_port = " + str(c.db_port))
+            + cells.Text("region = " + str(c.region))
+            + cells.Text("vpc_id = " + str(c.vpc_id))
+            + cells.Text("subnet = " + str(c.subnet))
+            + cells.Text("security_group = " + str(c.security_group))
+            + cells.Text("keypair = " + str(c.keypair))
+            + cells.Text("worker_name = " + str(c.worker_name))
+            + cells.Text("worker_iam_role_name = " + str(c.worker_iam_role_name))
+            + cells.Text("docker_image = " + str(c.docker_image))
+            + cells.Text("defaultStorageSize = " + str(c.defaultStorageSize))
+            + cells.Text("max_to_boot = " + str(c.max_to_boot))
         )
 
     def pushTaskLoopForward(self):
@@ -631,7 +674,7 @@ class AwsWorkerBootService(ServiceBase):
                         "We have %s instances of type %s booted vs %s desired. Shutting one down.",
                         state.booted,
                         state.instance_type,
-                        state.desired
+                        state.desired,
                     )
 
                     instance = instancesByType[state.instance_type].pop()
@@ -640,11 +683,11 @@ class AwsWorkerBootService(ServiceBase):
 
                 while state.spot_booted > state.spot_desired:
                     self._logger.info(
-                        "We have %s spot instances of type %s requested vs %s desired. " +
-                        "Terminating one down.",
+                        "We have %s spot instances of type %s requested vs %s desired. "
+                        + "Terminating one down.",
                         state.spot_booted,
                         state.instance_type,
-                        state.spot_desired
+                        state.spot_desired,
                     )
 
                     instance = spotInstancesByType[state.instance_type].pop()
@@ -656,7 +699,7 @@ class AwsWorkerBootService(ServiceBase):
                         "We have %s instances of type %s booted vs %s desired. Booting one.",
                         state.booted,
                         state.instance_type,
-                        state.desired
+                        state.desired,
                     )
 
                     try:
@@ -665,16 +708,26 @@ class AwsWorkerBootService(ServiceBase):
                         state.booted += 1
                         state.capacityConstrained = False
                     except Exception as e:
-                        if 'InsufficientInstanceCapacity' in str(e):
+                        if "InsufficientInstanceCapacity" in str(e):
                             state.desired = state.booted
                             state.capacityConstrained = True
-                        elif 'You have requested more instances ' in str(e):
-                            maxCount = int(str(e).split('than your current instance limit of ')[1].split(' ')[0])
-                            self._logger.info("Visible limit of %s observed for instance type %s", maxCount, state.instance_type)
+                        elif "You have requested more instances " in str(e):
+                            maxCount = int(
+                                str(e)
+                                .split("than your current instance limit of ")[1]
+                                .split(" ")[0]
+                            )
+                            self._logger.info(
+                                "Visible limit of %s observed for instance type %s",
+                                maxCount,
+                                state.instance_type,
+                            )
                             state.observedLimit = maxCount
                             state.desired = min(state.desired, maxCount)
                         else:
-                            self._logger.error("Failed to boot a worker:\n%s", traceback.format_exc())
+                            self._logger.error(
+                                "Failed to boot a worker:\n%s", traceback.format_exc()
+                            )
                             time.sleep(self.SLEEP_INTERVAL)
                             break
 
@@ -683,26 +736,39 @@ class AwsWorkerBootService(ServiceBase):
                         "We have %s spot instances of type %s booted vs %s desired. Booting one.",
                         state.spot_booted,
                         state.instance_type,
-                        state.spot_desired
+                        state.spot_desired,
                     )
 
                     try:
                         instanceId = self.api.bootWorker(
                             state.instance_type,
                             self.runtimeConfig.authToken,
-                            spotPrice=valid_instance_types[state.instance_type]['COST']
+                            spotPrice=valid_instance_types[state.instance_type]["COST"],
                         )
                         if not self.api.tagSpotRequest(instanceId):
-                            self._logger.error("Failed to tag spot-request associated with instance %s", instanceId)
+                            self._logger.error(
+                                "Failed to tag spot-request associated with instance %s",
+                                instanceId,
+                            )
                         state.spot_booted += 1
                     except Exception as e:
-                        if 'You have requested more instances ' in str(e):
-                            maxCount = int(str(e).split('than your current instance limit of ')[1].split(' ')[0])
-                            self._logger.info("Visible limit of %s observed for instance type %s", maxCount, state.instance_type)
+                        if "You have requested more instances " in str(e):
+                            maxCount = int(
+                                str(e)
+                                .split("than your current instance limit of ")[1]
+                                .split(" ")[0]
+                            )
+                            self._logger.info(
+                                "Visible limit of %s observed for instance type %s",
+                                maxCount,
+                                state.instance_type,
+                            )
                             state.observedLimit = maxCount
                             state.desired = min(state.desired, maxCount)
                         else:
-                            self._logger.error("Failed to boot a worker:\n%s", traceback.format_exc())
+                            self._logger.error(
+                                "Failed to boot a worker:\n%s", traceback.format_exc()
+                            )
                             break
 
         time.sleep(self.SLEEP_INTERVAL)

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -671,7 +671,8 @@ class AwsWorkerBootService(ServiceBase):
             for state in State.lookupAll():
                 while state.booted > state.desired:
                     self._logger.info(
-                        "We have %s instances of type %s booted vs %s desired. Shutting one down.",
+                        "We have %s instances of type %s booted "
+                        "vs %s desired. Shutting one down.",
                         state.booted,
                         state.instance_type,
                         state.desired,
@@ -733,7 +734,8 @@ class AwsWorkerBootService(ServiceBase):
 
                 while state.spot_booted < state.spot_desired:
                     self._logger.info(
-                        "We have %s spot instances of type %s booted vs %s desired. Booting one.",
+                        "We have %s spot instances of type %s booted "
+                        "vs %s desired. Booting one.",
                         state.spot_booted,
                         state.instance_type,
                         state.spot_desired,

--- a/object_database/service_manager/test_files/TestModule1.py
+++ b/object_database/service_manager/test_files/TestModule1.py
@@ -36,9 +36,13 @@ class RunningTaskWithSubtasks(RunningTask):
             if self.x <= 0:
                 return TaskStatusResult.Finished(result=1)
 
-            return TaskStatusResult.Subtasks({'A': TaskWithSubtasks(self.x-1), 'B': TaskWithSubtasks(self.x-2)})
+            return TaskStatusResult.Subtasks(
+                {"A": TaskWithSubtasks(self.x - 1), "B": TaskWithSubtasks(self.x - 2)}
+            )
         else:
-            return TaskStatusResult.Finished(subtaskResults['A'].result + subtaskResults['B'].result)
+            return TaskStatusResult.Finished(
+                subtaskResults["A"].result + subtaskResults["B"].result
+            )
 
 
 class TaskWithSubtasks(TaskExecutor):

--- a/object_database/tcp_server.py
+++ b/object_database/tcp_server.py
@@ -40,7 +40,9 @@ class ServerToClientProtocol(AlgebraicProtocol):
             try:
                 return handler(*args)
             except Exception:
-                self._logger.error("Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc())
+                self._logger.error(
+                    "Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc()
+                )
 
         self.handler = callHandler
 
@@ -84,11 +86,16 @@ class ClientToServerProtocol(AlgebraicProtocol):
 
     def setServerToClientHandler(self, handler):
         with self.lock:
+
             def callHandler(*args):
                 try:
                     return handler(*args)
                 except Exception:
-                    self._logger.error("Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc())
+                    self._logger.error(
+                        "Unexpected exception in %s:\n%s",
+                        handler.__name__,
+                        traceback.format_exc(),
+                    )
 
             self.handler = callHandler
             for m in self.msgs:
@@ -145,7 +152,9 @@ class EventLoopInThread:
         self.start()
 
         async def doit():
-            return await self.loop.create_connection(protocol_factory, host=host, port=port, family=socket.AF_INET, ssl=ssl)
+            return await self.loop.create_connection(
+                protocol_factory, host=host, port=port, family=socket.AF_INET, ssl=ssl
+            )
 
         res = asyncio.run_coroutine_threadsafe(doit(), self.loop)
 
@@ -155,7 +164,9 @@ class EventLoopInThread:
         self.start()
 
         async def doit():
-            return await self.loop.create_server(protocol_factory, host=host, port=port, family=socket.AF_INET, ssl=ssl)
+            return await self.loop.create_server(
+                protocol_factory, host=host, port=port, family=socket.AF_INET, ssl=ssl
+            )
 
         res = asyncio.run_coroutine_threadsafe(doit(), self.loop)
 
@@ -178,21 +189,23 @@ def connect(host, port, auth_token, timeout=10.0, retry=False, eventLoop=_eventL
                 lambda: ClientToServerProtocol(host, port, eventLoop.loop),
                 host=host,
                 port=port,
-                ssl=ssl_ctx
+                ssl=ssl_ctx,
             )
         except Exception:
-            if not retry or time.time() - t0 > timeout * .8:
+            if not retry or time.time() - t0 > timeout * 0.8:
                 raise
             time.sleep(min(timeout, max(timeout / 100.0, 0.01)))
 
     if proto is None:
         raise ConnectionRefusedError()
 
-    conn = DatabaseConnection(proto, {
-        propertyName:
-            proto.transport.get_extra_info(propertyName)
-            for propertyName in ['socket', 'peername', 'sockname']
-    })
+    conn = DatabaseConnection(
+        proto,
+        {
+            propertyName: proto.transport.get_extra_info(propertyName)
+            for propertyName in ["socket", "peername", "sockname"]
+        },
+    )
 
     conn.authenticate(auth_token)
 
@@ -224,7 +237,7 @@ class TcpServer(Server):
             lambda: ServerToClientProtocol(self, _eventLoop.loop),
             host=self.host,
             port=self.port,
-            ssl=self.ssl_ctx
+            ssl=self.ssl_ctx,
         )
         _eventLoop.loop.call_soon_threadsafe(self.checkHeartbeatsCallback)
 
@@ -234,7 +247,9 @@ class TcpServer(Server):
             try:
                 self.checkForDeadConnections()
             except Exception:
-                logging.error("Caught exception in checkForDeadConnections:\n%s", traceback.format_exc())
+                logging.error(
+                    "Caught exception in checkForDeadConnections:\n%s", traceback.format_exc()
+                )
 
     def stop(self):
         Server.stop(self)

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -46,10 +46,7 @@ def diff_object_types_histograms(new_histo, old_histo):
     """ Returns a new histogram that is the difference of it inputs """
     all_keys = set(new_histo.keys()).union(old_histo.keys())
 
-    dd = {
-        k: new_histo[k] - old_histo[k]
-        for k in all_keys if new_histo[k] - old_histo[k] != 0
-    }
+    dd = {k: new_histo[k] - old_histo[k] for k in all_keys if new_histo[k] - old_histo[k] != 0}
     return dd
 
 
@@ -59,10 +56,9 @@ def sort_by_value(histogram, topK=None, filterFn=None):
         If filter is specified the results are filtered using that function
         If topK is specified, only return topK results
     """
-    res = reversed(sorted(
-        [(val, tag) for tag, val in histogram.items()],
-        key=lambda pair: pair[0]
-    ))
+    res = reversed(
+        sorted([(val, tag) for tag, val in histogram.items()], key=lambda pair: pair[0])
+    )
 
     if filter is not None:
         res = filter(filterFn, res)
@@ -81,18 +77,12 @@ def log_cells_stats(cells, logger, indentation=0):
 
     log("#####################################################")
     log("#  Cells structure DEBUG Log")
-    log("#  - dirty: {}"
-        .format(len(cells._dirtyNodes)))
-    log("#  - need bcast: {}"
-        .format(len(cells._nodesToBroadcast)))
-    log("#  - cells: {}"
-        .format(len(cells._cells)))
-    log("#  - known children: {}"
-        .format(len(cells._cellsKnownChildren)))
-    log("#  - to discard: {}"
-        .format(len(cells._nodesToDiscard)))
-    log("#  - subscribed-to keys: {}"
-        .format(len(cells._subscribedCells)))
+    log("#  - dirty: {}".format(len(cells._dirtyNodes)))
+    log("#  - need bcast: {}".format(len(cells._nodesToBroadcast)))
+    log("#  - cells: {}".format(len(cells._cells)))
+    log("#  - known children: {}".format(len(cells._cellsKnownChildren)))
+    log("#  - to discard: {}".format(len(cells._nodesToDiscard)))
+    log("#  - subscribed-to keys: {}".format(len(cells._subscribedCells)))
     log("#####################################################")
 
 

--- a/object_database/view.py
+++ b/object_database/view.py
@@ -42,7 +42,7 @@ class ObjectDoesntExistException(Exception):
 
 class MaskView:
     def __enter__(self):
-        if hasattr(_cur_view, 'view'):
+        if hasattr(_cur_view, "view"):
             self.view = _cur_view.view
             del _cur_view.view
         else:
@@ -137,7 +137,7 @@ class View(object):
                 reads,
                 indexReads,
                 tid,
-                confirmCallback
+                confirmCallback,
             )
 
             if not self._confirmCommitCallback:
@@ -149,7 +149,9 @@ class View(object):
                 if time.time() - t0 > LOG_SLOW_COMMIT_THRESHOLD:
                     self._logger.info(
                         "Committing %s writes and %s set changes took %.1f seconds",
-                        len(writes), len(setAdds) + len(setRemoves), time.time() - t0
+                        len(writes),
+                        len(setAdds) + len(setRemoves),
+                        time.time() - t0,
                     )
 
                 if res.matches.Success:
@@ -157,7 +159,7 @@ class View(object):
                 if res.matches.Disconnected:
                     raise DisconnectedException()
                 if res.matches.RevisionConflict:
-                    if hasattr(res.key, 'fieldId'):
+                    if hasattr(res.key, "fieldId"):
                         fieldId = res.key.fieldId
                         fieldDef = self._db._field_id_to_field_def.get(fieldId)
                     else:
@@ -169,7 +171,7 @@ class View(object):
     def nocommit(self):
         class Scope:
             def __enter__(scope):
-                assert not hasattr(_cur_view, 'view')
+                assert not hasattr(_cur_view, "view")
                 _cur_view.view = self
                 self._view.enter()
 
@@ -180,7 +182,7 @@ class View(object):
         return Scope()
 
     def __enter__(self):
-        assert not hasattr(_cur_view, 'view')
+        assert not hasattr(_cur_view, "view")
         _cur_view.view = self
         self._view.enter()
         return self
@@ -204,11 +206,12 @@ class ViewWatcher:
     call 'callback' with the view and a boolean indicating whether they are
     exiting with an exception.
     """
+
     def __init__(self, callback):
         self.callback = callback
 
     def __enter__(self):
-        if not hasattr(_cur_view, 'watchers'):
+        if not hasattr(_cur_view, "watchers"):
             _cur_view.watchers = set()
         _cur_view.watchers.add(self)
 
@@ -229,8 +232,10 @@ class Transaction(View):
     def noconfirm(self):
         """Indicate that the transaction should return immediately without a round-trip to
         confirm that it was successful."""
+
         def ignoreConfirmResult(result):
             pass
+
         self._confirmCommitCallback = ignoreConfirmResult
 
         return self

--- a/object_database/web/ActiveWebService_util.py
+++ b/object_database/web/ActiveWebService_util.py
@@ -18,10 +18,22 @@ from itertools import chain
 from object_database.web.ActiveWebServiceSchema import active_webservice_schema
 
 from object_database.web.cells import (
-    Main, Subscribed, Traceback, Span, Button, Octicon,
-    Tabs, Table, Clickable, Dropdown, Popover, HeaderBar,
-    LargePendingDownloadDisplay, PageView,
-    HorizontalSequence, SplitView
+    Main,
+    Subscribed,
+    Traceback,
+    Span,
+    Button,
+    Octicon,
+    Tabs,
+    Table,
+    Clickable,
+    Dropdown,
+    Popover,
+    HeaderBar,
+    LargePendingDownloadDisplay,
+    PageView,
+    HorizontalSequence,
+    SplitView,
 )
 
 from object_database.web.AuthPlugin import AuthPluginBase
@@ -54,38 +66,45 @@ class Configuration:
 
 
 def view():
-    buttons = HorizontalSequence([
-        Button(
-            HorizontalSequence([Octicon('shield', color='green'), Span('Lock ALL')]),
-            lambda: [s.lock() for s in service_schema.Service.lookupAll()]),
-        Button(
-            HorizontalSequence([Octicon('shield', color='orange'), Span('Prepare ALL')]),
-            lambda: [s.prepare() for s in service_schema.Service.lookupAll()]),
-        Button(
-            HorizontalSequence([Octicon('stop', color='red'), Span('Unlock ALL')]),
-            lambda: [s.unlock() for s in service_schema.Service.lookupAll()]),
-    ], margin=1)
-    tabs = Tabs(
-        Services=servicesTable(),
-        Hosts=hostsTable()
+    buttons = HorizontalSequence(
+        [
+            Button(
+                HorizontalSequence([Octicon("shield", color="green"), Span("Lock ALL")]),
+                lambda: [s.lock() for s in service_schema.Service.lookupAll()],
+            ),
+            Button(
+                HorizontalSequence([Octicon("shield", color="orange"), Span("Prepare ALL")]),
+                lambda: [s.prepare() for s in service_schema.Service.lookupAll()],
+            ),
+            Button(
+                HorizontalSequence([Octicon("stop", color="red"), Span("Unlock ALL")]),
+                lambda: [s.unlock() for s in service_schema.Service.lookupAll()],
+            ),
+        ],
+        margin=1,
     )
+    tabs = Tabs(Services=servicesTable(), Hosts=hostsTable())
     return SplitView([(buttons, 1), (tabs, 10)], split="horizontal")
 
 
 def hostsTable():
     hosts = Table(
         colFun=lambda: [
-            'Connection', 'IsMaster', 'Hostname', 'RAM ALLOCATION',
-            'CORE ALLOCATION', 'SERVICE COUNT', 'CPU USE', 'RAM USE'
+            "Connection",
+            "IsMaster",
+            "Hostname",
+            "RAM ALLOCATION",
+            "CORE ALLOCATION",
+            "SERVICE COUNT",
+            "CPU USE",
+            "RAM USE",
         ],
         rowFun=lambda: sorted(
-            service_schema.ServiceHost.lookupAll(), key=lambda s:
-            s.hostname),
-        headerFun=lambda x: x,
-        rendererFun=lambda s, field: Subscribed(
-            lambda: hostsTableDataPrep(s, field)
+            service_schema.ServiceHost.lookupAll(), key=lambda s: s.hostname
         ),
-        maxRowsPerPage=50
+        headerFun=lambda x: x,
+        rendererFun=lambda s, field: Subscribed(lambda: hostsTableDataPrep(s, field)),
+        maxRowsPerPage=50,
     )
     return hosts
 
@@ -104,7 +123,7 @@ def hostsTableDataPrep(s, field):
     elif field == "Hostname":
         data = s.hostname
     elif field == "RAM ALLOCATION":
-        data = "%.1f / %.1f" % ( s.gbRamUsed, s.maxGbRam)
+        data = "%.1f / %.1f" % (s.gbRamUsed, s.maxGbRam)
     elif field == "CORE ALLOCATION":
         data = "%s / %s" % (s.coresUsed, s.maxCores)
     elif field == "SERVICE COUNT":
@@ -120,31 +139,41 @@ def hostsTableDataPrep(s, field):
 
 def servicesTable():
 
-    serviceCountsChain = chain(range(5), range(10, 100, 10), range(100, 400, 25),
-                               range(400, 1001, 100))
+    serviceCountsChain = chain(
+        range(5), range(10, 100, 10), range(100, 400, 25), range(400, 1001, 100)
+    )
     serviceCounts = [val for val in serviceCountsChain]
 
     table = Table(
         colFun=lambda: [
-            'Service', 'Codebase Status', 'Codebase', 'Module', 'Class',
-            'Placement', 'Active', 'TargetCount', 'Cores', 'RAM',
-            'Boot Status'],
-        rowFun=lambda:
-            sorted(service_schema.Service.lookupAll(), key=lambda s:
-                   s.name),
+            "Service",
+            "Codebase Status",
+            "Codebase",
+            "Module",
+            "Class",
+            "Placement",
+            "Active",
+            "TargetCount",
+            "Cores",
+            "RAM",
+            "Boot Status",
+        ],
+        rowFun=lambda: sorted(service_schema.Service.lookupAll(), key=lambda s: s.name),
         headerFun=lambda x: x,
         rendererFun=lambda s, field: Subscribed(
             lambda: servicesTableDataPrep(s, field, serviceCounts)
         ),
-        maxRowsPerPage=50
+        maxRowsPerPage=50,
     )
     return table
 
 
 def __serviceCountSetter(service, ct):
     """Helper function for servicesTableDataPrep. """
+
     def f():
         service.target_count = ct
+
     return f
 
 
@@ -157,58 +186,48 @@ def servicesTableDataPrep(s, field, serviceCounts):
     serviceCounts : list of ints
     """
 
-    if field == 'Service':
+    if field == "Service":
         data = Clickable(s.name, "/services/" + s.name)
-    elif field == 'Codebase Status':
+    elif field == "Codebase Status":
         data = (
             Clickable(
-                HorizontalSequence(
-                    [Octicon('stop', color='red'), Span('Unlocked')]
-                ),
-                lambda: s.lock()
-            ) if s.isUnlocked else
-            Clickable(
-                HorizontalSequence(
-                    [Octicon('shield', color='green'), Span('Locked')]
-                ),
-                lambda: s.prepare()
-            ) if s.isLocked else
-            Clickable(
-                HorizontalSequence(
-                    [Octicon('shield', color='orange'), Span('Prepared')]
-                ), lambda: s.unlock()
+                HorizontalSequence([Octicon("stop", color="red"), Span("Unlocked")]),
+                lambda: s.lock(),
+            )
+            if s.isUnlocked
+            else Clickable(
+                HorizontalSequence([Octicon("shield", color="green"), Span("Locked")]),
+                lambda: s.prepare(),
+            )
+            if s.isLocked
+            else Clickable(
+                HorizontalSequence([Octicon("shield", color="orange"), Span("Prepared")]),
+                lambda: s.unlock(),
             )
         )
-    elif field == 'Codebase':
-        data = (str(s.codebase) if s.codebase else "")
-    elif field == 'Module':
+    elif field == "Codebase":
+        data = str(s.codebase) if s.codebase else ""
+    elif field == "Module":
         data = s.service_module_name
-    elif field == 'Class':
+    elif field == "Class":
         data = s.service_class_name
-    elif field == 'Placement':
+    elif field == "Placement":
         data = s.placement
-    elif field == 'Active':
-        data = Subscribed(
-            lambda: len(
-                service_schema.ServiceInstance.lookupAll(service=s)
-            )
-        )
-    elif field == 'TargetCount':
+    elif field == "Active":
+        data = Subscribed(lambda: len(service_schema.ServiceInstance.lookupAll(service=s)))
+    elif field == "TargetCount":
         data = Dropdown(
-            s.target_count,
-            [(str(ct), __serviceCountSetter(s, ct)) for ct in serviceCounts]
+            s.target_count, [(str(ct), __serviceCountSetter(s, ct)) for ct in serviceCounts]
         )
-    elif field == 'Cores':
+    elif field == "Cores":
         data = str(s.coresUsed)
-    elif field == 'RAM':
+    elif field == "RAM":
         data = str(s.gbRamUsed)
-    elif field == 'Boot Status':
+    elif field == "Boot Status":
         data = (
-            Popover(
-                Octicon("alert"),
-                "Failed",
-                Traceback(s.lastFailureReason or "<Unknown>")
-            ) if s.isThrottled() else ""
+            Popover(Octicon("alert"), "Failed", Traceback(s.lastFailureReason or "<Unknown>"))
+            if s.isThrottled()
+            else ""
         )
     else:
         data = ""
@@ -232,11 +251,12 @@ def makeServiceDropdown(services):
         Subscribed(
             lambda: Dropdown(
                 "Service",
-                [("All", "/services")] +
-                [(s.name, "/services/" + s.name)
-                 for s in sorted(services.Service.lookupAll(),
-                                 key=lambda s:s.name)]
-            ),
+                [("All", "/services")]
+                + [
+                    (s.name, "/services/" + s.name)
+                    for s in sorted(services.Service.lookupAll(), key=lambda s: s.name)
+                ],
+            )
         )
     ]
 
@@ -262,10 +282,10 @@ def makeMainHeader(toggles, current_username, authorized_groups_text):
         toggles,
         [
             LargePendingDownloadDisplay(),
-            Octicon('person') >> Span(current_username),
-            Span('Authorized Groups: {}'.format(authorized_groups_text)),
-            Button(Octicon('sign-out'), '/logout')
-        ]
+            Octicon("person") >> Span(current_username),
+            Span("Authorized Groups: {}".format(authorized_groups_text)),
+            Button(Octicon("sign-out"), "/logout"),
+        ],
     )
 
 
@@ -287,14 +307,11 @@ def makeMainView(display, toggles, current_username, authorized_groups_text):
     primary view container, with configured header
     """
     header = makeMainHeader(toggles, current_username, authorized_groups_text)
-    return PageView(
-        Main(display),
-        header=header
-    )
+    return PageView(Main(display), header=header)
 
 
 def displayAndHeadersForPathAndQueryArgs(path, queryArgs):
-    if len(path) and path[0] == 'services':
+    if len(path) and path[0] == "services":
         if len(path) == 1:
             return view(), []
 
@@ -313,12 +330,9 @@ def displayAndHeadersForPathAndQueryArgs(path, queryArgs):
         if len(path) == 2:
             return (
                 Subscribed(
-                    lambda: serviceType.serviceDisplay(serviceObj,
-                                                       queryArgs=queryArgs)
-                ).withSerializationContext(
-                    serviceObj.getSerializationContext()
-                ),
-                serviceToggles
+                    lambda: serviceType.serviceDisplay(serviceObj, queryArgs=queryArgs)
+                ).withSerializationContext(serviceObj.getSerializationContext()),
+                serviceToggles,
             )
 
         typename = path[2]
@@ -331,33 +345,31 @@ def displayAndHeadersForPathAndQueryArgs(path, queryArgs):
                 break
 
         if typeObj is None:
-            return Traceback(
-                "Can't find fully-qualified type %s" % typename), []
+            return Traceback("Can't find fully-qualified type %s" % typename), []
 
         if len(path) == 3:
             return (
-                serviceType.serviceDisplay(serviceObj, objType=typename,
-                                           queryArgs=queryArgs)
-                .withSerializationContext(
-                    serviceObj.getSerializationContext()
-                ),
-                serviceToggles
+                serviceType.serviceDisplay(
+                    serviceObj, objType=typename, queryArgs=queryArgs
+                ).withSerializationContext(serviceObj.getSerializationContext()),
+                serviceToggles,
             )
 
         instance = typeObj.fromIdentity(path[3])
 
         return (
-            serviceType.serviceDisplay(serviceObj, instance=instance,
-                                       queryArgs=queryArgs)
-            .withSerializationContext(serviceObj.getSerializationContext()),
-            serviceToggles
+            serviceType.serviceDisplay(
+                serviceObj, instance=instance, queryArgs=queryArgs
+            ).withSerializationContext(serviceObj.getSerializationContext()),
+            serviceToggles,
         )
 
     return Traceback("Invalid url path: %s" % path), []
 
 
-def writeJsonMessage(message, ws, largeMessageAck, logger, frames_per_ack=10,
-                     frame_size=32 * 1024):
+def writeJsonMessage(
+    message, ws, largeMessageAck, logger, frames_per_ack=10, frame_size=32 * 1024
+):
     """Send a message over the websocket.
 
     Note: We have to chunk in 64kb frames
@@ -381,12 +393,11 @@ def writeJsonMessage(message, ws, largeMessageAck, logger, frames_per_ack=10,
     frames = []
     i = 0
     while i < len(msg):
-        frames.append(msg[i:i+frame_size])
+        frames.append(msg[i : i + frame_size])
         i += frame_size
 
     if len(frames) >= frames_per_ack:
-        logger.info("Sending large message of %s bytes over %s frames",
-                    len(msg), len(frames))
+        logger.info("Sending large message of %s bytes over %s frames", len(msg), len(frames))
 
     ws.send(json.dumps(len(frames)))
 
@@ -395,14 +406,13 @@ def writeJsonMessage(message, ws, largeMessageAck, logger, frames_per_ack=10,
 
         # block until we get the ack for frames_per_ack frames ago. That
         # way we always have frames_per_ack frames in the buffer.
-        framesSent = index+1
+        framesSent = index + 1
         if framesSent % frames_per_ack == 0 and framesSent > frames_per_ack:
             ack = largeMessageAck.get()
             if ack is StopIteration:
                 return
             else:
-                assert ack == framesSent - frames_per_ack, (
-                    ack, framesSent - frames_per_ack)
+                assert ack == framesSent - frames_per_ack, (ack, framesSent - frames_per_ack)
 
     framesSent = len(frames)
 
@@ -439,16 +449,15 @@ def readThread(ws, cells, largeMessageAck, logger):
         else:
             try:
                 jsonMsg = json.loads(msg)
-                if 'ACK' in jsonMsg:
-                    largeMessageAck.put(jsonMsg['ACK'])
+                if "ACK" in jsonMsg:
+                    largeMessageAck.put(jsonMsg["ACK"])
                 else:
-                    cell_id = jsonMsg.get('target_cell')
+                    cell_id = jsonMsg.get("target_cell")
                     cell = cells[cell_id]
                     if cell is not None:
                         cell.onMessageWithTransaction(jsonMsg)
             except Exception:
-                logger.error("Exception in inbound message: %s",
-                             traceback.format_exc())
+                logger.error("Exception in inbound message: %s", traceback.format_exc())
 
             cells.triggerIfHasDirty()
 

--- a/object_database/web/AuthPlugin_test.py
+++ b/object_database/web/AuthPlugin_test.py
@@ -19,58 +19,70 @@ from object_database.web.AuthPlugin import LdapAuthPlugin
 
 
 class LdapAuthPluginTest(unittest.TestCase):
-
     def test_ldap_plugin_authenticate_no_groups(self):
         ldap_auth = LdapAuthPlugin(
-            "localhost", "bogus_base_dn", "bogus_ntlm_domain",
-            authorized_groups=None
+            "localhost", "bogus_base_dn", "bogus_ntlm_domain", authorized_groups=None
         )
 
-        with patch.object(ldap_auth, 'getLdapConnection') as mock_getConn:
-            with patch.object(ldap_auth, 'getUserAttribute') as mock_getUserAttr:
+        with patch.object(ldap_auth, "getLdapConnection") as mock_getConn:
+            with patch.object(ldap_auth, "getUserAttribute") as mock_getUserAttr:
                 error = ldap_auth.authenticate("McFly", "M@rty")
 
-        self.assertEqual(error, '')
+        self.assertEqual(error, "")
         mock_getConn.assert_called_once()
         self.assertEqual(mock_getUserAttr.call_count, 0)
 
     def test_ldap_plugin_authenticate_with_groups(self):
         ldap_auth = LdapAuthPlugin(
-            "localhost", "bogus_base_dn", "bogus_ntlm_domain",
-            authorized_groups=['Protagonists', 'Scientists']
+            "localhost",
+            "bogus_base_dn",
+            "bogus_ntlm_domain",
+            authorized_groups=["Protagonists", "Scientists"],
         )
 
         # 1. test with users that belong to a valid group
-        with patch.object(ldap_auth, 'getLdapConnection') as mock_getConn:
-            with patch.object(ldap_auth,
-                              'getUserAttribute',
-                              return_value=['CN=Protagonists, OU=BackToDasFutuur',
-                                            'CN=Stars, OU=BackToDasFutuur']) as mock_getUserAttr:
+        with patch.object(ldap_auth, "getLdapConnection") as mock_getConn:
+            with patch.object(
+                ldap_auth,
+                "getUserAttribute",
+                return_value=[
+                    "CN=Protagonists, OU=BackToDasFutuur",
+                    "CN=Stars, OU=BackToDasFutuur",
+                ],
+            ) as mock_getUserAttr:
                 error = ldap_auth.authenticate("McFly", "M@rty")
 
-        self.assertEqual(error, '')
+        self.assertEqual(error, "")
         mock_getConn.assert_called_once()
         mock_getUserAttr.assert_called_once()
 
-        with patch.object(ldap_auth, 'getLdapConnection') as mock_getConn:
-            with patch.object(ldap_auth,
-                              'getUserAttribute',
-                              return_value=['CN=SideKicks, OU=BackToDasFutuur',
-                                            'CN=Scientists, OU=BackToDasFutuur']) as mock_getUserAttr:
+        with patch.object(ldap_auth, "getLdapConnection") as mock_getConn:
+            with patch.object(
+                ldap_auth,
+                "getUserAttribute",
+                return_value=[
+                    "CN=SideKicks, OU=BackToDasFutuur",
+                    "CN=Scientists, OU=BackToDasFutuur",
+                ],
+            ) as mock_getUserAttr:
                 error = ldap_auth.authenticate("Brown", "Emmet, Dr.")
 
-        self.assertEqual(error, '')
+        self.assertEqual(error, "")
         mock_getConn.assert_called_once()
         mock_getUserAttr.assert_called_once()
 
         # 2. test with a user that does not belong to a valid group
-        with patch.object(ldap_auth, 'getLdapConnection') as mock_getConn:
-            with patch.object(ldap_auth,
-                              'getUserAttribute',
-                              return_value=['CN=Nemesis, OU=BackToDasFutuur',
-                                            'CN=Brutes, OU=BackToDasFutuur']) as mock_getUserAttr:
+        with patch.object(ldap_auth, "getLdapConnection") as mock_getConn:
+            with patch.object(
+                ldap_auth,
+                "getUserAttribute",
+                return_value=[
+                    "CN=Nemesis, OU=BackToDasFutuur",
+                    "CN=Brutes, OU=BackToDasFutuur",
+                ],
+            ) as mock_getUserAttr:
                 error = ldap_auth.authenticate("Tannen", "B1ff")
 
-        self.assertNotEqual(error, '')
+        self.assertNotEqual(error, "")
         mock_getConn.assert_called_once()
         mock_getUserAttr.assert_called_once()

--- a/object_database/web/CellsTestPage.py
+++ b/object_database/web/CellsTestPage.py
@@ -19,6 +19,7 @@ class CellsTestPage(object):
     We find all subclasses of these in object_database.web.cells_demo and
     show them in a hierarchical view.
     """
+
     def category(self):
         """Return a string we'll use to group this."""
         return type(self).__module__.split(".")[-1]

--- a/object_database/web/CellsTestService.py
+++ b/object_database/web/CellsTestService.py
@@ -45,12 +45,14 @@ def getPages():
     odbCodebase = Codebase.FromRootlevelModule(object_database)
     # these are all the cell_demo cells
     for name, value in odbCodebase.allModuleLevelValues():
-        if isinstance(value, type) and issubclass(value, CellsTestPage) and \
-           value is not CellsTestPage:
+        if (
+            isinstance(value, type)
+            and issubclass(value, CellsTestPage)
+            and value is not CellsTestPage
+        ):
             try:
                 instance = value()
-                _pagesCache.setdefault(instance.category(), {})[
-                    value.__name__] = instance
+                _pagesCache.setdefault(instance.category(), {})[value.__name__] = instance
             except Exception:
                 traceback.print_exc()
 
@@ -65,8 +67,8 @@ class CellsTestService(ServiceBase):
     def serviceDisplay(serviceObject, instance=None, objType=None, queryArgs=None):
         queryArgs = queryArgs or {}
 
-        if 'category' in queryArgs and 'name' in queryArgs:
-            page = getPages()[queryArgs['category']][queryArgs['name']]
+        if "category" in queryArgs and "name" in queryArgs:
+            page = getPages()[queryArgs["category"]][queryArgs["name"]]
             contentsOverride = cells.Slot()
 
             pageSource = textwrap.dedent("".join(getsourcelines(page.cell.__func__)[0]))
@@ -75,9 +77,12 @@ class CellsTestService(ServiceBase):
                 if contentsOverride.get() is not None:
                     try:
                         locals = {}
-                        exec(contentsOverride.get(), sys.modules[
-                            type(page).__module__].__dict__, locals)
-                        return locals['cell'](page)
+                        exec(
+                            contentsOverride.get(),
+                            sys.modules[type(page).__module__].__dict__,
+                            locals,
+                        )
+                        return locals["cell"](page)
                     except Exception:
                         return cells.Traceback(traceback.format_exc())
 
@@ -86,9 +91,12 @@ class CellsTestService(ServiceBase):
             def onEnter(buffer, selection):
                 contentsOverride.set(buffer)
 
-            ed = cells.CodeEditor(keybindings={'Enter': onEnter},
-                                  noScroll=True, minLines=20,
-                                  onTextChange=lambda *args: None)
+            ed = cells.CodeEditor(
+                keybindings={"Enter": onEnter},
+                noScroll=True,
+                minLines=20,
+                onTextChange=lambda *args: None,
+            )
             ed.setContents(pageSource)
 
             description = page.text()
@@ -100,21 +108,17 @@ class CellsTestService(ServiceBase):
             def actualDisplay():
                 return cells.Card(cells.Text("nothing to display"), padding=10)
 
-        resultArea = cells.SplitView([
-            (cells.Subscribed(actualDisplay), 4),
-            (cells.Card(cells.Text(description), padding=2), 0)],
-            split="horizontal"
+        resultArea = cells.SplitView(
+            [
+                (cells.Subscribed(actualDisplay), 4),
+                (cells.Card(cells.Text(description), padding=2), 0),
+            ],
+            split="horizontal",
         )
 
-        inputArea = cells.SplitView(
-            [(selectionPanel(page), 2), (ed, 9)]
-        )
+        inputArea = cells.SplitView([(selectionPanel(page), 2), (ed, 9)])
 
-        return cells.ResizablePanel(
-            resultArea,
-            inputArea,
-            split="horizontal"
-        )
+        return cells.ResizablePanel(resultArea, inputArea, split="horizontal")
 
     def doWork(self, shouldStop):
         while not shouldStop.is_set():
@@ -125,6 +129,7 @@ def reload():
     """Force the process to kill itself. When you refresh,
     it'll be the new code."""
     import os
+
     os._exit(0)
 
 
@@ -134,8 +139,8 @@ def selectionPanel(page):
         for _, item in sorted(category.items()):
             displayName = "{}.{}".format(item.category(), item.name())
             url = "CellsTestService?{}".format(
-                urllib.parse.urlencode(
-                    dict(category=item.category(), name=item.name())))
+                urllib.parse.urlencode(dict(category=item.category(), name=item.name()))
+            )
             clickable = cells.Clickable(displayName, url, makeBold=item is page)
             availableCells.append(clickable)
     reloadInput = cells.Button(cells.Octicon("sync"), reload)

--- a/object_database/web/EditorDisplayService.py
+++ b/object_database/web/EditorDisplayService.py
@@ -42,15 +42,15 @@ class EditorDisplayService(ServiceBase):
         def onEnter(buffer, selection):
             contentsOverride.set(buffer)
 
-        ed = cells.CodeEditor(keybindings={'Enter': onEnter},
-                              noScroll=True, minLines=20,
-                              onTextChange=lambda *args: None)
+        ed = cells.CodeEditor(
+            keybindings={"Enter": onEnter},
+            noScroll=True,
+            minLines=20,
+            onTextChange=lambda *args: None,
+        )
 
         inputArea = cells.SplitView(
-            [
-                (cells.Button(cells.Octicon("sync"), reload), 1),
-                (ed, 25)
-            ], split="horizontal"
+            [(cells.Button(cells.Octicon("sync"), reload), 1), (ed, 25)], split="horizontal"
         )
 
         contentsOverride = cells.Slot()
@@ -59,26 +59,23 @@ class EditorDisplayService(ServiceBase):
             if contentsOverride.get() is not None:
                 try:
                     locals = {}
-                    exec(contentsOverride.get(), sys.modules[
-                        type(page).__module__].__dict__, locals)
-                    return locals['cell'](page)
+                    exec(
+                        contentsOverride.get(),
+                        sys.modules[type(page).__module__].__dict__,
+                        locals,
+                    )
+                    return locals["cell"](page)
                 except Exception:
                     return cells.Traceback(traceback.format_exc())
             else:
                 return cells.Sequence(
-                    [cells.Card(cells.Text("Row %s of 20" % (item + 1))) for item in
-                     range(20)]
+                    [cells.Card(cells.Text("Row %s of 20" % (item + 1))) for item in range(20)]
                 )
 
         # DISPLAY AREA
-        displayArea = cells.Card(
-            cells.Subscribed(actualDisplay)
-        )
+        displayArea = cells.Card(cells.Subscribed(actualDisplay))
 
-        return cells.SplitView([
-            (displayArea, 3),
-            (inputArea, 2)
-        ], split="vertical")
+        return cells.SplitView([(displayArea, 3), (inputArea, 2)], split="vertical")
 
     def doWork(self, shouldStop):
         while not shouldStop.is_set():
@@ -89,4 +86,5 @@ def reload():
     """Force the process to kill itself. When you refresh,
     it'll be the new code."""
     import os
+
     os._exit(0)

--- a/object_database/web/LoginPlugin.py
+++ b/object_database/web/LoginPlugin.py
@@ -35,6 +35,7 @@ class FlaskUser:
         We make these objects from our ObjectDB User classes so that Flask can
         handle them without having to hold a view into ObjectDB
     """
+
     @staticmethod
     def makeFromUser(user):
         if user is None:
@@ -62,7 +63,7 @@ class FlaskUser:
 
     @property
     def is_anonymous(self):
-        return True if self.username.lower() == 'anonymous' else False
+        return True if self.username.lower() == "anonymous" else False
 
     def get_id(self) -> str:
         return self.username  # must return unicode by Python 3 strings are unicode
@@ -74,6 +75,7 @@ class LoginPluginInterface:
         The derived class will register `/login` and `/logout` endpoints with
         the Flask app and it will provide a load_user method.
     """
+
     REQUIRED_KEYS = None
 
     def __init__(self, object_db, auth_plugins, config=None):
@@ -100,17 +102,18 @@ class LoginPluginInterface:
             for key in self.REQUIRED_KEYS:
                 if key not in config:
                     raise Exception(
-                        "{cls} missing configuration parameter '{key}'"
-                        .format(cls=self.__class__.__name__, key=key)
+                        "{cls} missing configuration parameter '{key}'".format(
+                            cls=self.__class__.__name__, key=key
+                        )
                     )
-                setattr(self, '_' + key, config[key])
+                setattr(self, "_" + key, config[key])
 
 
 class LoginForm(FlaskForm):
-    username = StringField('Username', validators=[DataRequired()])
-    password = PasswordField('Password', validators=[DataRequired()])
-    remember_me = BooleanField('Remember Me')
-    submit = SubmitField('Sign In')
+    username = StringField("Username", validators=[DataRequired()])
+    password = PasswordField("Password", validators=[DataRequired()])
+    remember_me = BooleanField("Remember Me")
+    submit = SubmitField("Sign In")
 
 
 USER_LOGIN_DURATION = 24 * 60 * 60  # 24 hours
@@ -132,16 +135,16 @@ class User:
         self.login_ip = ""
 
 
-def authorized_groups_text(authorized_groups, default_text='All') -> str:
+def authorized_groups_text(authorized_groups, default_text="All") -> str:
     """ Helper function that returns a string for display purposes. """
     res = default_text
     if authorized_groups:
-        res = ', '.join(authorized_groups)
+        res = ", ".join(authorized_groups)
     return res
 
 
 class LoginIpPlugin(LoginPluginInterface):
-    REQUIRED_KEYS = ['company_name']
+    REQUIRED_KEYS = ["company_name"]
 
     def __init__(self, db, auth_plugins, config=None):
         self._logger = logging.getLogger(__name__)
@@ -150,8 +153,9 @@ class LoginIpPlugin(LoginPluginInterface):
 
         if len(auth_plugins) != 1:
             raise Exception(
-                "LoginIpPlugin requires exactly 1 auth_plugin but {} were given."
-                .format(len(auth_plugins))
+                "LoginIpPlugin requires exactly 1 auth_plugin but {} were given.".format(
+                    len(auth_plugins)
+                )
             )
 
         self._auth_plugins = auth_plugins
@@ -162,8 +166,10 @@ class LoginIpPlugin(LoginPluginInterface):
         self.init_config(config)
 
     def init_app(self, flask_app):
-        flask_app.add_url_rule('/login', endpoint=None, view_func=self.login, methods=['GET', 'POST'])
-        flask_app.add_url_rule('/logout', endpoint=None, view_func=self.logout)
+        flask_app.add_url_rule(
+            "/login", endpoint=None, view_func=self.login, methods=["GET", "POST"]
+        )
+        flask_app.add_url_rule("/logout", endpoint=None, view_func=self.logout)
 
     @property
     def authorized_groups_text(self):
@@ -190,14 +196,14 @@ class LoginIpPlugin(LoginPluginInterface):
                 return error
 
         self._login_user(username, login_ip)
-        return ''
+        return ""
 
     def login(self):
         if current_user.is_authenticated:
             return redirect(next_url())
 
         if self.bypassAuth:
-            error = self._authenticate('anonymous', 'fake-pass')
+            error = self._authenticate("anonymous", "fake-pass")
             assert not error, error
             return redirect(next_url())
 
@@ -205,12 +211,12 @@ class LoginIpPlugin(LoginPluginInterface):
 
         def render(error=None):
             if error:
-                flash(error, 'danger')
+                flash(error, "danger")
             return render_template(
-                'login.html',
+                "login.html",
                 form=form,
                 title=self._company_name,
-                authorized_groups_text=self.authorized_groups_text
+                authorized_groups_text=self.authorized_groups_text,
             )
 
         if form.validate_on_submit():
@@ -228,7 +234,9 @@ class LoginIpPlugin(LoginPluginInterface):
     def logout(self):
         current_username = current_user.username
         self._logout_user(current_username)
-        return redirect(url_for('index'))  # FIXME: we are assuming the app has defined the 'index' endpoint
+        return redirect(
+            url_for("index")
+        )  # FIXME: we are assuming the app has defined the 'index' endpoint
 
     def load_user(self, username):
         with self._db.view():

--- a/object_database/web/cells/CellsTestMixin.py
+++ b/object_database/web/cells/CellsTestMixin.py
@@ -126,7 +126,8 @@ class CellsTestMixin:
                 self.assertEqual(
                     len(selected_cells),
                     expected_count,
-                    f"{len(selected_cells)} != {expected_count} for cells with tag '{step['tag']}'",
+                    f"{len(selected_cells)} != {expected_count} "
+                    + f"for cells with tag '{step['tag']}'",
                 )
 
             for cell in selected_cells:

--- a/object_database/web/cells/CellsTestMixin.py
+++ b/object_database/web/cells/CellsTestMixin.py
@@ -9,20 +9,18 @@ class CellsTestMixin:
 
     def assertNoCellExceptions(self, cells: Cells):
         exceptions = cells.childrenWithExceptions()
-        self.assertTrue(not exceptions, "\n\n".join([e.childByIndex(0).contents for e in exceptions]))
+        self.assertTrue(
+            not exceptions, "\n\n".join([e.childByIndex(0).contents for e in exceptions])
+        )
 
     def assertCellTagExists(self, cells: Cells, tag: str, expected_count=1):
-        res = self.waitForCells(
-            cells,
-            lambda: cells.findChildrenByTag(tag)
-        )
+        res = self.waitForCells(cells, lambda: cells.findChildrenByTag(tag))
         self.assertIsNotNone(res)
         self.assertEqual(len(res), expected_count)
 
     def assertCellTypeExists(self, cells: Cells, typ, expected_count=1):
         res = self.waitForCells(
-            cells,
-            lambda: cells.findChildrenMatching(lambda cell: isinstance(cell, typ))
+            cells, lambda: cells.findChildrenMatching(lambda cell: isinstance(cell, typ))
         )
         self.assertIsNotNone(res)
         self.assertEqual(len(res), expected_count)
@@ -101,7 +99,7 @@ class CellsTestMixin:
                 code = codeAndMaybeVars[0]
                 vars_in_ctx = codeAndMaybeVars[1]
 
-            vars_in_ctx['cell'] = cell
+            vars_in_ctx["cell"] = cell
 
             return code, vars_in_ctx
 
@@ -109,13 +107,13 @@ class CellsTestMixin:
         for step in script:
             selected_cells = []
 
-            if 'tag' in step:
-                selected_cells = root_cell.findChildrenByTag(step['tag'])
+            if "tag" in step:
+                selected_cells = root_cell.findChildrenByTag(step["tag"])
 
-            if 'cond' in step:
+            if "cond" in step:
                 really_selected_cells = []
                 for cell in selected_cells:
-                    code, vars_in_ctx = codeAndVars(step['cond'], cell)
+                    code, vars_in_ctx = codeAndVars(step["cond"], cell)
                     res = eval(compile(code, "<string>", "eval"), vars_in_ctx)
                     if res:
                         really_selected_cells.append(cell)
@@ -126,32 +124,30 @@ class CellsTestMixin:
 
             if expected_count is not None:
                 self.assertEqual(
-                    len(selected_cells), expected_count,
-                    f"{len(selected_cells)} != {expected_count} for cells with tag '{step['tag']}'"
+                    len(selected_cells),
+                    expected_count,
+                    f"{len(selected_cells)} != {expected_count} for cells with tag '{step['tag']}'",
                 )
 
             for cell in selected_cells:
-                if 'msg' in step:
-                    cell.onMessageWithTransaction(step['msg'])
+                if "msg" in step:
+                    cell.onMessageWithTransaction(step["msg"])
                     cells.renderMessages()
 
-                if 'check' in step:
-                    code, vars_in_ctx = codeAndVars(step['check'], cell)
+                if "check" in step:
+                    code, vars_in_ctx = codeAndVars(step["check"], cell)
 
                     res = eval(compile(code, "<string>", "eval"), vars_in_ctx)
-                    self.assertTrue(
-                        res,
-                        f"'{code}' is not True"
-                    )
+                    self.assertTrue(res, f"'{code}' is not True")
 
-                if 'script' in step:
-                    self.check_ui_script(cells, step['script'], root_cell=cell)
+                if "script" in step:
+                    self.check_ui_script(cells, step["script"], root_cell=cell)
 
     def expected_count_for_step(self, step):
-        if 'exp_cnt' in step:
-            return step['exp_cnt']
+        if "exp_cnt" in step:
+            return step["exp_cnt"]
 
-        if 'cond' in step:
+        if "cond" in step:
             return None
 
         return 1

--- a/object_database/web/cells/Messenger.py
+++ b/object_database/web/cells/Messenger.py
@@ -10,20 +10,16 @@ def cellUpdated(cell):
     if cell.parent is not None:
         parent_id = cell.parent.identity
 
-    structure = getStructure(
-        parent_id,
-        cell,
-        None,
-        expand=True)
+    structure = getStructure(parent_id, cell, None, expand=True)
     envelope = {
         "channel": "#main",
         "type": "#cellUpdated",
         "shouldDisplay": cell.shouldDisplay,
-        "extraData": cell.exportData
+        "extraData": cell.exportData,
     }
     structure.update(envelope)
     if cell.postscript:
-        structure['postscript'] = cell.postscript
+        structure["postscript"] = cell.postscript
 
     return structure
 
@@ -38,7 +34,7 @@ def cellDataUpdated(cell):
         "type": "#cellDataUpdated",
         "shouldDisplay": cell.shouldDisplay,
         "id": cell.identity,
-        "dataInfo": cell.exportData["dataInfo"]
+        "dataInfo": cell.exportData["dataInfo"],
     }
     return data
 
@@ -59,10 +55,10 @@ def cellDiscarded(cell):
     be sent over a websocket
     """
     return {
-        'channel': '#main',
-        'type': '#cellDiscarded',
-        'cellType': cell.__class__.__name__,
-        'id': cell.identity
+        "channel": "#main",
+        "type": "#cellDiscarded",
+        "cellType": cell.__class__.__name__,
+        "id": cell.identity,
     }
 
 
@@ -83,11 +79,7 @@ def appendPostscript(jsString):
     A JSON parsable dictionary that can
     be sent over a websocket
     """
-    return {
-        'channel': '#main',
-        'type': '#appendPostscript',
-        'script': jsString
-    }
+    return {"channel": "#main", "type": "#appendPostscript", "script": jsString}
 
 
 def getStructure(parent_id, cell, name_in_parent, expand=False):
@@ -144,7 +136,7 @@ def _getFlatStructure(parent_id, cell, name_in_parent):
         "nameInParent": name_in_parent,
         "parentId": parent_id,
         "namedChildren": own_children,
-        "extraData": cell.exportData
+        "extraData": cell.exportData,
     }
 
 
@@ -172,20 +164,20 @@ def _getExpandedStructure(parent_id, cell, name_in_parent):
         "extraData": cell.exportData,
         "nameInParent": name_in_parent,
         "parentId": parent_id,
-        "namedChildren": own_children
+        "namedChildren": own_children,
     }
 
 
 def _getExpandedChildren(cell):
     own_children = {}
     for child_name, child in cell.children.items():
-        own_children[child_name] = _resolveExpandedChild(cell.identity, child,
-                                                         child_name)
+        own_children[child_name] = _resolveExpandedChild(cell.identity, child, child_name)
     return own_children
 
 
 def _resolveExpandedChild(parent_id, cell_or_list, name_in_parent):
     if isinstance(cell_or_list, list):
-        return [_resolveExpandedChild(parent_id, cell, name_in_parent) for
-                cell in cell_or_list]
+        return [
+            _resolveExpandedChild(parent_id, cell, name_in_parent) for cell in cell_or_list
+        ]
     return _getExpandedStructure(parent_id, cell_or_list, name_in_parent)

--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -8,7 +8,6 @@ from object_database.web.cells.cells import (
     ensureSubscribedType,
     ensureSubscribedSchema,
     wrapCallback,
-
     # Classes
     GeventPipe,
     Cells,
@@ -62,7 +61,7 @@ from object_database.web.cells.cells import (
     AsyncDropdown,
     CircleLoader,
     Timestamp,
-    HorizontalSequence
+    HorizontalSequence,
 )
 
 from object_database.web.cells.views.split_view import SplitView
@@ -84,7 +83,7 @@ from object_database.web.cells.util import (
     Margin,
     MarginSides,
     MarginRight,
-    MarginLeft
+    MarginLeft,
 )
 
 from object_database.web.cells.views.resizable_panel import ResizablePanel

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -58,6 +58,7 @@ def registerDisplay(type, **context):
             is exactly matched in the parent cell. We'll check contexts in the
             order in which they were registered.
     """
+
     def registrar(displayFunc):
         ContextualDisplay._typeToDisplay.setdefault(type, []).append(
             (ContextualDisplay.ContextMatcher(context), displayFunc)
@@ -70,7 +71,7 @@ def registerDisplay(type, **context):
 
 def context(contextKey):
     """During cell evaluation, lookup context from our parent cell by name."""
-    if not hasattr(_cur_cell, 'cell'):
+    if not hasattr(_cur_cell, "cell"):
         raise Exception("Please call 'context' from within a message or cell update function.")
 
     return _cur_cell.cell.getContext(contextKey)
@@ -106,7 +107,7 @@ def augmentToBeUnique(listOfItems):
     output = []
     for x in listOfItems:
         counts[x] = counts.setdefault(x, 0) + 1
-        output.append((x, counts[x]-1))
+        output.append((x, counts[x] - 1))
 
     return output
 
@@ -120,8 +121,7 @@ class GeventPipe:
 
     def __init__(self):
         self.read_fd, self.write_fd = os.pipe()
-        self.fileobj = gevent.fileobject.FileObjectPosix(
-            self.read_fd, bufsize=2)
+        self.fileobj = gevent.fileobject.FileObjectPosix(self.read_fd, bufsize=2)
         self.netChange = 0
 
     def wait(self):
@@ -206,7 +206,7 @@ class Cells:
                     self._logger.error(
                         "Callback %s threw an unexpected exception:\n%s",
                         callback,
-                        traceback.format_exc()
+                        traceback.format_exc(),
                     )
         except queue.Empty:
             return
@@ -221,14 +221,12 @@ class Cells:
         self._gEventHasTransactions.trigger()
 
     def withRoot(self, root_cell, serialization_context=None, session_state=None):
-        self._root.setChild(
-            root_cell
-        )
+        self._root.setChild(root_cell)
         self._root.setContext(
             SessionState,
             session_state
             or self._root.context.get(SessionState)
-            or SessionState()._reset(self)
+            or SessionState()._reset(self),
         )
         self._root.withSerializationContext(
             serialization_context
@@ -321,13 +319,11 @@ class Cells:
                 del self._subscribedCells[subscription]
 
     def markDirty(self, cell):
-        assert not cell.garbageCollected, (cell, cell.text if isinstance(
-            cell, Text) else "")
+        assert not cell.garbageCollected, (cell, cell.text if isinstance(cell, Text) else "")
         self._dirtyNodes.add(cell)
 
     def markToDiscard(self, cell):
-        assert not cell.garbageCollected, (cell, cell.text if isinstance(
-            cell, Text) else "")
+        assert not cell.garbageCollected, (cell, cell.text if isinstance(cell, Text) else "")
 
         self._nodesToDiscard.add(cell)
         # TODO: lifecycle attribute; see cell.updateLifecycleState()
@@ -468,11 +464,10 @@ class Cells:
                         # to plain children dicts) in the near future.
                         if not isinstance(child_cell, Cell):
                             childname = node.children.findNameFor(child_cell)
-                            raise Exception("Cell of type %s had a non-cell child %s of type %s != Cell." % (
-                                type(node),
-                                childname,
-                                type(child_cell)
-                            ))
+                            raise Exception(
+                                "Cell of type %s had a non-cell child %s of type %s != Cell."
+                                % (type(node), childname, type(child_cell))
+                            )
                         if child_cell.cells:
                             child_cell.prepareForReuse()
                             # TODO: lifecycle attribute; see cell.updateLifecycleState()
@@ -480,11 +475,15 @@ class Cells:
 
                 except Exception:
                     self._logger.error(
-                        "Node %s had exception during recalculation:\n%s", node, traceback.format_exc())
+                        "Node %s had exception during recalculation:\n%s",
+                        node,
+                        traceback.format_exc(),
+                    )
                     self._logger.error(
-                        "Subscribed cell threw an exception:\n%s", traceback.format_exc())
+                        "Subscribed cell threw an exception:\n%s", traceback.format_exc()
+                    )
                     tracebackCell = Traceback(traceback.format_exc())
-                    node.children['content'] = tracebackCell
+                    node.children["content"] = tracebackCell
                 finally:
                     _cur_cell.cell = None
                     _cur_cell.isProcessingMessage = False
@@ -505,8 +504,7 @@ class Cells:
 
     def findChildrenByTag(self, tag, stopSearchingAtFoundTag=True):
         return self._root.findChildrenByTag(
-            tag,
-            stopSearchingAtFoundTag=stopSearchingAtFoundTag
+            tag, stopSearchingAtFoundTag=stopSearchingAtFoundTag
         )
 
     def findChildrenMatching(self, filtr):
@@ -533,7 +531,7 @@ class Slot:
 
         # mark the cells object present when we were created so we can trigger
         # it when we get updated.
-        if hasattr(_cur_cell, 'cell') and _cur_cell.cell is not None:
+        if hasattr(_cur_cell, "cell") and _cur_cell.cell is not None:
             self._cells = _cur_cell.cell.cells
         else:
             self._cells = None
@@ -549,7 +547,9 @@ class Slot:
         with self._lock:
             # we can only create a dependency if we're being read
             # as part of a cell's state recalculation.
-            if getattr(_cur_cell, 'cell', None) is not None and getattr(_cur_cell, 'isProcessingCell', False):
+            if getattr(_cur_cell, "cell", None) is not None and getattr(
+                _cur_cell, "isProcessingCell", False
+            ):
                 self._subscribedCells.add(_cur_cell.cell)
 
             return self._value
@@ -587,8 +587,7 @@ class SessionState(object):
 
     def _reset(self, cells):
         self._slots = {
-            k: Slot(v.getWithoutRegisteringDependency())
-            for k, v in self._slots.items()
+            k: Slot(v.getWithoutRegisteringDependency()) for k, v in self._slots.items()
         }
 
         for s in self._slots.values():
@@ -597,8 +596,7 @@ class SessionState(object):
                 try:
                     s._value.prepareForReuse()
                 except Exception:
-                    logging.warn(
-                        f"Reusing a Cell slot could create a problem: {s._value}")
+                    logging.warn(f"Reusing a Cell slot could create a problem: {s._value}")
         return self
 
     def _slotFor(self, name):
@@ -705,14 +703,14 @@ class Cell:
         message sends to the client. In the future, this should be integrated
         into a general lifecycle management scheme.
         """
-        if (self.wasCreated):
+        if self.wasCreated:
             self.wasCreated = False
-        if (self.wasUpdated):
+        if self.wasUpdated:
             self.wasUpdated = False
-        if (self.wasDataUpdated):
+        if self.wasDataUpdated:
             self.wasDataUpdated = False
         # NOTE: self.wasRemoved is set to False for self.prepareForReuse
-        if (self.wasRemoved):
+        if self.wasRemoved:
             self.wasRemoved = False
 
     def evaluateWithDependencies(self, fun):
@@ -748,10 +746,7 @@ class Cell:
                 return cells
 
         for child in self.children.allChildren:
-            cells.extend(
-                child.findChildrenByTag(
-                    tag, stopSearchingAtFoundTag)
-            )
+            cells.extend(child.findChildrenByTag(tag, stopSearchingAtFoundTag))
 
         return cells
 
@@ -796,12 +791,10 @@ class Cell:
             except RevisionConflictException:
                 tries += 1
                 if tries > MAX_TRIES or time.time() - t0 > MAX_TIMEOUT:
-                    self._logger.error(
-                        "OnMessage timed out. This should really fail.")
+                    self._logger.error("OnMessage timed out. This should really fail.")
                     return
             except Exception:
-                self._logger.error(
-                    "Exception in dropdown logic:\n%s", traceback.format_exc())
+                self._logger.error("Exception in dropdown logic:\n%s", traceback.format_exc())
                 return
             finally:
                 _cur_cell.cell = None
@@ -837,8 +830,14 @@ class Cell:
         return self.cells.db.transaction().setSerializationContext(self.serializationContext)
 
     def prepare(self):
-        if self.serializationContext is TypedPythonCodebase.coreSerializationContext() and self.parent is not None:
-            if self.parent.serializationContext is TypedPythonCodebase.coreSerializationContext():
+        if (
+            self.serializationContext is TypedPythonCodebase.coreSerializationContext()
+            and self.parent is not None
+        ):
+            if (
+                self.parent.serializationContext
+                is TypedPythonCodebase.coreSerializationContext()
+            ):
                 self.parent.prepare()
             self.serializationContext = self.parent.serializationContext
 
@@ -926,7 +925,9 @@ class Cell:
     @property
     def identity(self):
         if self._identity is None:
-            assert self.cells is not None, "Can't ask for identity for %s as it's not part of a cells package" % self
+            assert self.cells is not None, (
+                "Can't ask for identity for %s as it's not part of a cells package" % self
+            )
             self._identity = self.cells._newID()
         return self._identity
 
@@ -983,13 +984,13 @@ class Card(Cell):
 
     def recalculate(self):
         bodyCell = Cell.makeCell(self.body)
-        self.children['body'] = bodyCell
+        self.children["body"] = bodyCell
 
         if self.header is not None:
             headerCell = Cell.makeCell(self.header)
-            self.children['header'] = headerCell
+            self.children["header"] = headerCell
 
-        self.exportData['padding'] = self.padding
+        self.exportData["padding"] = self.padding
 
     def sortsAs(self):
         return self.contents.sortsAs()
@@ -999,7 +1000,7 @@ class CardTitle(Cell):
     def __init__(self, inner):
         super().__init__()
         innerCell = Cell.makeCell(inner)
-        self.children['inner'] = innerCell
+        self.children["inner"] = innerCell
 
     def sortsAs(self):
         return self.inner.sortsAs()
@@ -1030,18 +1031,21 @@ class Modal(Cell):
         self.buttons = {}
         for i in range(len(buttons)):
             button = buttons[i]
-            self.buttons['____button_{}__'.format(i)] = button
+            self.buttons["____button_{}__".format(i)] = button
 
     def recalculate(self):
-        self.children.addFromDict({
-            'buttons': list(self.buttons.values()),
-            'title': self.title,
-            'message': self.message})
-        self.exportData['show'] = self.show.get()
+        self.children.addFromDict(
+            {
+                "buttons": list(self.buttons.values()),
+                "title": self.title,
+                "message": self.message,
+            }
+        )
+        self.exportData["show"] = self.show.get()
 
 
 class Octicon(Cell):
-    def __init__(self, which, color='black'):
+    def __init__(self, which, color="black"):
         super().__init__()
         self.whichOcticon = which
         self.color = color
@@ -1050,23 +1054,23 @@ class Octicon(Cell):
         return self.whichOcticon
 
     def recalculate(self):
-        octiconClasses = ['octicon', ('octicon-%s' % self.whichOcticon)]
-        self.exportData['octiconClasses'] = octiconClasses
-        self.exportData['color'] = self.color
+        octiconClasses = ["octicon", ("octicon-%s" % self.whichOcticon)]
+        self.exportData["octiconClasses"] = octiconClasses
+        self.exportData["color"] = self.color
 
 
 class Badge(Cell):
-    def __init__(self, inner, style='primary'):
+    def __init__(self, inner, style="primary"):
         super().__init__()
         self.inner = self.makeCell(inner)
         self.style = style
-        self.exportData['badgeStyle'] = self.style
+        self.exportData["badgeStyle"] = self.style
 
     def sortsAs(self):
         return self.inner.sortsAs()
 
     def recalculate(self):
-        self.children['inner'] = self.inner
+        self.children["inner"] = self.inner
 
 
 class CollapsiblePanel(Cell):
@@ -1081,10 +1085,10 @@ class CollapsiblePanel(Cell):
 
     def recalculate(self):
         expanded = self.evaluateWithDependencies(self.isExpanded)
-        self.exportData['isExpanded'] = expanded
-        self.children['content'] = self.content
+        self.exportData["isExpanded"] = expanded
+        self.children["content"] = self.content
         if expanded:
-            self.children['panel'] = self.panel
+            self.children["panel"] = self.panel
 
 
 class Text(Cell):
@@ -1099,9 +1103,9 @@ class Text(Cell):
 
     def recalculate(self):
         escapedText = html.escape(str(self.text)) if self.text else " "
-        self.exportData['escapedText'] = escapedText
-        self.exportData['rawText'] = self.text
-        self.exportData['textColor'] = self.text_color
+        self.exportData["escapedText"] = escapedText
+        self.exportData["rawText"] = self.text
+        self.exportData["textColor"] = self.text_color
 
 
 class Padding(Cell):
@@ -1115,7 +1119,7 @@ class Padding(Cell):
 class Span(Cell):
     def __init__(self, text):
         super().__init__()
-        self.exportData['text'] = text
+        self.exportData["text"] = text
 
     def sortsAs(self):
         return self.contents
@@ -1139,7 +1143,7 @@ class Sequence(Cell):
         elements = [Cell.makeCell(x) for x in elements]
 
         self.elements = elements
-        self.children['elements'] = elements
+        self.children["elements"] = elements
         self.overflow = overflow
         self.margin = margin
         self.isFlexParent = False
@@ -1155,9 +1159,9 @@ class Sequence(Cell):
     def recalculate(self):
         self.updateChildren()
         if self.isFlexParent:
-            self.exportData['flexParent'] = True
-        self.children['elements'] = self.elements
-        self.exportData['margin'] = self.margin
+            self.exportData["flexParent"] = True
+        self.children["elements"] = self.elements
+        self.exportData["margin"] = self.margin
 
     def updateChildren(self):
         newElements = []
@@ -1170,7 +1174,7 @@ class Sequence(Cell):
             else:
                 newElements.append(childCell)
         self.elements = newElements
-        self.children['elements'] = self.elements
+        self.children["elements"] = self.elements
 
     def sortsAs(self):
         if self.elements:
@@ -1212,9 +1216,9 @@ class HorizontalSequence(Cell):
     def recalculate(self):
         self.updateChildren()
         if self.isFlexParent:
-            self.exportData['flexParent'] = True
-        self.exportData['margin'] = self.margin
-        self.exportData['wrap'] = self.wrap
+            self.exportData["flexParent"] = True
+        self.exportData["margin"] = self.margin
+        self.exportData["wrap"] = self.wrap
 
     def updateChildren(self):
         newElements = []
@@ -1227,7 +1231,7 @@ class HorizontalSequence(Cell):
             else:
                 newElements.append(childCell)
         self.elements = newElements
-        self.children['elements'] = self.elements
+        self.children["elements"] = self.elements
 
     def sortAs(self):
         if self.elements:
@@ -1241,7 +1245,7 @@ class Columns(Cell):
         elements = [Cell.makeCell(x) for x in elements]
 
         self.elements = elements
-        self.children['elements'] = self.elements
+        self.children["elements"] = self.elements
 
     def __add__(self, other):
         other = Cell.makeCell(other)
@@ -1268,16 +1272,19 @@ class HeaderBar(Cell):
         self.centerItems = centerItems
         self.rightItems = rightItems
 
-        self.children.addFromDict({
-            'leftItems': self.leftItems,
-            'centerItems': self.centerItems,
-            'rightItems': self.rightItems})
+        self.children.addFromDict(
+            {
+                "leftItems": self.leftItems,
+                "centerItems": self.centerItems,
+                "rightItems": self.rightItems,
+            }
+        )
 
 
 class Main(Cell):
     def __init__(self, child):
         super().__init__()
-        self.children['child'] = child
+        self.children["child"] = child
 
 
 class _NavTab(Cell):
@@ -1290,19 +1297,19 @@ class _NavTab(Cell):
         self.child = child
 
     def recalculate(self):
-        self.exportData['clickData'] = {
-            'event': 'click',
-            'ix': str(self.index),
-            'target_cell': self.target
+        self.exportData["clickData"] = {
+            "event": "click",
+            "ix": str(self.index),
+            "target_cell": self.target,
         }
 
         if self.index == self.slot.get():
-            self.exportData['isActive'] = True
+            self.exportData["isActive"] = True
         else:
-            self.exportData['isActive'] = False
+            self.exportData["isActive"] = False
 
         childCell = Cell.makeCell(self.child)
-        self.children['child'] = childCell
+        self.children["child"] = childCell
 
 
 class Tabs(Cell):
@@ -1320,20 +1327,20 @@ class Tabs(Cell):
         self.whichSlot.set(index)
 
     def recalculate(self):
-        displayCell = Subscribed(
-            lambda: self.headersAndChildren[self.whichSlot.get()][1])
-        self.children['display'] = displayCell
-        self.children['headers'] = []
+        displayCell = Subscribed(lambda: self.headersAndChildren[self.whichSlot.get()][1])
+        self.children["display"] = displayCell
+        self.children["headers"] = []
 
         headersToAdd = []
         for i in range(len(self.headersAndChildren)):
             headerCell = _NavTab(
-                self.whichSlot, i, self._identity, self.headersAndChildren[i][0])
+                self.whichSlot, i, self._identity, self.headersAndChildren[i][0]
+            )
             headersToAdd.append(headerCell)
-        self.children['headers'] = headersToAdd
+        self.children["headers"] = headersToAdd
 
     def onMessage(self, msgFrame):
-        self.whichSlot.set(int(msgFrame['ix']))
+        self.whichSlot.set(int(msgFrame["ix"]))
 
 
 class Dropdown(Cell):
@@ -1353,13 +1360,16 @@ class Dropdown(Cell):
         super().__init__()
 
         if singleLambda is not None:
+
             def makeCallback(cell):
                 def callback():
                     singleLambda(cell)
+
                 return callback
 
-            self.headersAndLambdas = [(header, makeCallback(header))
-                                      for header in headersAndLambdas]
+            self.headersAndLambdas = [
+                (header, makeCallback(header)) for header in headersAndLambdas
+            ]
         else:
             self.headersAndLambdas = headersAndLambdas
 
@@ -1369,15 +1379,15 @@ class Dropdown(Cell):
         return self.title.sortsAs()
 
     def recalculate(self):
-        self.children['title'] = self.title
-        self.children['dropdownItems'] = []
+        self.children["title"] = self.title
+        self.children["dropdownItems"] = []
 
         # Because the items here are not separate cells,
         # we have to perform an extra hack of a dict
         # to get the proper data to the temporary
         # JS Component
-        self.exportData['targetIdentity'] = self.identity
-        self.exportData['dropdownItemInfo'] = {}
+        self.exportData["targetIdentity"] = self.identity
+        self.exportData["dropdownItemInfo"] = {}
 
         itemsToAdd = []
         for i in range(len(self.headersAndLambdas)):
@@ -1385,20 +1395,21 @@ class Dropdown(Cell):
             childCell = Cell.makeCell(header)
             itemsToAdd.append(childCell)
             if not isinstance(onDropdown, str):
-                self.exportData['dropdownItemInfo'][i] = 'callback'
+                self.exportData["dropdownItemInfo"][i] = "callback"
             else:
-                self.exportData['dropdownItemInfo'][i] = onDropdown
-        self.children['dropdownItems'] = itemsToAdd
+                self.exportData["dropdownItemInfo"][i] = onDropdown
+        self.children["dropdownItems"] = itemsToAdd
 
     def onMessage(self, msgFrame):
         self._logger.info(msgFrame)
-        fun = self.headersAndLambdas[msgFrame['ix']][1]
+        fun = self.headersAndLambdas[msgFrame["ix"]][1]
         fun()
 
 
 class CircleLoader(Cell):
     """A simple circular loading indicator
     """
+
     def __init__(self):
         super().__init__()
 
@@ -1425,6 +1436,7 @@ class AsyncDropdown(Cell):
             )
 
     """
+
     def __init__(self, labelText, contentCellFunc, loadingIndicatorCell=None):
         """
         Parameters
@@ -1445,19 +1457,21 @@ class AsyncDropdown(Cell):
         super().__init__()
         self.slot = Slot(False)
         self.labelText = labelText
-        self.exportData['labelText'] = self.labelText
+        self.exportData["labelText"] = self.labelText
         if not loadingIndicatorCell:
             loadingIndicatorCell = CircleLoader()
-        self.contentCell = Cell.makeCell(AsyncDropdownContent(self.slot, contentCellFunc, loadingIndicatorCell))
-        self.children['content'] = Cell.makeCell(self.contentCell)
+        self.contentCell = Cell.makeCell(
+            AsyncDropdownContent(self.slot, contentCellFunc, loadingIndicatorCell)
+        )
+        self.children["content"] = Cell.makeCell(self.contentCell)
 
     def onMessage(self, messageFrame):
         """On `dropdown` events sent to this
         Cell over the socket, we will be told
         whether the dropdown menu is open or not
         """
-        if messageFrame['event'] == 'dropdown':
-            self.slot.set(not messageFrame['isOpen'])
+        if messageFrame["event"] == "dropdown":
+            self.slot.set(not messageFrame["isOpen"])
 
 
 class AsyncDropdownContent(Cell):
@@ -1479,6 +1493,7 @@ class AsyncDropdownContent(Cell):
     the front-end, meaning the drawer would never open
     or close since Dropdowns render closed initially.
     """
+
     def __init__(self, slot, contentFunc, loadingIndicatorCell):
         """
         Parameters
@@ -1504,8 +1519,7 @@ class AsyncDropdownContent(Cell):
         self.contentFunc = contentFunc
         self.loadingCell = loadingIndicatorCell
         self.contentCell = Subscribed(self.changeHandler)
-        self.children.addFromDict({
-            'content': Cell.makeCell(self.contentCell)})
+        self.children.addFromDict({"content": Cell.makeCell(self.contentCell)})
 
     def changeHandler(self):
         """If the slot is true, the
@@ -1529,23 +1543,23 @@ class Container(Cell):
     def __init__(self, child=None):
         super().__init__()
         if child is None:
-            self.children['child'] = None
+            self.children["child"] = None
         else:
             childCell = Cell.makeCell(child)
-            self.children['child'] = childCell
+            self.children["child"] = childCell
 
     def setChild(self, child):
         self.setContents("", child)
 
     def setContents(self, newContents, newChildren):
-        self.children['child'] = Cell.makeCell(newChildren)
+        self.children["child"] = Cell.makeCell(newChildren)
         self.markDirty()
 
 
 class Scrollable(Container):
     def __init__(self, child=None, height=None):
         super().__init__(child)
-        self.exportData['height'] = height
+        self.exportData["height"] = height
 
 
 class RootCell(Container):
@@ -1570,7 +1584,7 @@ class Traceback(Cell):
         super().__init__()
         self.traceback = traceback
         tracebackCell = Cell.makeCell(traceback)
-        self.children['traceback'] = tracebackCell
+        self.children["traceback"] = tracebackCell
 
     def sortsAs(self):
         return self.traceback
@@ -1584,7 +1598,7 @@ class Code(Cell):
         super().__init__()
         self.codeContents = codeContents
         codeContentsCell = Cell.makeCell(codeContents)
-        self.children['code'] = codeContentsCell
+        self.children["code"] = codeContentsCell
 
     def sortsAs(self):
         return self.codeContents
@@ -1632,8 +1646,8 @@ class ContextualDisplay(Cell):
     def recalculate(self):
         with self.view():
             childCell = self.getChild()
-            self.children['child'] = childCell
-            self.exportData['objectType'] = str(type(self.obj))
+            self.children["child"] = childCell
+            self.exportData["objectType"] = str(type(self.obj))
 
 
 class Subscribed(Cell):
@@ -1689,15 +1703,15 @@ class Subscribed(Cell):
                     self.wrapsSequence = True
                 elif isinstance(newCell, HorizontalSequence):
                     self.wrapsHorizSequence = True
-                self.children['content'] = newCell
+                self.children["content"] = newCell
             except SubscribeAndRetry:
                 raise
             except Exception:
-                tracebackCell = Traceback(
-                    traceback.format_exc())
-                self.children['content'] = tracebackCell
+                tracebackCell = Traceback(traceback.format_exc())
+                self.children["content"] = tracebackCell
                 self._logger.error(
-                    "Subscribed inner function threw exception:\n%s", traceback.format_exc())
+                    "Subscribed inner function threw exception:\n%s", traceback.format_exc()
+                )
 
             self._resetSubscriptionsToViewReads(v)
 
@@ -1732,7 +1746,8 @@ class SubscribedSequence(Cell):
         The axis along which this SubscribedSequence
         should lay itself out.
     """
-    def __init__(self, itemsFun, rendererFun, orientation='vertical'):
+
+    def __init__(self, itemsFun, rendererFun, orientation="vertical"):
         """
         Parameters
         ----------
@@ -1784,9 +1799,9 @@ class SubscribedSequence(Cell):
             self._updateExistingItems()
             self.updateChildren()
 
-            self.exportData['orientation'] = self.orientation
+            self.exportData["orientation"] = self.orientation
             if self.isFlexParent:
-                self.exportData['flexParent'] = True
+                self.exportData["flexParent"] = True
 
     def updateChildren(self):
         """Updates the stored children and namedChildren
@@ -1818,11 +1833,11 @@ class SubscribedSequence(Cell):
 
             self._processChild(current_child, new_children)
 
-        self.children['elements'] = new_children
+        self.children["elements"] = new_children
 
     def sortAs(self):
-        if len(self.children['elements']):
-            return self.children['elements'][0].sortAs()
+        if len(self.children["elements"]):
+            return self.children["elements"][0].sortAs()
 
     def _processChild(self, child, children):
         """Determines whether or not to flatten nested
@@ -1838,7 +1853,7 @@ class SubscribedSequence(Cell):
             # or SubscribedSequence of some kind.
             # In this case, we need to flatten its elements.
             # Note that only matching orientations flatten.
-            children += child.children['content'].children['elements']
+            children += child.children["content"].children["elements"]
         else:
             children.append(child)
 
@@ -1852,8 +1867,8 @@ class SubscribedSequence(Cell):
             raise
         except Exception:
             self._logger.error(
-                "SubscribedSequence itemsFun threw exception:\n%s",
-                traceback.format_exc())
+                "SubscribedSequence itemsFun threw exception:\n%s", traceback.format_exc()
+            )
             self.items = []
 
     def _updateExistingItems(self):
@@ -1870,15 +1885,15 @@ class SubscribedSequence(Cell):
         """Returns true if this object wraps
         a Subscribed that wraps a Sequence that
         has the same orientation as itself"""
-        if self.orientation == 'vertical':
+        if self.orientation == "vertical":
             return child.wrapsSequence
-        elif self.orientation == 'horizontal':
+        elif self.orientation == "horizontal":
             return child.wrapsHorizSequence
         return False
 
 
 def HorizontalSubscribedSequence(itemsFun, rendererFun):
-    return SubscribedSequence(itemsFun, rendererFun, orientation='horizontal')
+    return SubscribedSequence(itemsFun, rendererFun, orientation="horizontal")
 
 
 HSubscribedSequence = HorizontalSubscribedSequence
@@ -1899,18 +1914,16 @@ class Popover(Cell):
         contentCell = Cell.makeCell(contents)
         detailCell = Cell.makeCell(detail)
         titleCell = Cell.makeCell(title)
-        self.children.addFromDict({
-            'content': contentCell,
-            'detail': detailCell,
-            'title': titleCell
-        })
+        self.children.addFromDict(
+            {"content": contentCell, "detail": detailCell, "title": titleCell}
+        )
 
     def recalculate(self):
-        self.exportData['width'] = self.width
+        self.exportData["width"] = self.width
 
     def sortsAs(self):
-        if self.children.hasChildNamed('title'):
-            return self.children['title'].sortAs()
+        if self.children.hasChildNamed("title"):
+            return self.children["title"].sortAs()
 
 
 class Grid(Cell):
@@ -1946,7 +1959,8 @@ class Grid(Cell):
                 raise
             except Exception:
                 self._logger.error(
-                    "Row fun calc threw an exception:\n%s", traceback.format_exc())
+                    "Row fun calc threw an exception:\n%s", traceback.format_exc()
+                )
                 self.rows = []
             try:
                 self.cols = augmentToBeUnique(self.colFun())
@@ -1954,56 +1968,53 @@ class Grid(Cell):
                 raise
             except Exception:
                 self._logger.error(
-                    "Col fun calc threw an exception:\n%s", traceback.format_exc())
+                    "Col fun calc threw an exception:\n%s", traceback.format_exc()
+                )
                 self.cols = []
 
             self._resetSubscriptionsToViewReads(v)
 
-        new_named_children = {
-            'headers': [],
-            'rowLabels': [],
-            'dataCells': []
-        }
+        new_named_children = {"headers": [], "rowLabels": [], "dataCells": []}
         seen = set()
 
         for col_ix, col in enumerate(self.cols):
             seen.add((None, col))
             if (None, col) in self.existingItems:
-                new_named_children['headers'].append(self.existingItems[(None, col)])
+                new_named_children["headers"].append(self.existingItems[(None, col)])
             else:
                 try:
                     headerCell = Cell.makeCell(self.headerFun(col[0]))
                     self.existingItems[(None, col)] = headerCell
-                    new_named_children['headers'].append(headerCell)
+                    new_named_children["headers"].append(headerCell)
                 except SubscribeAndRetry:
                     raise
                 except Exception:
                     tracebackCell = Traceback(traceback.format_exc)()
                     self.existingItems[(None, col)] = tracebackCell
-                    new_named_children['headers'].append(tracebackCell)
+                    new_named_children["headers"].append(tracebackCell)
 
         if self.rowLabelFun is not None:
             for row_ix, row in enumerate(self.rows):
                 seen.add((None, row))
                 if (row, None) in self.existingItems:
                     rowLabelCell = self.existingItems[(row, None)]
-                    new_named_children['rowLabels'].append(rowLabelCell)
+                    new_named_children["rowLabels"].append(rowLabelCell)
                 else:
                     try:
                         rowLabelCell = Cell.makeCell(self.rowLabelFun(row[0]))
                         self.existingItems[(row, None)] = rowLabelCell
-                        new_named_children['rowLabels'].append(rowLabelCell)
+                        new_named_children["rowLabels"].append(rowLabelCell)
                     except SubscribeAndRetry:
                         raise
                     except Exception:
                         tracebackCell = Traceback(traceback.format_exc())
                         self.existingItems[(row, None)] = tracebackCell
-                        new_named_children['rowLabels'].append(tracebackCell)
+                        new_named_children["rowLabels"].append(tracebackCell)
 
         seen = set()
         for row_ix, row in enumerate(self.rows):
             new_named_children_column = []
-            new_named_children['dataCells'].append(new_named_children_column)
+            new_named_children["dataCells"].append(new_named_children_column)
             for col_ix, col in enumerate(self.cols):
                 seen.add((row, col))
                 if (row, col) in self.existingItems:
@@ -2027,9 +2038,9 @@ class Grid(Cell):
             if i not in seen:
                 del self.existingItems[i]
 
-        self.exportData['rowNum'] = len(self.rows)
-        self.exportData['colNum'] = len(self.cols)
-        self.exportData['hasTopHeader'] = (self.rowLabelFun is not None)
+        self.exportData["rowNum"] = len(self.rows)
+        self.exportData["colNum"] = len(self.cols)
+        self.exportData["hasTopHeader"] = self.rowLabelFun is not None
 
 
 class SortWrapper:
@@ -2069,10 +2080,10 @@ class SingleLineTextBox(Cell):
 
     def recalculate(self):
         if self.pattern:
-            self.exportData['pattern'] = self.pattern
+            self.exportData["pattern"] = self.pattern
 
     def onMessage(self, msgFrame):
-        self.slot.set(msgFrame['text'])
+        self.slot.set(msgFrame["text"])
 
 
 class Table(Cell):
@@ -2160,13 +2171,12 @@ class Table(Cell):
 
         page = 0
         try:
-            page = max(0, int(self.curPage.get())-1)
+            page = max(0, int(self.curPage.get()) - 1)
             page = min(page, (len(rows) - 1) // self.maxRowsPerPage)
         except Exception:
-            self._logger.error(
-                "Failed to parse current page: %s", traceback.format_exc())
+            self._logger.error("Failed to parse current page: %s", traceback.format_exc())
 
-        return rows[page * self.maxRowsPerPage:(page+1) * self.maxRowsPerPage]
+        return rows[page * self.maxRowsPerPage : (page + 1) * self.maxRowsPerPage]
 
     def makeHeaderCell(self, col_ix):
         col = self.cols[col_ix]
@@ -2179,13 +2189,15 @@ class Table(Cell):
                 return ""
             return Octicon("arrow-up" if not self.sortColumnAscending.get() else "arrow-down")
 
-        cell = Cell.makeCell(self.headerFun(col)).nowrap() >> \
-            Padding() >> Subscribed(icon).nowrap()
+        cell = (
+            Cell.makeCell(self.headerFun(col)).nowrap()
+            >> Padding()
+            >> Subscribed(icon).nowrap()
+        )
 
         def onClick():
             if self.sortColumn.get() == col_ix:
-                self.sortColumnAscending.set(
-                    not self.sortColumnAscending.get())
+                self.sortColumnAscending.set(not self.sortColumnAscending.get())
             else:
                 self.sortColumn.set(col_ix)
                 self.sortColumnAscending.set(False)
@@ -2193,12 +2205,18 @@ class Table(Cell):
         res = Clickable(cell, onClick, makeBold=True)
 
         if self.columnFilters[col].get() is None:
-            res = res.nowrap() >> Clickable(Octicon("search"),
-                                            lambda: self.columnFilters[col].set("")).nowrap()
+            res = (
+                res.nowrap()
+                >> Clickable(
+                    Octicon("search"), lambda: self.columnFilters[col].set("")
+                ).nowrap()
+            )
         else:
-            res = res >> SingleLineTextBox(self.columnFilters[col]).nowrap() >> \
-                Button(Octicon("x"), lambda: self.columnFilters[col].set(
-                    None), small=True)
+            res = (
+                res
+                >> SingleLineTextBox(self.columnFilters[col]).nowrap()
+                >> Button(Octicon("x"), lambda: self.columnFilters[col].set(None), small=True)
+            )
 
         return Card(res, padding=1)
 
@@ -2210,7 +2228,8 @@ class Table(Cell):
                 raise
             except Exception:
                 self._logger.error(
-                    "Col fun calc threw an exception:\n%s", traceback.format_exc())
+                    "Col fun calc threw an exception:\n%s", traceback.format_exc()
+                )
                 self.cols = []
 
             try:
@@ -2222,40 +2241,41 @@ class Table(Cell):
                 raise
             except Exception:
                 self._logger.error(
-                    "Row fun calc threw an exception:\n%s", traceback.format_exc())
+                    "Row fun calc threw an exception:\n%s", traceback.format_exc()
+                )
                 self.rows = []
 
             self._resetSubscriptionsToViewReads(v)
 
         new_named_children = {
-            'headers': [],
-            'dataCells': [],
-            'page': None,
-            'right': None,
-            'left': None
+            "headers": [],
+            "dataCells": [],
+            "page": None,
+            "right": None,
+            "left": None,
         }
         seen = set()
 
         for col_ix, col in enumerate(self.cols):
             seen.add((None, col))
             if (None, col) in self.existingItems:
-                new_named_children['headers'].append(self.existingItems[(None, col)])
+                new_named_children["headers"].append(self.existingItems[(None, col)])
             else:
                 try:
                     headerCell = self.makeHeaderCell(col_ix)
                     self.existingItems[(None, col)] = headerCell
-                    new_named_children['headers'].append(headerCell)
+                    new_named_children["headers"].append(headerCell)
                 except SubscribeAndRetry:
                     raise
                 except Exception:
                     tracebackCell = Traceback(traceback.format_exc())
                     self.existingItems[(None, col)] = tracebackCell
-                    new_named_children['headers'].append(tracebackCell)
+                    new_named_children["headers"].append(tracebackCell)
 
         seen = set()
         for row_ix, row in enumerate(self.rows):
             new_named_children_columns = []
-            new_named_children['dataCells'].append(new_named_children_columns)
+            new_named_children["dataCells"].append(new_named_children_columns)
             for col_ix, col in enumerate(self.cols):
                 seen.add((row, col))
                 if (row, col) in self.existingItems:
@@ -2279,11 +2299,11 @@ class Table(Cell):
             if i not in seen:
                 del self.existingItems[i]
 
-        totalPages = ((len(self.filteredRows) - 1) // self.maxRowsPerPage + 1)
+        totalPages = (len(self.filteredRows) - 1) // self.maxRowsPerPage + 1
 
         if totalPages <= 1:
             pageCell = Cell.makeCell(totalPages).nowrap()
-            self.children['page'] = pageCell
+            self.children["page"] = pageCell
         else:
             pageCell = (
                 SingleLineTextBox(self.curPage, pattern="[0-9]+")
@@ -2291,36 +2311,30 @@ class Table(Cell):
                 .height(20)
                 .nowrap()
             )
-            self.children['page'] = pageCell
+            self.children["page"] = pageCell
         if self.curPage.get() == "1":
-            leftCell = Octicon(
-                "triangle-left", color="lightgray").nowrap()
-            self.children['left'] = leftCell
+            leftCell = Octicon("triangle-left", color="lightgray").nowrap()
+            self.children["left"] = leftCell
         else:
-            leftCell = (
-                Clickable(
-                    Octicon("triangle-left"),
-                    lambda: self.curPage.set(str(int(self.curPage.get())-1))
-                ).nowrap()
-            )
-            self.children['left'] = leftCell
+            leftCell = Clickable(
+                Octicon("triangle-left"),
+                lambda: self.curPage.set(str(int(self.curPage.get()) - 1)),
+            ).nowrap()
+            self.children["left"] = leftCell
         if self.curPage.get() == str(totalPages):
-            rightCell = Octicon(
-                "triangle-right", color="lightgray").nowrap()
-            self.children['right'] = rightCell
+            rightCell = Octicon("triangle-right", color="lightgray").nowrap()
+            self.children["right"] = rightCell
         else:
-            rightCell = (
-                Clickable(
-                    Octicon("triangle-right"),
-                    lambda: self.curPage.set(str(int(self.curPage.get())+1))
-                ).nowrap()
-            )
-            self.children['right'] = rightCell
+            rightCell = Clickable(
+                Octicon("triangle-right"),
+                lambda: self.curPage.set(str(int(self.curPage.get()) + 1)),
+            ).nowrap()
+            self.children["right"] = rightCell
 
         # temporary js WS refactoring data
-        self.exportData['totalPages'] = totalPages
-        self.exportData['numColumns'] = len(self.cols)
-        self.exportData['numRows'] = len(self.rows)
+        self.exportData["totalPages"] = totalPages
+        self.exportData["numColumns"] = len(self.cols)
+        self.exportData["numRows"] = len(self.rows)
 
 
 class Clickable(Cell):
@@ -2332,19 +2346,21 @@ class Clickable(Cell):
 
     def calculatedOnClick(self):
         if isinstance(self.f, str):
-            return quoteForJs("window.location.href = '__url__'".replace("__url__", quoteForJs(self.f, "'")), '"')
+            return quoteForJs(
+                "window.location.href = '__url__'".replace("__url__", quoteForJs(self.f, "'")),
+                '"',
+            )
         else:
-            return (
-                "cellSocket.sendString(JSON.stringify({'event':'click', 'target_cell': '__identity__'}))"
-                .replace("__identity__", self.identity)
+            return "cellSocket.sendString(JSON.stringify({'event':'click', 'target_cell': '__identity__'}))".replace(
+                "__identity__", self.identity
             )
 
     def recalculate(self):
-        self.children['content'] = self.content
-        self.exportData['bold'] = self.bold
+        self.children["content"] = self.content
+        self.exportData["bold"] = self.bold
 
         # TODO: this event handling situation must be refactored
-        self.exportData['events'] = {"onclick": self.calculatedOnClick()}
+        self.exportData["events"] = {"onclick": self.calculatedOnClick()}
 
     def sortsAs(self):
         return self.content.sortsAs()
@@ -2352,8 +2368,14 @@ class Clickable(Cell):
     def onMessage(self, msgFrame):
         val = self.f()
         if isinstance(val, str):
-            self.triggerPostscript(quoteForJs("window.location.href = '__url__'".replace(
-                "__url__", quoteForJs(val, "'")), '"'))
+            self.triggerPostscript(
+                quoteForJs(
+                    "window.location.href = '__url__'".replace(
+                        "__url__", quoteForJs(val, "'")
+                    ),
+                    '"',
+                )
+            )
 
 
 class Button(Clickable):
@@ -2364,19 +2386,19 @@ class Button(Clickable):
         self.style = style
 
     def recalculate(self):
-        self.children['content'] = self.content
+        self.children["content"] = self.content
 
         isActive = False
         if self.active:
             isActive = True
 
         # temporary js WS refactoring data
-        self.exportData['small'] = self.small
-        self.exportData['active'] = isActive
-        self.exportData['style'] = self.style
+        self.exportData["small"] = self.small
+        self.exportData["active"] = isActive
+        self.exportData["style"] = self.style
 
         # TODO: this event handling situation must be refactored
-        self.exportData['events'] = {"onclick": self.calculatedOnClick()}
+        self.exportData["events"] = {"onclick": self.calculatedOnClick()}
 
 
 class ButtonGroup(Cell):
@@ -2385,7 +2407,7 @@ class ButtonGroup(Cell):
         self.buttons = buttons
 
     def recalculate(self):
-        self.children['buttons'] = self.buttons
+        self.children["buttons"] = self.buttons
 
 
 class LoadContentsFromUrl(Cell):
@@ -2399,13 +2421,11 @@ class LoadContentsFromUrl(Cell):
         self.targetUrl = targetUrl
 
     def recalculate(self):
-        self.exportData['loadTargetId'] = 'loadtarget%s' % self._identity
+        self.exportData["loadTargetId"] = "loadtarget%s" % self._identity
 
-        self.postscript = (
-            "$('#loadtarget__identity__').load('__url__')"
-            .replace("__identity__", self._identity)
-            .replace("__url__", quoteForJs(self.targetUrl, "'"))
-        )
+        self.postscript = "$('#loadtarget__identity__').load('__url__')".replace(
+            "__identity__", self._identity
+        ).replace("__url__", quoteForJs(self.targetUrl, "'"))
 
 
 class SubscribeAndRetry(Exception):
@@ -2451,17 +2471,22 @@ class Expands(Cell):
         return self.closed.sortsAs()
 
     def recalculate(self):
-        inlineScript = "cellSocket.sendString(JSON.stringify({'event':'click', 'target_cell': '%s'}))" % self.identity
+        inlineScript = (
+            "cellSocket.sendString(JSON.stringify({'event':'click', 'target_cell': '%s'}))"
+            % self.identity
+        )
 
-        self.children.addFromDict({
-            'content': self.open if self.isExpanded else self.closed,
-            'icon': self.openedIcon if self.isExpanded else self.closedIcon
-        })
+        self.children.addFromDict(
+            {
+                "content": self.open if self.isExpanded else self.closed,
+                "icon": self.openedIcon if self.isExpanded else self.closedIcon,
+            }
+        )
 
         # TODO: Refactor this. We shouldn't need to send
         # an inline script!
-        self.exportData['events'] = {"onclick": inlineScript}
-        self.exportData['isOpen'] = self.isExpanded
+        self.exportData["events"] = {"onclick": inlineScript}
+        self.exportData["isOpen"] = self.isExpanded
 
         for c in self.children.allChildren:
             if c.cells is not None:
@@ -2475,13 +2500,15 @@ class Expands(Cell):
 class CodeEditor(Cell):
     """Produce a code editor."""
 
-    def __init__(self,
-                 keybindings=None,
-                 noScroll=False,
-                 minLines=None,
-                 fontSize=None,
-                 autocomplete=True,
-                 onTextChange=None):
+    def __init__(
+        self,
+        keybindings=None,
+        noScroll=False,
+        minLines=None,
+        fontSize=None,
+        autocomplete=True,
+        onTextChange=None,
+    ):
         """Create a code editor
 
         keybindings - map from keycode to a lambda function that will receive
@@ -2511,37 +2538,36 @@ class CodeEditor(Cell):
         # and will cause parent Sequences
         # to become flex parent
         self.isFlex = True
-        self.exportData['flexChild'] = True
+        self.exportData["flexChild"] = True
 
     def getContents(self):
         return self._slot.get()[1]
 
     def setContents(self, contents):
-        newSlotState = (self._slot.getWithoutRegisteringDependency()[
-                        0]+1000000, contents)
+        newSlotState = (self._slot.getWithoutRegisteringDependency()[0] + 1000000, contents)
         self._slot.set(newSlotState)
         self.sendCurrentStateToBrowser(newSlotState)
 
     def onMessage(self, msgFrame):
-        if msgFrame['event'] == 'keybinding':
-            self.keybindings[msgFrame['key']](
-                msgFrame['buffer'], msgFrame['selection'])
-        elif msgFrame['event'] == 'editing':
+        if msgFrame["event"] == "keybinding":
+            self.keybindings[msgFrame["key"]](msgFrame["buffer"], msgFrame["selection"])
+        elif msgFrame["event"] == "editing":
             if self.onTextChange:
-                self._slot.set((self._slot.getWithoutRegisteringDependency()[
-                               0] + 1, msgFrame['buffer']))
-                self.onTextChange(msgFrame['buffer'], msgFrame['selection'])
+                self._slot.set(
+                    (self._slot.getWithoutRegisteringDependency()[0] + 1, msgFrame["buffer"])
+                )
+                self.onTextChange(msgFrame["buffer"], msgFrame["selection"])
 
     def recalculate(self):
         # temporary js WS refactoring data
-        self.exportData['initialText'] = self.initialText
-        self.exportData['autocomplete'] = self.autocomplete
-        self.exportData['noScroll'] = self.noScroll
+        self.exportData["initialText"] = self.initialText
+        self.exportData["autocomplete"] = self.autocomplete
+        self.exportData["noScroll"] = self.noScroll
         if self.fontSize is not None:
-            self.exportData['fontSize'] = self.fontSize
+            self.exportData["fontSize"] = self.fontSize
         if self.minLines is not None:
-            self.exportData['minLines'] = self.minLines
-        self.exportData['keybindings'] = [k for k in self.keybindings.keys()]
+            self.exportData["minLines"] = self.minLines
+        self.exportData["keybindings"] = [k for k in self.keybindings.keys()]
 
     def sendCurrentStateToBrowser(self, newSlotState):
         if self.cells is not None:
@@ -2566,8 +2592,9 @@ class CodeEditor(Cell):
                 editor.setValue(newText, 1)
                 editor.selection.setRange(range)
 
-                """
-                .replace("__identity__", self.identity)
+                """.replace(
+                    "__identity__", self.identity
+                )
                 .replace("__text__", quoteForJs(newSlotState[1], '"'))
                 .replace("__iteration__", str(newSlotState[0]))
             )
@@ -2578,9 +2605,7 @@ class CodeEditor(Cell):
 class OldSheet(Cell):
     """Make a nice spreadsheet viewer. The dataset needs to be static in this implementation."""
 
-    def __init__(self, columnNames, rowCount, rowFun,
-                 colWidth=200,
-                 onCellDblClick=None):
+    def __init__(self, columnNames, rowCount, rowFun, colWidth=200, onCellDblClick=None):
         """
         columnNames:
             names to go in column Header
@@ -2610,46 +2635,49 @@ class OldSheet(Cell):
 
         self._hookfns = {}
         if onCellDblClick is not None:
+
             def _makeOnCellDblClick(func):
                 def _onMessage(sheet, msgFrame):
-                    return onCellDblClick(sheet=sheet,
-                                          row=msgFrame["row"],
-                                          col=msgFrame["col"])
+                    return onCellDblClick(
+                        sheet=sheet, row=msgFrame["row"], col=msgFrame["col"]
+                    )
+
                 return _onMessage
 
-            self._hookfns["onCellDblClick"] = _makeOnCellDblClick(
-                onCellDblClick)
+            self._hookfns["onCellDblClick"] = _makeOnCellDblClick(onCellDblClick)
 
     def _addHandsontableOnCellDblClick(self):
         pass
 
     def recalculate(self):
-        errorCell = Subscribed(lambda: Traceback(self.error.get()) if self.error.get() is not None else Text(""))
-        self.children['error'] = errorCell
+        errorCell = Subscribed(
+            lambda: Traceback(self.error.get()) if self.error.get() is not None else Text("")
+        )
+        self.children["error"] = errorCell
 
         # Deleted the postscript that was here.
         # Should now be implemented completely
         # in the JS side component.
 
-        self.exportData['divStyle'] = self._divStyle()
-        self.exportData['columnNames'] = [x for x in self.columnNames]
-        self.exportData['rowCount'] = self.rowCount
-        self.exportData['columnWidth'] = self.colWidth
-        self.exportData['handlesDoubleClick'] = ("onCellDblClick" in self._hookfns)
+        self.exportData["divStyle"] = self._divStyle()
+        self.exportData["columnNames"] = [x for x in self.columnNames]
+        self.exportData["rowCount"] = self.rowCount
+        self.exportData["columnWidth"] = self.colWidth
+        self.exportData["handlesDoubleClick"] = "onCellDblClick" in self._hookfns
 
     def onMessage(self, msgFrame):
         """TODO: We will need to update the Cell lifecycle
         and data handling before we can move this
         to the JS side"""
 
-        if msgFrame["event"] == 'sheet_needs_data':
-            row = msgFrame['data']
+        if msgFrame["event"] == "sheet_needs_data":
+            row = msgFrame["data"]
 
             if row in self.rowsSent:
                 return
 
             rows = []
-            for rowToRender in range(max(0, row-100), min(row+100, self.rowCount)):
+            for rowToRender in range(max(0, row - 100), min(row + 100, self.rowCount)):
                 if rowToRender not in self.rowsSent:
                     self.rowsSent.add(rowToRender)
                     rows.append(rowToRender)
@@ -2661,16 +2689,18 @@ class OldSheet(Cell):
                         var hot = handsOnTables["__identity__"].table
 
                         hot.getSettings().data.cache[__row__] = __data__
-                        """
-                        .replace("__row__", str(rowToRender))
+                        """.replace(
+                            "__row__", str(rowToRender)
+                        )
                         .replace("__identity__", self._identity)
                         .replace("__data__", json.dumps(rowData))
                     )
 
             if rows:
                 self.triggerPostscript(
-                    """handsOnTables["__identity__"].table.render()"""
-                    .replace("__identity__", self._identity)
+                    """handsOnTables["__identity__"].table.render()""".replace(
+                        "__identity__", self._identity
+                    )
                 )
         else:
             return self._hookfns[msgFrame["event"]](self, msgFrame)
@@ -2679,8 +2709,7 @@ class OldSheet(Cell):
 class Sheet(Cell):
     """Make a nice spreadsheet viewer. The dataset needs to be static in this implementation."""
 
-    def __init__(self, columnFun, rowFun, colWidth=50, rowHeight=30,
-                 onCellDblClick=None):
+    def __init__(self, columnFun, rowFun, colWidth=50, rowHeight=30, onCellDblClick=None):
         """
         columnFun:
             function taking 'start' and 'end' integer column as arguments and
@@ -2711,29 +2740,32 @@ class Sheet(Cell):
 
         self._hookfns = {}
         if onCellDblClick is not None:
+
             def _makeOnCellDblClick(func):
                 def _onMessage(sheet, msgFrame):
-                    return onCellDblClick(sheet=sheet,
-                                          row=msgFrame["row"],
-                                          col=msgFrame["col"])
+                    return onCellDblClick(
+                        sheet=sheet, row=msgFrame["row"], col=msgFrame["col"]
+                    )
+
                 return _onMessage
 
-            self._hookfns["onCellDblClick"] = _makeOnCellDblClick(
-                onCellDblClick)
+            self._hookfns["onCellDblClick"] = _makeOnCellDblClick(onCellDblClick)
 
     def _addHandsontableOnCellDblClick(self):
         pass
 
     def recalculate(self):
-        errorCell = Subscribed(lambda: Traceback(self.error.get()) if self.error.get() is not None else Text(""))
-        self.children['error'] = errorCell
+        errorCell = Subscribed(
+            lambda: Traceback(self.error.get()) if self.error.get() is not None else Text("")
+        )
+        self.children["error"] = errorCell
 
         # Deleted the postscript that was here.
         # Should now be implemented completely
         # in the JS side component.
 
-        self.exportData['colWidth'] = self.colWidth
-        self.exportData['rowHeight'] = self.rowHeight
+        self.exportData["colWidth"] = self.colWidth
+        self.exportData["rowHeight"] = self.rowHeight
         # self.exportData['handlesDoubleClick'] = ("onCellDblClick" in self._hookfns)
 
     def onMessage(self, msgFrame):
@@ -2747,27 +2779,22 @@ class Sheet(Cell):
         # their first column values set.
         ROW_LEN_OFFSET = 0
 
-        if msgFrame["event"] == 'sheet_needs_data':
-            start_row = msgFrame['start_row']
-            end_row = msgFrame['end_row']
-            start_column = msgFrame['start_column']
-            end_column = msgFrame['end_column']
-            rowsToSend = self.rowFun(start_row,
-                                     end_row,
-                                     start_column,
-                                     end_column)
-            columnsToSend = self.columnFun(start_column,
-                                           end_column)
-            if (not all([len(columnsToSend) == (len(row) - ROW_LEN_OFFSET) for row in
-                         rowsToSend])):
-                self._logger.error(
-                    "Sheet.rowFun generated rows don't match column length. "
-                )
+        if msgFrame["event"] == "sheet_needs_data":
+            start_row = msgFrame["start_row"]
+            end_row = msgFrame["end_row"]
+            start_column = msgFrame["start_column"]
+            end_column = msgFrame["end_column"]
+            rowsToSend = self.rowFun(start_row, end_row, start_column, end_column)
+            columnsToSend = self.columnFun(start_column, end_column)
+            if not all(
+                [len(columnsToSend) == (len(row) - ROW_LEN_OFFSET) for row in rowsToSend]
+            ):
+                self._logger.error("Sheet.rowFun generated rows don't match column length. ")
             dataInfo = {
                 "data": rowsToSend,
                 "column_names": columnsToSend,
                 "action": msgFrame["action"],
-                "axis": msgFrame["axis"]
+                "axis": msgFrame["axis"],
             }
             self.exportData["dataInfo"] = dataInfo
             self.wasDataUpdated = True
@@ -2793,32 +2820,31 @@ class Plot(Cell):
 
     def recalculate(self):
         chartUpdaterCell = Subscribed(lambda: _PlotUpdater(self))
-        errorCell = Subscribed(lambda: Traceback(self.error.get()) if self.error.get() is not None else Text(""))
-        self.children.addFromDict({
-            'chartUpdater': chartUpdaterCell,
-            'error': errorCell
-        })
+        errorCell = Subscribed(
+            lambda: Traceback(self.error.get()) if self.error.get() is not None else Text("")
+        )
+        self.children.addFromDict({"chartUpdater": chartUpdaterCell, "error": errorCell})
         self.postscript = ""
 
     def onMessage(self, msgFrame):
-        d = msgFrame['data']
+        d = msgFrame["data"]
         curVal = self.curXYRanges.get() or ((None, None), (None, None))
 
         self.curXYRanges.set(
-            ((d.get('xaxis.range[0]', curVal[0][0]), d.get('xaxis.range[1]', curVal[0][1])),
-             (d.get('yaxis.range[0]', curVal[1][0]), d.get('yaxis.range[1]', curVal[1][1])))
+            (
+                (d.get("xaxis.range[0]", curVal[0][0]), d.get("xaxis.range[1]", curVal[0][1])),
+                (d.get("yaxis.range[0]", curVal[1][0]), d.get("yaxis.range[1]", curVal[1][1])),
+            )
         )
 
-        self.cells._logger.info(
-            "User navigated plot to %s", self.curXYRanges.get())
+        self.cells._logger.info("User navigated plot to %s", self.curXYRanges.get())
 
     def setXRange(self, low, high):
         curXY = self.curXYRanges.getWithoutRegisteringDependency()
-        self.curXYRanges.set(
-            ((low, high), curXY[1] if curXY else (None, None))
-        )
+        self.curXYRanges.set(((low, high), curXY[1] if curXY else (None, None)))
 
-        self.triggerPostscript(f"""
+        self.triggerPostscript(
+            f"""
             plotDiv = document.getElementById('plot__identity__');
             newLayout = plotDiv.layout
 
@@ -2847,7 +2873,10 @@ class Plot(Cell):
             console.log("cells.Plot: range for 'plot__identity__' is now " +
                 plotDiv.layout.xaxis.range[0] + " to " + plotDiv.layout.xaxis.range[1])
 
-            """.replace("__identity__", self._identity))
+            """.replace(
+                "__identity__", self._identity
+            )
+        )
 
 
 class _PlotUpdater(Cell):
@@ -2859,7 +2888,7 @@ class _PlotUpdater(Cell):
         self.linePlot = linePlot
         self.namedDataSubscriptions = linePlot.namedDataSubscriptions
         self.chartId = linePlot._identity
-        self.exportData['plotId'] = self.chartId
+        self.exportData["plotId"] = self.chartId
 
     def calculatedDataJson(self):
         series = self.callFun(self.namedDataSubscriptions)
@@ -2867,8 +2896,10 @@ class _PlotUpdater(Cell):
         assert isinstance(series, (dict, list))
 
         if isinstance(series, dict):
-            return [self.processSeries(callableOrData, name)
-                    for name, callableOrData in series.items()]
+            return [
+                self.processSeries(callableOrData, name)
+                for name, callableOrData in series.items()
+            ]
         else:
             return [self.processSeries(callableOrData, None) for callableOrData in series]
 
@@ -2887,18 +2918,17 @@ class _PlotUpdater(Cell):
         data = self.callFun(callableOrData)
 
         if isinstance(data, list):
-            res = {'x': [float(x) for x in range(len(data))],
-                   'y': [float(d) for d in data]}
+            res = {"x": [float(x) for x in range(len(data))], "y": [float(d) for d in data]}
         else:
             assert isinstance(data, dict)
             res = dict(data)
 
             for k, v in res.items():
                 if isinstance(v, numpy.ndarray):
-                    res[k] = v.astype('float64').tostring().hex()
+                    res[k] = v.astype("float64").tostring().hex()
 
         if name is not None:
-            res['name'] = name
+            res["name"] = name
 
         return res
 
@@ -2909,16 +2939,16 @@ class _PlotUpdater(Cell):
             self.linePlot.error.set(None)
 
             # temporary js WS refactoring data
-            self.exportData['exceptionOccured'] = False
+            self.exportData["exceptionOccured"] = False
 
             try:
                 jsonDataToDraw = self.calculatedDataJson()
-                self.exportData['plotData'] = jsonDataToDraw
+                self.exportData["plotData"] = jsonDataToDraw
             except SubscribeAndRetry:
                 raise
             except Exception:
                 # temporary js WS refactoring data
-                self.exportData['exceptionOccured'] = True
+                self.exportData["exceptionOccured"] = True
 
                 self._logger.error(traceback.format_exc())
                 self.linePlot.error.set(traceback.format_exc())
@@ -2928,6 +2958,7 @@ class _PlotUpdater(Cell):
 
 class Timestamp(Cell):
     """Display current time zone."""
+
     def __init__(self, timestamp):
         """
         Parameters:
@@ -2936,13 +2967,13 @@ class Timestamp(Cell):
             time from epoch
         """
         super().__init__()
-        assert isinstance(timestamp, (float, int)), ("expected time since "
-                                                     "epoch float or int for"
-                                                     " 'timestamp' argument.")
+        assert isinstance(timestamp, (float, int)), (
+            "expected time since " "epoch float or int for" " 'timestamp' argument."
+        )
         self.timestamp = timestamp
 
     def recalculate(self):
-        self.exportData['timestamp'] = self.timestamp
+        self.exportData["timestamp"] = self.timestamp
 
 
 class Panel(Cell):
@@ -2957,6 +2988,7 @@ class Panel(Cell):
         A child cell that will be displayed within
         the bordered Panel area.
     """
+
     def __init__(self, content):
         """
         Parameters
@@ -2972,4 +3004,4 @@ class Panel(Cell):
         self.content = Cell.makeCell(content)
 
     def recalculate(self):
-        self.children['content'] = Cell.makeCell(self.content)
+        self.children["content"] = Cell.makeCell(self.content)

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -100,8 +100,10 @@ def wrapCallback(callback):
 
 
 def augmentToBeUnique(listOfItems):
-    """Returns a list of [(x,index)] for each 'x' in listOfItems, where index is the number of times
-    we've seen 'x' before.
+    """ Given a list that may include duplicates, return a list of unique items
+
+    Returns a list of [(x,index)] for each 'x' in listOfItems,
+    where index is the number of times we've seen 'x' before.
     """
     counts = {}
     output = []
@@ -212,10 +214,11 @@ class Cells:
             return
 
     def scheduleCallback(self, callback):
-        """Schedule a callback that will execute on the main cells thread as soon as possible.
+        """Schedule a callback to execute on the main cells thread as soon as possible.
 
-        Code in other threads shouldn't modify cells or slots. Cells that want to trigger
-        asynchronous work can do so and then push content back into Slot objects using these callbacks.
+        Code in other threads shouldn't modify cells or slots.
+        Cells that want to trigger asynchronous work can do so and then push
+        content back into Slot objects using these callbacks.
         """
         self._callbacks.put(callback)
         self._gEventHasTransactions.trigger()
@@ -724,7 +727,10 @@ class Cell:
             return result
 
     def triggerPostscript(self, javascript):
-        """Queue a postscript (piece of javascript to execute) to be run at the end of message processing."""
+        """ Queue a postscript to be run at the end of message processing.
+
+        A postscript is a piece of javascript to execute.
+        """
         self.cells._pendingPostscripts.append(javascript)
 
     def tagged(self, tag):
@@ -776,7 +782,7 @@ class Cell:
         return Messenger.getStructure(self.parent.identity, self, expand)
 
     def onMessageWithTransaction(self, *args):
-        """Call our inner 'onMessage' function with a transaction and a revision conflict retry loop."""
+        """ Call our inner 'onMessage' function with a transaction in a retry loop. """
         tries = 0
         t0 = time.time()
         while True:
@@ -2351,8 +2357,10 @@ class Clickable(Cell):
                 '"',
             )
         else:
-            return "cellSocket.sendString(JSON.stringify({'event':'click', 'target_cell': '__identity__'}))".replace(
-                "__identity__", self.identity
+            return (
+                "cellSocket.sendString(JSON.stringify("
+                f"{'event':'click', 'target_cell': '{self.identity}'}"
+                "))"
             )
 
     def recalculate(self):
@@ -2582,11 +2590,15 @@ class CodeEditor(Cell):
 
                 curRange = editor.selection.getRange()
                 var Range = require('ace/range').Range
-                var range = new Range(curRange.start.row,curRange.start.column,curRange.end.row,curRange.end.column)
+                var range = new Range(curRange.start.row,
+                                      curRange.start.column,
+                                      curRange.end.row,
+                                      curRange.end.column)
 
                 newText = "__text__";
 
-                console.log("Resetting editor text to " + newText.length + " because it changed on the server" +
+                console.log("Resetting editor text to " + newText.length
+                    + " because it changed on the server" +
                     " Cur iteration is __iteration__.")
 
                 editor.setValue(newText, 1)
@@ -2603,7 +2615,7 @@ class CodeEditor(Cell):
 
 
 class OldSheet(Cell):
-    """Make a nice spreadsheet viewer. The dataset needs to be static in this implementation."""
+    """A spreadsheet viewer. The dataset needs to be static."""
 
     def __init__(self, columnNames, rowCount, rowFun, colWidth=200, onCellDblClick=None):
         """
@@ -2707,7 +2719,7 @@ class OldSheet(Cell):
 
 
 class Sheet(Cell):
-    """Make a nice spreadsheet viewer. The dataset needs to be static in this implementation."""
+    """A spreadsheet viewer. The dataset must be static."""
 
     def __init__(self, columnFun, rowFun, colWidth=50, rowHeight=30, onCellDblClick=None):
         """
@@ -2850,10 +2862,13 @@ class Plot(Cell):
 
             if (typeof(newLayout.xaxis.range[0]) === 'string') {{
                 formatDate = function(d) {{
-                    return (d.getYear() + 1900) + "-" + ("00" + (d.getMonth() + 1)).substr(-2) + "-" +
-                            ("00" + d.getDate()).substr(-2) + " " + ("00" + d.getHours()).substr(-2) + ":" +
-                            ("00" + d.getMinutes()).substr(-2) + ":" + ("00" + d.getSeconds()).substr(-2) + "." +
-                            ("000000" + d.getMilliseconds()).substr(-3)
+                    return (d.getYear() + 1900) +
+                            "-" + ("00" + (d.getMonth() + 1)).substr(-2) +
+                            "-" + ("00" + d.getDate()).substr(-2) +
+                            " " + ("00" + d.getHours()).substr(-2) +
+                            ":" + ("00" + d.getMinutes()).substr(-2) +
+                            ":" + ("00" + d.getSeconds()).substr(-2) +
+                            "." + ("000000" + d.getMilliseconds()).substr(-3)
                     }};
 
                 newLayout.xaxis.range[0] = formatDate(new Date({low*1000}));

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -31,16 +31,15 @@ from object_database.web.cells import (
     Slot,
     ensureSubscribedType,
     registerDisplay,
-    Flex
+    Flex,
 )
 
 from object_database import InMemServer, Schema, Indexed, connect
 from object_database.util import genToken, configureLogging
-from object_database.frontends.service_manager import autoconfigureAndStartServiceManagerProcess
-from object_database.test_util import (
-    currentMemUsageMb,
-    log_cells_stats
+from object_database.frontends.service_manager import (
+    autoconfigureAndStartServiceManagerProcess,
 )
+from object_database.test_util import currentMemUsageMb, log_cells_stats
 from object_database.web.cells.Messenger import getStructure
 from object_database.web.cells import (
     Padding,
@@ -48,7 +47,7 @@ from object_database.web.cells import (
     PaddingLeft,
     Margin,
     MarginSides,
-    MarginRight
+    MarginRight,
 )
 
 import logging
@@ -67,10 +66,7 @@ class Thing:
 class CellsTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        configureLogging(
-            preamble="cells_test",
-            level=logging.INFO
-        )
+        configureLogging(preamble="cells_test", level=logging.INFO)
         cls._logger = logging.getLogger(__name__)
 
     def setUp(self):
@@ -139,16 +135,11 @@ class CellsTests(unittest.TestCase):
         self.assertFalse(basicCell.wasRemoved)
 
     def test_cells_recalculation(self):
-        pair = [
-            Container("HI"),
-            Container("HI2")
-        ]
+        pair = [Container("HI"), Container("HI2")]
 
         sequence = Sequence(pair)
 
-        self.cells.withRoot(
-            sequence
-        )
+        self.cells.withRoot(sequence)
 
         self.cells._recalculateCells()
         pair[0].setChild("HIHI")
@@ -159,16 +150,14 @@ class CellsTests(unittest.TestCase):
         self.assertEqual(pair[1].parent, sequence)
 
         # Assert that the first Container has a Cell child
-        self.assertIsInstance(pair[0].children['child'], Cell)
+        self.assertIsInstance(pair[0].children["child"], Cell)
 
     def test_cells_reusable(self):
         c1 = Card(Text("HI"))
         c2 = Card(Text("HI2"))
         slot = Slot(0)
 
-        self.cells.withRoot(
-            Subscribed(lambda: c1 if slot.get() else c2)
-        )
+        self.cells.withRoot(Subscribed(lambda: c1 if slot.get() else c2))
 
         self.cells.renderMessages()
         slot.set(1)
@@ -181,10 +170,12 @@ class CellsTests(unittest.TestCase):
     def test_cells_subscriptions(self):
         self.cells.withRoot(
             Subscribed(
-                lambda: Sequence([
-                    Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
-                    for thing in Thing.lookupAll()
-                ])
+                lambda: Sequence(
+                    [
+                        Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
+                        for thing in Thing.lookupAll()
+                    ]
+                )
             )
         )
 
@@ -201,7 +192,7 @@ class CellsTests(unittest.TestCase):
 
         # three 'Span', three 'Text', the Sequence, the Subscribed, and a delete
         # self.assertEqual(len(self.cells.renderMessages()), 9)
-        nodes_created = [ node for node in self.cells._nodesToBroadcast if node.wasCreated]
+        nodes_created = [node for node in self.cells._nodesToBroadcast if node.wasCreated]
 
         # We have discarded only one
         self.assertEqual(len(self.cells._nodesToDiscard), 1)
@@ -222,10 +213,12 @@ class CellsTests(unittest.TestCase):
         def checkThing2s():
             ensureSubscribedType(Thing2)
 
-            res = Sequence([
-                Span("Thing(k=%s).x = %s"
-                     % (thing.k, thing.x)) for thing in Thing2.lookupAll()
-            ])
+            res = Sequence(
+                [
+                    Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
+                    for thing in Thing2.lookupAll()
+                ]
+            )
 
             computed.set()
 
@@ -248,7 +241,7 @@ class CellsTests(unittest.TestCase):
                 lambda: Thing.lookupAll(k=0),
                 lambda thing: Subscribed(
                     lambda: Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
-                )
+                ),
             )
         )
 
@@ -265,16 +258,17 @@ class CellsTests(unittest.TestCase):
 
             messages = self.cells.renderMessages()
 
-            self.assertTrue(len(self.cells) < 20, "Have %s cells at pass %s"
-                            % (len(self.cells), i))
-            self.assertTrue(len(messages) < 20, "Got %s messages at pass %s"
-                            % (len(messages), i))
+            self.assertTrue(
+                len(self.cells) < 20, "Have %s cells at pass %s" % (len(self.cells), i)
+            )
+            self.assertTrue(
+                len(messages) < 20, "Got %s messages at pass %s" % (len(messages), i)
+            )
 
     def helper_memory_leak(self, cell, initFn, workFn, thresholdMB):
         port = 8021
         server, cleanupFn = autoconfigureAndStartServiceManagerProcess(
-            port=port,
-            authToken=self.token,
+            port=port, authToken=self.token
         )
         try:
             db = connect("localhost", port, self.token, retry=True)
@@ -295,18 +289,19 @@ class CellsTests(unittest.TestCase):
             self._logger.info("Initial Memory Usage: {} MB".format(rss0))
             self._logger.info("Final   Memory Usage: {} MB".format(rss))
             self.assertTrue(
-                rss - rss0 < thresholdMB,
-                "Memory Usage Increased by {} MB.".format(rss - rss0)
+                rss - rss0 < thresholdMB, "Memory Usage Increased by {} MB.".format(rss - rss0)
             )
         finally:
             cleanupFn()
 
     def test_cells_memory_leak1(self):
         cell = Subscribed(
-            lambda: Sequence([
-                Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
-                for thing in Thing.lookupAll(k=0)
-            ])
+            lambda: Sequence(
+                [
+                    Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
+                    for thing in Thing.lookupAll(k=0)
+                ]
+            )
         )
 
         def workFn(db, cells, iterations=5000):
@@ -332,19 +327,12 @@ class CellsTests(unittest.TestCase):
 
     @unittest.skip("Test is failing oddly, but it's not clear what test is trying to do")
     def test_cells_memory_leak2(self):
-        cell = (
-            SubscribedSequence(
-                lambda: Thing.lookupAll(k=0),
-                lambda thing: Subscribed(
-                    lambda: Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
-                )
-            ) +
-            SubscribedSequence(
-                lambda: Thing.lookupAll(k=1),
-                lambda thing: Subscribed(
-                    lambda: Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
-                )
-            )
+        cell = SubscribedSequence(
+            lambda: Thing.lookupAll(k=0),
+            lambda thing: Subscribed(lambda: Span("Thing(k=%s).x = %s" % (thing.k, thing.x))),
+        ) + SubscribedSequence(
+            lambda: Thing.lookupAll(k=1),
+            lambda thing: Subscribed(lambda: Span("Thing(k=%s).x = %s" % (thing.k, thing.x))),
         )
 
         def workFn(db, cells, iterations=5000):
@@ -400,10 +388,10 @@ class CellsTests(unittest.TestCase):
             return Text(X.x).tagged("display " + str(X.x))
 
         self.cells.withRoot(
-            Card(X(0)).withContext(size="small") +
-            Card(X(1)).withContext(size="large") +
-            Card(X(2)).withContext(size="something else") +
-            Card(X(3))
+            Card(X(0)).withContext(size="small")
+            + Card(X(1)).withContext(size="large")
+            + Card(X(2)).withContext(size="something else")
+            + Card(X(3))
         )
 
         self.cells.renderMessages()
@@ -423,7 +411,7 @@ class CellsTests(unittest.TestCase):
         def handler():
             return changedCell
 
-        dropdown = AsyncDropdown('Untitled', handler)
+        dropdown = AsyncDropdown("Untitled", handler)
         dropdown.contentCell.loadingCell = Text("INITIAL")
         self.cells.withRoot(dropdown)
         self.cells.renderMessages()
@@ -441,10 +429,7 @@ class CellsTests(unittest.TestCase):
 class CellsMessagingTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        configureLogging(
-            preamble="cells_test",
-            level=logging.INFO
-        )
+        configureLogging(preamble="cells_test", level=logging.INFO)
         cls._logger = logging.getLogger(__name__)
 
     def setUp(self):
@@ -460,10 +445,7 @@ class CellsMessagingTests(unittest.TestCase):
         self.server.stop()
 
     def test_cells_initial_messages(self):
-        pair = [
-            Container("HI"),
-            Container("HI2")
-        ]
+        pair = [Container("HI"), Container("HI2")]
         pairCell = Sequence(pair)
         self.cells.withRoot(pairCell)
 
@@ -477,13 +459,10 @@ class CellsMessagingTests(unittest.TestCase):
         # We should for now only have the initial
         # creation message for the RootCell
         self.assertEqual(len(msgs), 1)
-        self.assertEqual(msgs[0]['id'], self.cells._root.identity)
+        self.assertEqual(msgs[0]["id"], self.cells._root.identity)
 
     def test_cells_simple_update_message(self):
-        pair = [
-            Container("Hello"),
-            Container("World")
-        ]
+        pair = [Container("Hello"), Container("World")]
         sequence = Sequence(pair)
 
         # Initial recalculation
@@ -502,19 +481,16 @@ class CellsMessagingTests(unittest.TestCase):
         self.assertEqual(len(msgs), 1)
 
         # It should be an update to the Sequence
-        self.assertEqual(msgs[0]['id'], sequence.identity)
+        self.assertEqual(msgs[0]["id"], sequence.identity)
 
         # Sequence's namedChildren should have a length now of 3
-        self.assertEqual(len(sequence.children['elements']), 3)
+        self.assertEqual(len(sequence.children["elements"]), 3)
 
 
 class CellsStructureTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        configureLogging(
-            preamble="cells_structure_test",
-            level=logging.INFO
-        )
+        configureLogging(preamble="cells_structure_test", level=logging.INFO)
         cls._logger = logging.getLogger(__name__)
 
     def setUp(self):
@@ -538,15 +514,12 @@ class CellsStructureTests(unittest.TestCase):
         container.cells = self.cells
         self.cells.withRoot(container)
         structure = getStructure(None, container, None)
-        expected_subset = {
-            "id": container.identity,
-            "cellType": "Sequence"
-        }
+        expected_subset = {"id": container.identity, "cellType": "Sequence"}
         self.assertTrue(isinstance(structure, dict))
         self.assertDictContainsSubset(expected_subset, structure)
-        self.assertIn('elements', structure['namedChildren'].keys())
-        self.assertIn(first.identity, structure['namedChildren']['elements'])
-        self.assertIn(second.identity, structure['namedChildren']['elements'])
+        self.assertIn("elements", structure["namedChildren"].keys())
+        self.assertIn(first.identity, structure["namedChildren"]["elements"])
+        self.assertIn(second.identity, structure["namedChildren"]["elements"])
 
     def test_basic_expanded_structure(self):
         first = Text("Hello")
@@ -557,35 +530,29 @@ class CellsStructureTests(unittest.TestCase):
         container.cells = self.cells
         self.cells.withRoot(container)
         struct = getStructure(None, container, None, expand=True)
-        expected_subset = {
-            "id": container.identity,
-            "cellType": "Sequence"
-        }
+        expected_subset = {"id": container.identity, "cellType": "Sequence"}
         expected_first_element = {
             "id": first.identity,
             "cellType": "Text",
-            "namedChildren": {}
+            "namedChildren": {},
         }
         expected_second_element = {
             "id": second.identity,
             "cellType": "Text",
-            "namedChildren": {}
+            "namedChildren": {},
         }
 
         self.assertTrue(isinstance(struct, dict))
-        self.assertTrue(isinstance(struct['namedChildren'], dict))
+        self.assertTrue(isinstance(struct["namedChildren"], dict))
         self.assertDictContainsSubset(expected_subset, struct)
-        self.assertIn("elements", struct['namedChildren'])
-        elements = struct['namedChildren']['elements']
+        self.assertIn("elements", struct["namedChildren"])
+        elements = struct["namedChildren"]["elements"]
         self.assertIsInstance(elements, list)
         self.assertDictContainsSubset(expected_first_element, elements[0])
         self.assertDictContainsSubset(expected_second_element, elements[1])
 
     def test_cell_self_flat_struct(self):
-        c = Sequence([
-            Text("Hello"),
-            Text("World")
-        ])
+        c = Sequence([Text("Hello"), Text("World")])
         self.cells.withRoot(c)
         self.cells._recalculateCells()
         struct = c.getCurrentStructure()
@@ -595,10 +562,7 @@ class CellsStructureTests(unittest.TestCase):
 class CellsSequenceHandlingTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        configureLogging(
-            preamble="cells_test",
-            level=logging.INFO
-        )
+        configureLogging(preamble="cells_test", level=logging.INFO)
         cls._logger = logging.getLogger(__name__)
 
     def setUp(self):
@@ -614,38 +578,40 @@ class CellsSequenceHandlingTests(unittest.TestCase):
         self.server.stop()
 
     def test_seq_elements_length(self):
-        child_elements = [Text('One'), Text('Two'), Text('Three')]
+        child_elements = [Text("One"), Text("Two"), Text("Three")]
         child_seq = Sequence(child_elements)
-        parent_seq = Sequence([Text('First'), child_seq, Text('Third')])
+        parent_seq = Sequence([Text("First"), child_seq, Text("Third")])
         self.cells.withRoot(parent_seq)
         self.cells._recalculateCells()
         self.assertEqual(len(child_seq.elements), len(child_elements))
 
     def test_seq_element_presence(self):
-        child_elements = [Text('One'), Text('Two'), Text('Three')]
+        child_elements = [Text("One"), Text("Two"), Text("Three")]
         child_seq = Sequence(child_elements)
-        parent_seq = Sequence([Text('First'), child_seq, Text('Third')])
+        parent_seq = Sequence([Text("First"), child_seq, Text("Third")])
         self.cells.withRoot(parent_seq)
 
         self.assertIn(child_elements[0], child_seq.elements)
 
     def test_seq_not_flex_parent(self):
-        child_seq = Sequence([Text('One'), Text('Two'), Text('Three')])
-        parent_seq = Sequence([Text('First'), child_seq, Text('Last')])
+        child_seq = Sequence([Text("One"), Text("Two"), Text("Three")])
+        parent_seq = Sequence([Text("First"), child_seq, Text("Last")])
         parent_seq.recalculate()
         self.assertFalse(parent_seq.isFlexParent)
         self.assertFalse(parent_seq.isFlex)
 
     def test_seq_becomes_flex_parent(self):
-        child_seq = Sequence([Text('One'), Text('Two'), Text('Three')])
-        parent_seq = Sequence([Flex(Text('First')), child_seq, Text('Last')])
+        child_seq = Sequence([Text("One"), Text("Two"), Text("Three")])
+        parent_seq = Sequence([Flex(Text("First")), child_seq, Text("Last")])
         parent_seq.recalculate()
         self.assertTrue(parent_seq.isFlexParent)
 
     def test_seq_flattens_non_flex(self):
-        first_child_seq = Sequence([Text('One'), Text('Two')])
-        second_child_seq = Sequence([Text('Five'), Text('Six')])
-        parent_seq = Sequence([Text('Outer'), first_child_seq, Flex(second_child_seq), Text('Last')])
+        first_child_seq = Sequence([Text("One"), Text("Two")])
+        second_child_seq = Sequence([Text("Five"), Text("Six")])
+        parent_seq = Sequence(
+            [Text("Outer"), first_child_seq, Flex(second_child_seq), Text("Last")]
+        )
         self.cells.withRoot(parent_seq)
         self.cells._recalculateCells()
 
@@ -655,7 +621,9 @@ class CellsSequenceHandlingTests(unittest.TestCase):
         self.assertIn(first_child_seq.elements[1], parent_seq.elements)
 
     def test_basic_plus_composition(self):
-        result = Text("Hello") + Text("There") + Text("This Is A") + Button("Button", lambda: None)
+        result = (
+            Text("Hello") + Text("There") + Text("This Is A") + Button("Button", lambda: None)
+        )
         self.assertTrue(isinstance(result, Sequence))
         self.assertEqual(len(result.elements), 4)
 
@@ -663,10 +631,7 @@ class CellsSequenceHandlingTests(unittest.TestCase):
 class CellsHorizSequenceHandlingTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        configureLogging(
-            preamble="cells_test",
-            level=logging.INFO
-        )
+        configureLogging(preamble="cells_test", level=logging.INFO)
         cls._logger = logging.getLogger(__name__)
 
     def setUp(self):
@@ -682,38 +647,40 @@ class CellsHorizSequenceHandlingTests(unittest.TestCase):
         self.server.stop()
 
     def test_horiz_seq_elements_length(self):
-        child_elements = [Text('One'), Text('Two'), Text('Three')]
+        child_elements = [Text("One"), Text("Two"), Text("Three")]
         child_seq = HorizontalSequence(child_elements)
-        parent_seq = HorizontalSequence([Text('First'), child_seq, Text('Third')])
+        parent_seq = HorizontalSequence([Text("First"), child_seq, Text("Third")])
         self.cells.withRoot(parent_seq)
         self.cells._recalculateCells()
         self.assertEqual(len(child_seq.elements), len(child_elements))
 
     def test_horiz_seq_element_presence(self):
-        child_elements = [Text('One'), Text('Two'), Text('Three')]
+        child_elements = [Text("One"), Text("Two"), Text("Three")]
         child_seq = HorizontalSequence(child_elements)
-        parent_seq = HorizontalSequence([Text('First'), child_seq, Text('Third')])
+        parent_seq = HorizontalSequence([Text("First"), child_seq, Text("Third")])
         self.cells.withRoot(parent_seq)
 
         self.assertIn(child_elements[0], child_seq.elements)
 
     def test_horiz_seq_not_flex_parent(self):
-        child_seq = HorizontalSequence([Text('One'), Text('Two'), Text('Three')])
-        parent_seq = HorizontalSequence([Text('First'), child_seq, Text('Last')])
+        child_seq = HorizontalSequence([Text("One"), Text("Two"), Text("Three")])
+        parent_seq = HorizontalSequence([Text("First"), child_seq, Text("Last")])
         parent_seq.recalculate()
         self.assertFalse(parent_seq.isFlexParent)
         self.assertFalse(parent_seq.isFlex)
 
     def test_horiz_seq_becomes_flex_parent(self):
-        child_seq = HorizontalSequence([Text('One'), Text('Two'), Text('Three')])
-        parent_seq = HorizontalSequence([Flex(Text('First')), child_seq, Text('Last')])
+        child_seq = HorizontalSequence([Text("One"), Text("Two"), Text("Three")])
+        parent_seq = HorizontalSequence([Flex(Text("First")), child_seq, Text("Last")])
         parent_seq.recalculate()
         self.assertTrue(parent_seq.isFlexParent)
 
     def test_horiz_seq_flattens_non_flex(self):
-        first_child_seq = HorizontalSequence([Text('One'), Text('Two')])
-        second_child_seq = HorizontalSequence([Text('Five'), Text('Six')])
-        parent_seq = HorizontalSequence([Text('Outer'), first_child_seq, Flex(second_child_seq), Text('Last')])
+        first_child_seq = HorizontalSequence([Text("One"), Text("Two")])
+        second_child_seq = HorizontalSequence([Text("Five"), Text("Six")])
+        parent_seq = HorizontalSequence(
+            [Text("Outer"), first_child_seq, Flex(second_child_seq), Text("Last")]
+        )
         self.cells.withRoot(parent_seq)
         self.cells._recalculateCells()
 
@@ -723,7 +690,7 @@ class CellsHorizSequenceHandlingTests(unittest.TestCase):
         self.assertIn(first_child_seq.elements[1], parent_seq.elements)
 
     def test_basic_rshift_composition(self):
-        result = (Text("Hi") >> Text("Bye") >> Text("Go Away") >> Button("Away", lambda: None))
+        result = Text("Hi") >> Text("Bye") >> Text("Go Away") >> Button("Away", lambda: None)
         self.assertTrue(isinstance(result, HorizontalSequence))
         self.assertEqual(len(result.elements), 4)
 
@@ -731,10 +698,7 @@ class CellsHorizSequenceHandlingTests(unittest.TestCase):
 class CellsSubscribedSequenceHandlingTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        configureLogging(
-            preamble="cells_test",
-            level=logging.INFO
-        )
+        configureLogging(preamble="cells_test", level=logging.INFO)
         cls._logger = logging.getLogger(__name__)
 
     def setUp(self):
@@ -766,7 +730,7 @@ class CellsSubscribedSequenceHandlingTests(unittest.TestCase):
         self.cells.withRoot(sub_seq)
         self.cells._recalculateCells()
         self.assertEqual(len(sub_seq.items), 50)
-        self.assertEqual(len(sub_seq.children['elements']), 50)
+        self.assertEqual(len(sub_seq.children["elements"]), 50)
 
     def test_elements_length_changed(self):
         exampleData = self.exampleItems
@@ -784,66 +748,65 @@ class CellsSubscribedSequenceHandlingTests(unittest.TestCase):
 
     def test_horizontal_constructor(self):
         sub_seq = HorizontalSubscribedSequence(self.itemsFun, self.rendererFun)
-        self.assertEqual(sub_seq.orientation, 'horizontal')
+        self.assertEqual(sub_seq.orientation, "horizontal")
         self.assertIsInstance(sub_seq, SubscribedSequence)
 
     def test_abbrev_vert_constructor(self):
         sub_seq = VSubscribedSequence(self.itemsFun, self.rendererFun)
-        self.assertEqual(sub_seq.orientation, 'vertical')
+        self.assertEqual(sub_seq.orientation, "vertical")
         self.assertIsInstance(sub_seq, SubscribedSequence)
 
     def test_abbrev_horiz_constructor(self):
         sub_seq = HSubscribedSequence(self.itemsFun, self.rendererFun)
-        self.assertEqual(sub_seq.orientation, 'horizontal')
+        self.assertEqual(sub_seq.orientation, "horizontal")
         self.assertIsInstance(sub_seq, SubscribedSequence)
 
 
 class CellsUtilTests(unittest.TestCase):
-
     def test_padding_all_dimensions(self):
-        cell = Text('test')
+        cell = Text("test")
         Padding(10, cell)
-        self.assertTrue('padding' in cell.exportData['customStyle'])
-        self.assertEqual('10px', cell.exportData['customStyle']['padding'])
+        self.assertTrue("padding" in cell.exportData["customStyle"])
+        self.assertEqual("10px", cell.exportData["customStyle"]["padding"])
 
     def test_padding_right(self):
         cell = Text("test")
         PaddingRight(22, cell)
-        self.assertFalse('padding' in cell.exportData['customStyle'])
-        self.assertTrue('padding-right' in cell.exportData['customStyle'])
-        self.assertEqual('22px', cell.exportData['customStyle']['padding-right'])
+        self.assertFalse("padding" in cell.exportData["customStyle"])
+        self.assertTrue("padding-right" in cell.exportData["customStyle"])
+        self.assertEqual("22px", cell.exportData["customStyle"]["padding-right"])
 
     def test_padding_left(self):
         cell = Text("test")
         PaddingLeft(22, cell)
-        self.assertFalse('padding' in cell.exportData['customStyle'])
-        self.assertTrue('padding-left' in cell.exportData['customStyle'])
-        self.assertEqual('22px', cell.exportData['customStyle']['padding-left'])
+        self.assertFalse("padding" in cell.exportData["customStyle"])
+        self.assertTrue("padding-left" in cell.exportData["customStyle"])
+        self.assertEqual("22px", cell.exportData["customStyle"]["padding-left"])
 
     def test_margin_all_dimensions(self):
         cell = Text("test")
         Margin(15, cell)
-        self.assertTrue('margin' in cell.exportData['customStyle'])
-        self.assertEqual('15px', cell.exportData['customStyle']['margin'])
+        self.assertTrue("margin" in cell.exportData["customStyle"])
+        self.assertEqual("15px", cell.exportData["customStyle"]["margin"])
 
     def test_margin_sides(self):
         cell = Text("test")
         MarginSides(10, cell)
-        self.assertTrue('margin-right' in cell.exportData['customStyle'])
-        self.assertTrue('margin-left' in cell.exportData['customStyle'])
-        self.assertEqual('10px', cell.exportData['customStyle']['margin-right'])
-        self.assertEqual('10px', cell.exportData['customStyle']['margin-left'])
+        self.assertTrue("margin-right" in cell.exportData["customStyle"])
+        self.assertTrue("margin-left" in cell.exportData["customStyle"])
+        self.assertEqual("10px", cell.exportData["customStyle"]["margin-right"])
+        self.assertEqual("10px", cell.exportData["customStyle"]["margin-left"])
 
     def test_margin_right(self):
         cell = Text("test")
         MarginRight(12, cell)
-        self.assertTrue('margin-right' in cell.exportData['customStyle'])
-        self.assertEqual('12px', cell.exportData['customStyle']['margin-right'])
-        self.assertFalse('margin' in cell.exportData['customStyle'])
-        self.assertEqual('0px', cell.exportData['customStyle']['margin-left'])
-        self.assertEqual('0px', cell.exportData['customStyle']['margin-bottom'])
-        self.assertEqual('0px', cell.exportData['customStyle']['margin-top'])
+        self.assertTrue("margin-right" in cell.exportData["customStyle"])
+        self.assertEqual("12px", cell.exportData["customStyle"]["margin-right"])
+        self.assertFalse("margin" in cell.exportData["customStyle"])
+        self.assertEqual("0px", cell.exportData["customStyle"]["margin-left"])
+        self.assertEqual("0px", cell.exportData["customStyle"]["margin-bottom"])
+        self.assertEqual("0px", cell.exportData["customStyle"]["margin-top"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/object_database/web/cells/children.py
+++ b/object_database/web/cells/children.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 
-class Children():
+class Children:
     """A 'Collection-Like' object that holds Cell child references.
 
     By 'Collection-like' we mean that this object maintains
@@ -52,6 +52,7 @@ class Children():
         the key where the instance appears in
         namedChildren. Used for reverse lookups.
     """
+
     def __init__(self, parent=None):
         """
         Parameters

--- a/object_database/web/cells/children_test.py
+++ b/object_database/web/cells/children_test.py
@@ -2,13 +2,12 @@ import unittest
 from object_database.web.cells.children import Children
 
 
-class DummyObject():
+class DummyObject:
     def __init__(self):
         self.parent = None
 
 
 class CellChildrenTests(unittest.TestCase):
-
     def test_get_dimensions_zero(self):
         item = DummyObject()
         children = Children()
@@ -22,19 +21,13 @@ class CellChildrenTests(unittest.TestCase):
         self.assertEqual(result, 1)
 
     def test_get_dimensions_two(self):
-        item = [
-            [DummyObject() for d in range(20)] for c in range(20)
-        ]
+        item = [[DummyObject() for d in range(20)] for c in range(20)]
         children = Children()
         result = children._getDimensions(item)
         self.assertEqual(result, 2)
 
     def test_get_dimensions_three(self):
-        item = [
-            [
-                [DummyObject() for a in range(20)] for b in range(20)
-            ] for c in range(20)
-        ]
+        item = [[[DummyObject() for a in range(20)] for b in range(20)] for c in range(20)]
         children = Children()
         result = children._getDimensions(item)
         self.assertEqual(result, 3)
@@ -42,19 +35,15 @@ class CellChildrenTests(unittest.TestCase):
     def test_add_child_zero_dm(self):
         child = DummyObject()
         children = Children()
-        children.addChildNamed('first', child)
-        self.assertTrue('first' in children.namedChildren)
+        children.addChildNamed("first", child)
+        self.assertTrue("first" in children.namedChildren)
         self.assertTrue(child in children.allChildren)
-        self.assertEqual(child, children.namedChildren['first'])
+        self.assertEqual(child, children.namedChildren["first"])
 
     def test_basic_add_child_one_dm(self):
-        child = [
-            DummyObject(),
-            DummyObject(),
-            DummyObject()
-        ]
+        child = [DummyObject(), DummyObject(), DummyObject()]
         children = Children()
-        children.addChildNamed('first', child)
+        children.addChildNamed("first", child)
         self.assertEqual(len(children.allChildren), 3)
         for item in children.allChildren:
             self.assertIsInstance(item, DummyObject)
@@ -62,91 +51,85 @@ class CellChildrenTests(unittest.TestCase):
     def test_add_child_one_dm(self):
         child = [DummyObject() for d in range(20)]
         children = Children()
-        children.addChildNamed('first', child)
-        self.assertTrue('first' in children.namedChildren)
+        children.addChildNamed("first", child)
+        self.assertTrue("first" in children.namedChildren)
         for item in child:
             self.assertTrue(item in children.allChildren)
-        self.assertEqual(child, children.namedChildren['first'])
+        self.assertEqual(child, children.namedChildren["first"])
         self.assertEqual(len(children.allChildren), 20)
         for item in children.allChildren:
             self.assertIsInstance(item, DummyObject)
 
     def test_add_child_two_dm(self):
-        child = [
-            [DummyObject() for d in range(20)] for c in range(30)
-        ]
+        child = [[DummyObject() for d in range(20)] for c in range(30)]
         children = Children()
-        children.addChildNamed('first', child)
-        self.assertTrue('first' in children.namedChildren)
+        children.addChildNamed("first", child)
+        self.assertTrue("first" in children.namedChildren)
         for outerItem in child:
             for innerItem in outerItem:
                 self.assertTrue(innerItem in children.allChildren)
-        self.assertEqual(child, children.namedChildren['first'])
+        self.assertEqual(child, children.namedChildren["first"])
         self.assertEqual(len(children.allChildren), 600)
 
     def test_remove_child_zero_dm(self):
         child = DummyObject()
         children = Children()
-        children.addChildNamed('first', child)
+        children.addChildNamed("first", child)
         self.assertEqual(len(children.allChildren), 1)
-        children.removeChildNamed('first')
+        children.removeChildNamed("first")
         self.assertEqual(len(children.allChildren), 0)
-        self.assertFalse('first' in children.namedChildren)
+        self.assertFalse("first" in children.namedChildren)
 
     def test_remove_child_one_dm(self):
         child = [DummyObject() for d in range(10)]
         children = Children()
-        children.addChildNamed('first', child)
+        children.addChildNamed("first", child)
         self.assertEqual(len(children.allChildren), 10)
-        children.removeChildNamed('first')
+        children.removeChildNamed("first")
         self.assertEqual(len(children.allChildren), 0)
-        self.assertFalse('first' in children.namedChildren)
+        self.assertFalse("first" in children.namedChildren)
 
     def test_remove_child_two_dm(self):
-        child = [
-            [DummyObject() for d in range(5)] for c in range(10)
-        ]
+        child = [[DummyObject() for d in range(5)] for c in range(10)]
         children = Children()
-        children.addChildNamed('first', child)
+        children.addChildNamed("first", child)
         self.assertEqual(len(children.allChildren), 50)
-        children.removeChildNamed('first')
+        children.removeChildNamed("first")
         self.assertEqual(len(children.allChildren), 0)
-        self.assertFalse('first' in children.namedChildren)
+        self.assertFalse("first" in children.namedChildren)
 
     def test_setitem_zero_dm(self):
         child = DummyObject()
         children = Children()
-        children['first'] = child
-        self.assertTrue('first' in children.namedChildren)
-        self.assertEqual(children.namedChildren['first'], child)
+        children["first"] = child
+        self.assertTrue("first" in children.namedChildren)
+        self.assertEqual(children.namedChildren["first"], child)
         self.assertEqual(len(children.allChildren), 1)
-        self.assertEqual(children.dimensionsForChildNamed('first'), 0)
+        self.assertEqual(children.dimensionsForChildNamed("first"), 0)
 
     def test_setitem_one_dm(self):
         child = [DummyObject() for d in range(10)]
         children = Children()
-        children['first'] = child
-        self.assertTrue('first' in children.namedChildren)
-        self.assertEqual(child, children.namedChildren['first'])
+        children["first"] = child
+        self.assertTrue("first" in children.namedChildren)
+        self.assertEqual(child, children.namedChildren["first"])
         self.assertEqual(len(children.allChildren), 10)
-        self.assertEqual(children.dimensionsForChildNamed('first'), 1)
+        self.assertEqual(children.dimensionsForChildNamed("first"), 1)
 
     def test_setitem_two_dm(self):
-        child = [
-            [DummyObject() for d in range(10)] for c in range(10)
-        ]
+        child = [[DummyObject() for d in range(10)] for c in range(10)]
         children = Children()
-        children['first'] = child
-        self.assertTrue('first' in children.namedChildren)
+        children["first"] = child
+        self.assertTrue("first" in children.namedChildren)
         self.assertEqual(len(children.allChildren), 100)
-        self.assertEqual(child, children.namedChildren['first'])
-        self.assertEqual(children.dimensionsForChildNamed('first'), 2)
+        self.assertEqual(child, children.namedChildren["first"])
+        self.assertEqual(children.dimensionsForChildNamed("first"), 2)
 
     def test_set_parent_zero_dm(self):
         parent = DummyObject()
         children = Children(parent)
         child = DummyObject()
-        children['test'] = child
+        children["test"] = child
         self.assertEqual(child.parent, parent)
         self.assertEqual(children.allChildren[0].parent, parent)
 
@@ -154,7 +137,7 @@ class CellChildrenTests(unittest.TestCase):
         parent = DummyObject()
         children = Children(parent)
         child = [DummyObject() for d in range(10)]
-        children['test'] = child
+        children["test"] = child
         for item in child:
             self.assertEqual(item.parent, parent)
         for item in children.allChildren:
@@ -163,10 +146,8 @@ class CellChildrenTests(unittest.TestCase):
     def test_set_parent_two_dm(self):
         parent = DummyObject()
         children = Children(parent)
-        child = [
-            [DummyObject() for d in range(5)] for c in range(5)
-        ]
-        children['test'] = child
+        child = [[DummyObject() for d in range(5)] for c in range(5)]
+        children["test"] = child
         for outerItem in child:
             for innerItem in outerItem:
                 self.assertEqual(innerItem.parent, parent)
@@ -176,12 +157,8 @@ class CellChildrenTests(unittest.TestCase):
     def test_set_parent_three_dm(self):
         parent = DummyObject()
         children = Children(parent)
-        child = [
-            [
-                [DummyObject() for d in range(5)] for c in range(5)
-            ] for b in range(4)
-        ]
-        children['test'] = child
+        child = [[[DummyObject() for d in range(5)] for c in range(5)] for b in range(4)]
+        children["test"] = child
         for outer in child:
             for middle in outer:
                 for inner in middle:
@@ -195,33 +172,31 @@ class CellChildrenTests(unittest.TestCase):
         parent = DummyObject()
         children = Children(parent)
         child = DummyObject()
-        children['test'] = child
+        children["test"] = child
         self.assertEqual(child.parent, parent)
-        del children['test']
+        del children["test"]
         self.assertIsNone(child.parent)
 
     def test_unset_parent_one_dm(self):
         parent = DummyObject()
         children = Children(parent)
         child = [DummyObject() for d in range(4)]
-        children['test'] = child
+        children["test"] = child
         for item in child:
             self.assertEqual(item.parent, parent)
-        del children['test']
+        del children["test"]
         for item in child:
             self.assertIsNone(item.parent)
 
     def test_unset_parent_two_dm(self):
         parent = DummyObject()
         children = Children(parent)
-        child = [
-            [DummyObject() for d in range(5)] for c in range(5)
-        ]
-        children['test'] = child
+        child = [[DummyObject() for d in range(5)] for c in range(5)]
+        children["test"] = child
         for outer in child:
             for inner in outer:
                 self.assertEqual(inner.parent, parent)
-        del children['test']
+        del children["test"]
         for outer in child:
             for inner in outer:
                 self.assertIsNone(inner.parent)
@@ -230,36 +205,34 @@ class CellChildrenTests(unittest.TestCase):
         children = Children()
         child = DummyObject()
         otherChild = DummyObject()
-        children['test'] = child
-        children['other_test'] = otherChild
+        children["test"] = child
+        children["other_test"] = otherChild
         self.assertTrue(child in children._reverseLookup)
-        self.assertEqual(children._reverseLookup[child], 'test')
+        self.assertEqual(children._reverseLookup[child], "test")
         self.assertTrue(otherChild in children._reverseLookup)
-        self.assertEqual(children._reverseLookup[otherChild], 'other_test')
+        self.assertEqual(children._reverseLookup[otherChild], "other_test")
 
     def test_add_reverse_lookup_one_dm(self):
         children = Children()
         child = [DummyObject() for d in range(5)]
-        children['test'] = child
+        children["test"] = child
         other_child = [DummyObject() for d in range(6)]
-        children['other_test'] = other_child
+        children["other_test"] = other_child
         for item in child:
             self.assertTrue(item in children._reverseLookup)
-            self.assertEqual(children._reverseLookup[item], 'test')
+            self.assertEqual(children._reverseLookup[item], "test")
         for item in other_child:
             self.assertTrue(item in children._reverseLookup)
-            self.assertEqual(children._reverseLookup[item], 'other_test')
+            self.assertEqual(children._reverseLookup[item], "other_test")
 
     def test_add_reverse_lookup_two_dm(self):
         children = Children()
-        child = [
-            [DummyObject() for d in range(5)] for c in range(10)
-        ]
-        children['test'] = child
+        child = [[DummyObject() for d in range(5)] for c in range(10)]
+        children["test"] = child
         for outer in child:
             for inner in outer:
                 self.assertTrue(inner in children._reverseLookup)
-                self.assertEqual(children._reverseLookup[inner], 'test')
+                self.assertEqual(children._reverseLookup[inner], "test")
 
     def test_remove_all(self):
         # One dimensional child
@@ -269,15 +242,13 @@ class CellChildrenTests(unittest.TestCase):
         one_dm = [DummyObject() for d in range(10)]
 
         # Three dimensional child
-        two_dm = [
-            [DummyObject() for d in range(10)] for c in range(10)
-        ]
+        two_dm = [[DummyObject() for d in range(10)] for c in range(10)]
 
         # Add the children
         children = Children()
-        children['zero'] = zero_dm
-        children['one'] = one_dm
-        children['two'] = two_dm
+        children["zero"] = zero_dm
+        children["one"] = one_dm
+        children["two"] = two_dm
         self.assertEqual(len(children.allChildren), 111)
         self.assertEqual(len(children.namedChildren.keys()), 3)
 

--- a/object_database/web/cells/non_display/key_action.py
+++ b/object_database/web/cells/non_display/key_action.py
@@ -55,6 +55,7 @@ class KeyAction(Cell):
     front end), see the MDN docs here:
     https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
     """
+
     def __init__(self, keyCmd, callback, wantedInfo=None, priority=4, stopsPropagation=False):
         super().__init__()
         self.shouldDisplay = False
@@ -68,12 +69,12 @@ class KeyAction(Cell):
 
     def recalculate(self):
         self.exportData = {
-            'keyCombo': self.keyCmd,
-            'wantedEventKeys': self.wantedInfo,
-            'priority': self.priority,
-            'stopsPropagation': self.stopsPropagation
+            "keyCombo": self.keyCmd,
+            "wantedEventKeys": self.wantedInfo,
+            "priority": self.priority,
+            "stopsPropagation": self.stopsPropagation,
         }
 
     def onMessage(self, messageFrame):
-        messageFrame['data']['keyCmd'] = self.keyCmd
-        self.callback(messageFrame['data'])
+        messageFrame["data"]["keyCmd"] = self.keyCmd
+        self.callback(messageFrame["data"])

--- a/object_database/web/cells/util.py
+++ b/object_database/web/cells/util.py
@@ -25,7 +25,7 @@ def waitForCellsCondition(cells: Cells, condition, timeout=10.0):
         condRes = condition()
 
         if not condRes:
-            time.sleep(.1)
+            time.sleep(0.1)
             cells.renderMessages()
         else:
             return condRes
@@ -39,6 +39,7 @@ def waitForCellsCondition(cells: Cells, condition, timeout=10.0):
 
 class CellDecorator(object):
     """A function that takes (and returns) a single Cell, and can be applied with the '*' operator."""
+
     def __init__(self, cellFunction, name):
         self.cellFunction = cellFunction
         self.name = name
@@ -65,7 +66,7 @@ def ShrinkWrap(aCell):
     The modified Cell instance
     """
     aCell.isShrinkWrapped = True
-    aCell.exportData['shrinkwrap'] = True
+    aCell.exportData["shrinkwrap"] = True
     return aCell
 
 
@@ -84,11 +85,11 @@ def Flex(aCell):
     The modified Cell instance
     """
     aCell.isFlex = True
-    aCell.exportData['flexChild'] = True
+    aCell.exportData["flexChild"] = True
     return aCell
 
 
-def CustomInset(aCell, kind='padding', top=None, right=None, bottom=None, left=None):
+def CustomInset(aCell, kind="padding", top=None, right=None, bottom=None, left=None):
     """Cell modifier function that sets
     insets across varying dimensions of
     the visible Cell component.
@@ -128,17 +129,12 @@ def CustomInset(aCell, kind='padding', top=None, right=None, bottom=None, left=N
         (specified by `kind`) at the left
         dimension. Defaults to None.
     """
-    dimensions = {
-        'top': top,
-        'right': right,
-        'bottom': bottom,
-        'left': left
-    }
+    dimensions = {"top": top, "right": right, "bottom": bottom, "left": left}
 
-    if 'customStyle' not in aCell.exportData:
-        aCell.exportData['customStyle'] = {}
+    if "customStyle" not in aCell.exportData:
+        aCell.exportData["customStyle"] = {}
 
-    assert kind in ['padding', 'margin'], "Inset kind must be 'padding' or 'margin'"
+    assert kind in ["padding", "margin"], "Inset kind must be 'padding' or 'margin'"
 
     # Check if all values are the same.
     # If so, we only set the global inset
@@ -181,30 +177,32 @@ def Padding(amount, cell=None):
     if cell is None:
         return CellDecorator(lambda cell: Padding(amount, cell), f"Padding({amount})")
 
-    return CustomInset(cell, 'padding', top=amount,
-                       right=amount, bottom=amount, left=amount)
+    return CustomInset(cell, "padding", top=amount, right=amount, bottom=amount, left=amount)
 
 
 def PaddingDimension(amount, direction, cell=None):
-    assert direction in ['top', 'right', 'left', 'bottom'], f"Padding dimension error: {direction}"
+    assert direction in [
+        "top",
+        "right",
+        "left",
+        "bottom",
+    ], f"Padding dimension error: {direction}"
     if cell is None:
-        return CellDecorator(lambda cell: PaddingDimension(amount, direction, cell), f"PaddingDimension({amount}, {direction})")
-    dimensions = {
-        'top': 0,
-        'right': 0,
-        'bottom': 0,
-        'left': 0
-    }
+        return CellDecorator(
+            lambda cell: PaddingDimension(amount, direction, cell),
+            f"PaddingDimension({amount}, {direction})",
+        )
+    dimensions = {"top": 0, "right": 0, "bottom": 0, "left": 0}
     dimensions[direction] = amount
-    return CustomInset(cell, 'padding', **dimensions)
+    return CustomInset(cell, "padding", **dimensions)
 
 
 def PaddingRight(amount, cell=None):
-    return PaddingDimension(amount, 'right', cell)
+    return PaddingDimension(amount, "right", cell)
 
 
 def PaddingLeft(amount, cell=None):
-    return PaddingDimension(amount, 'left', cell)
+    return PaddingDimension(amount, "left", cell)
 
 
 def Margin(amount, cell=None):
@@ -230,8 +228,7 @@ def Margin(amount, cell=None):
     if cell is None:
         return CellDecorator(lambda cell: Margin(amount, cell), f"Margin({amount})")
 
-    return CustomInset(cell, 'margin', top=amount,
-                       right=amount, bottom=amount, left=amount)
+    return CustomInset(cell, "margin", top=amount, right=amount, bottom=amount, left=amount)
 
 
 def MarginRight(amount, cell=None):
@@ -259,8 +256,7 @@ def MarginRight(amount, cell=None):
     if cell is None:
         return CellDecorator(lambda cell: MarginSides(amount, cell), f"MarginRight({amount})")
 
-    return CustomInset(cell, 'margin', top=0,
-                       right=amount, bottom=0, left=0)
+    return CustomInset(cell, "margin", top=0, right=amount, bottom=0, left=0)
 
 
 def MarginLeft(amount, cell=None):
@@ -288,8 +284,7 @@ def MarginLeft(amount, cell=None):
     if cell is None:
         return CellDecorator(lambda cell: MarginSides(amount, cell), f"MarginRight({amount})")
 
-    return CustomInset(cell, 'margin', top=0,
-                       right=0, bottom=0, left=amount)
+    return CustomInset(cell, "margin", top=0, right=0, bottom=0, left=amount)
 
 
 def MarginSides(amount, cell=None):
@@ -316,5 +311,4 @@ def MarginSides(amount, cell=None):
     if cell is None:
         return CellDecorator(lambda cell: MarginSides(amount, cell), f"MarginSides({amount})")
 
-    return CustomInset(cell, 'margin', top=0,
-                       right=amount, bottom=0, left=amount)
+    return CustomInset(cell, "margin", top=0, right=amount, bottom=0, left=amount)

--- a/object_database/web/cells/util.py
+++ b/object_database/web/cells/util.py
@@ -38,7 +38,7 @@ def waitForCellsCondition(cells: Cells, condition, timeout=10.0):
 
 
 class CellDecorator(object):
-    """A function that takes (and returns) a single Cell, and can be applied with the '*' operator."""
+    """ A Cell -> Cell function that can be applied with the '*' operator. """
 
     def __init__(self, cellFunction, name):
         self.cellFunction = cellFunction

--- a/object_database/web/cells/views/page_view.py
+++ b/object_database/web/cells/views/page_view.py
@@ -29,8 +29,8 @@ class PageView(Cell):
         self.updateChildren()
 
     def updateChildren(self):
-        self.children['main'] = self.main
+        self.children["main"] = self.main
         if self.header:
-            self.children['header'] = self.header
+            self.children["header"] = self.header
         if self.footer:
-            self.children['footer'] = self.footer
+            self.children["footer"] = self.footer

--- a/object_database/web/cells/views/resizable_panel.py
+++ b/object_database/web/cells/views/resizable_panel.py
@@ -23,15 +23,14 @@ class ResizablePanel(Cell):
         self.first = first
         self.second = second
         self.split = split
-        self.exportData['split'] = split
+        self.exportData["split"] = split
         self.updateNamedChildren()
 
     def recalculate(self):
         self.updateNamedChildren()
-        self.exportData['split'] = self.split
+        self.exportData["split"] = self.split
 
     def updateNamedChildren(self):
-        self.children.addFromDict({
-            'first': Cell.makeCell(self.first),
-            'second': Cell.makeCell(self.second)
-        })
+        self.children.addFromDict(
+            {"first": Cell.makeCell(self.first), "second": Cell.makeCell(self.second)}
+        )

--- a/object_database/web/cells/views/split_view.py
+++ b/object_database/web/cells/views/split_view.py
@@ -40,6 +40,7 @@ class SplitView(Cell):
             (Card(text("Third Item")), 1)
         ])
     """
+
     def __init__(self, childrenTuples=[], split="vertical"):
         """
         Parameters:
@@ -77,12 +78,12 @@ class SplitView(Cell):
         proportions = []
         for childTuple in self.childrenTuples:
             proportions.append(childTuple[1])
-        self.exportData['proportions'] = proportions
-        self.exportData['split'] = self.split
+        self.exportData["proportions"] = proportions
+        self.exportData["split"] = self.split
 
     def updateNamedChildren(self):
         newChildren = []
         for i in range(len(self.childrenTuples)):
             childTuple = self.childrenTuples[i]
             newChildren.append(Cell.makeCell(childTuple[0]))
-        self.children['elements'] = newChildren
+        self.children["elements"] = newChildren

--- a/object_database/web/cells_demo/buttons.py
+++ b/object_database/web/cells_demo/buttons.py
@@ -19,10 +19,18 @@ from object_database.web.CellsTestPage import CellsTestPage
 class SomeButtons(CellsTestPage):
     def cell(self):
         return (
-            cells.Button("Small Active", lambda: None, small=True, active=True, style="primary")
-            + cells.Button("Small Inactive", lambda: None, small=True, active=False, style="primary")
-            + cells.Button("Large Active", lambda: None, small=False, active=True, style="primary")
-            + cells.Button("Large Inactive", lambda: None, small=False, active=False, style="primary")
+            cells.Button(
+                "Small Active", lambda: None, small=True, active=True, style="primary"
+            )
+            + cells.Button(
+                "Small Inactive", lambda: None, small=True, active=False, style="primary"
+            )
+            + cells.Button(
+                "Large Active", lambda: None, small=False, active=True, style="primary"
+            )
+            + cells.Button(
+                "Large Inactive", lambda: None, small=False, active=False, style="primary"
+            )
         )
 
     def text(self):

--- a/object_database/web/cells_demo/card.py
+++ b/object_database/web/cells_demo/card.py
@@ -26,9 +26,9 @@ class SingleCard(CellsTestPage):
 
 class CardWithTitle(CellsTestPage):
     def cell(self):
-        return cells.Card("This is the card text",
-                          header="This is the header text 2",
-                          padding=0)
+        return cells.Card(
+            "This is the card text", header="This is the header text 2", padding=0
+        )
 
     def text(self):
         return "You should see a single 'card' with header text."

--- a/object_database/web/cells_demo/clickable.py
+++ b/object_database/web/cells_demo/clickable.py
@@ -22,7 +22,7 @@ class ClickableText(CellsTestPage):
 
         return cells.Clickable(
             cells.Subscribed(lambda: f"You've clicked on this text {slot.get()} times"),
-            lambda: slot.set(slot.get()+1)
+            lambda: slot.set(slot.get() + 1),
         )
 
     def text(self):

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -58,7 +58,10 @@ class CodeEditorInHorizSequence(CellsTestPage):
         )
 
     def text(self):
-        return "You should see two buttons that let you turn the editor on and off, and also see its contents."
+        return (
+            "You should see two buttons that let you turn the editor "
+            "on and off, and also see its contents."
+        )
 
 
 class CodeEditorBasicHorizSequence(CellsTestPage):
@@ -76,7 +79,10 @@ class CodeEditorBasicHorizSequence(CellsTestPage):
         )
 
     def text(self):
-        return "Should see a CodeEditor and its content (in panel) in a HorizontalSequence that is not a flex parent"
+        return (
+            "Should see a CodeEditor and its content (in panel) in a "
+            "HorizontalSequence that is not a flex parent"
+        )
 
 
 class CodeEditorInSplitView(CellsTestPage):

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -20,9 +20,9 @@ class CodeEditorDemo(CellsTestPage):
     def cell(self):
         isShown = cells.Slot(False)
 
-        return cells.Button("Toggle the editor", lambda: isShown.set(not isShown.get())) + cells.Flex(cells.Subscribed(
-            lambda: cells.CodeEditor() if isShown.get() else None
-        ))
+        return cells.Button(
+            "Toggle the editor", lambda: isShown.set(not isShown.get())
+        ) + cells.Flex(cells.Subscribed(lambda: cells.CodeEditor() if isShown.get() else None))
 
     def text(self):
         return "You should see a button that lets you see a text editor."
@@ -42,34 +42,38 @@ class CodeEditorInHorizSequence(CellsTestPage):
             aSlot.toggle()
 
         return (
-            cells.Button("Show the editor", lambda: toggle(editorShown)) +
-            cells.Button("Show the editor's contents", lambda: toggle(contentsShown)) +
-            cells.Flex(cells.HorizontalSubscribedSequence(lambda:
-                                                          (["Ed"] if editorShown.get() else []) +
-                                                          (["Contents"] if contentsShown.get() else []),
-                                                          lambda which:
-                                                          cells.CodeEditor(onTextChange=onTextChange) if which == "Ed" else
-                                                          cells.Subscribed(lambda: contents.get()) if which == "Contents" else
-                                                          None)))
+            cells.Button("Show the editor", lambda: toggle(editorShown))
+            + cells.Button("Show the editor's contents", lambda: toggle(contentsShown))
+            + cells.Flex(
+                cells.HorizontalSubscribedSequence(
+                    lambda: (["Ed"] if editorShown.get() else [])
+                    + (["Contents"] if contentsShown.get() else []),
+                    lambda which: cells.CodeEditor(onTextChange=onTextChange)
+                    if which == "Ed"
+                    else cells.Subscribed(lambda: contents.get())
+                    if which == "Contents"
+                    else None,
+                )
+            )
+        )
 
     def text(self):
         return "You should see two buttons that let you turn the editor on and off, and also see its contents."
 
 
 class CodeEditorBasicHorizSequence(CellsTestPage):
-
     def cell(self):
         contents = cells.Slot("No Text Entered Yet!")
 
         def onTextChange(content, selection):
             contents.set(content)
 
-        return cells.HorizontalSequence([
-            cells.CodeEditor(onTextChange=onTextChange),
-            cells.Panel(
-                cells.Subscribed(contents.get)
-            )
-        ])
+        return cells.HorizontalSequence(
+            [
+                cells.CodeEditor(onTextChange=onTextChange),
+                cells.Panel(cells.Subscribed(contents.get)),
+            ]
+        )
 
     def text(self):
         return "Should see a CodeEditor and its content (in panel) in a HorizontalSequence that is not a flex parent"
@@ -82,11 +86,9 @@ class CodeEditorInSplitView(CellsTestPage):
         def onTextChange(buffer, selection):
             contents.set(buffer)
 
-        return (
-            cells.ResizablePanel(
-                cells.CodeEditor(onTextChange=onTextChange),
-                cells.Subscribed(lambda: cells.Code(contents.get())),
-            )
+        return cells.ResizablePanel(
+            cells.CodeEditor(onTextChange=onTextChange),
+            cells.Subscribed(lambda: cells.Code(contents.get())),
         )
 
     def text(self):
@@ -100,12 +102,10 @@ class CodeEditorInSplitViewWithHeader(CellsTestPage):
         def onTextChange(buffer, selection):
             contents.set(buffer)
 
-        return (
-            cells.ResizablePanel(
-                cells.Text("This is an editor:") + cells.CodeEditor(onTextChange=onTextChange),
-                cells.Text("This should show what's in the editor") +
-                cells.Subscribed(lambda: cells.Code(contents.get())),
-            )
+        return cells.ResizablePanel(
+            cells.Text("This is an editor:") + cells.CodeEditor(onTextChange=onTextChange),
+            cells.Text("This should show what's in the editor")
+            + cells.Subscribed(lambda: cells.Code(contents.get())),
         )
 
     def text(self):

--- a/object_database/web/cells_demo/collapsible_panel.py
+++ b/object_database/web/cells_demo/collapsible_panel.py
@@ -23,21 +23,21 @@ class BasicCollapsiblePanel(CellsTestPage):
         return cells.Subscribed(
             lambda: cells.Button(
                 "Close" if isExpanded.get() else "Open",
-                lambda: isExpanded.set(not isExpanded.get())
+                lambda: isExpanded.set(not isExpanded.get()),
             )
         ) + cells.CollapsiblePanel(
             panel=cells.SubscribedSequence(
                 lambda: [1],
-                lambda i: cells.Text("PANE") +
+                lambda i: cells.Text("PANE")
                 # somehow, the presence of this cell prevents you from opening and closing
                 # the panel more than once?
-                cells.Subscribed(lambda: "Some Text")
+                + cells.Subscribed(lambda: "Some Text"),
             ),
             content=cells.ResizablePanel(
                 cells.Subscribed(lambda: cells.Card("I am some content")),
-                cells.Subscribed(lambda: cells.Card("I am the other half of content"))
+                cells.Subscribed(lambda: cells.Card("I am the other half of content")),
             ),
-            isExpanded=lambda: isExpanded.get()
+            isExpanded=lambda: isExpanded.get(),
         )
 
     def text(self):

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -91,7 +91,10 @@ class VertSequenceWithoutFlexNestedSeq(CellsTestPage):
         return firstButton + cells.Sequence(numberedTextItems) + lastButton
 
     def text(self):
-        return "Non Flex-Parent Sequences should flatten any nested Sequences and overflow normally"
+        return (
+            "Non Flex-Parent Sequences should flatten any nested Sequences "
+            "and overflow normally"
+        )
 
 
 class HorizSequenceWithFlex(CellsTestPage):

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -19,7 +19,12 @@ from object_database.web.cells.util import Flex
 
 class VertSequenceBasicConcat(CellsTestPage):
     def cell(self):
-        return (cells.Text("Hello") + cells.Text("There") + cells.Text("This Is A") + cells.Button("Button", lambda: None))
+        return (
+            cells.Text("Hello")
+            + cells.Text("There")
+            + cells.Text("This Is A")
+            + cells.Button("Button", lambda: None)
+        )
 
     def text(self):
         return "Should use plus operator to produce a non-flexed vertical sequence"
@@ -31,11 +36,13 @@ class VertSequenceWithFlex(CellsTestPage):
         middleCard = cells.Card(cells.Sequence(textItems))
         firstButton = cells.Button("First Button", lambda: None)
         secondButton = cells.Button("Another Button", lambda: None)
-        return (firstButton + Flex(middleCard) + secondButton)
+        return firstButton + Flex(middleCard) + secondButton
 
     def text(self):
-        return ("The vertical sequence should display two shrinkwrapped buttons sandwiching",
-                " a flexed-out card containing a scrollable list of items")
+        return (
+            "The vertical sequence should display two shrinkwrapped buttons sandwiching",
+            " a flexed-out card containing a scrollable list of items",
+        )
 
 
 class VertSequenceWithMultiFlex(CellsTestPage):
@@ -46,11 +53,13 @@ class VertSequenceWithMultiFlex(CellsTestPage):
         secondCard = cells.Card(cells.Sequence(secondTextItems))
         firstButton = cells.Button("First Button", lambda: None)
         secondButton = cells.Button("Another Button", lambda: None)
-        return (firstButton + Flex(firstCard) + Flex(secondCard) + secondButton)
+        return firstButton + Flex(firstCard) + Flex(secondCard) + secondButton
 
     def text(self):
-        return ("The vertical sequence should display two shrinkwrapped buttons sandwiching *two*",
-                " flexed-out cards of equal, greedy size containing a scrollable list of items")
+        return (
+            "The vertical sequence should display two shrinkwrapped buttons sandwiching *two*",
+            " flexed-out cards of equal, greedy size containing a scrollable list of items",
+        )
 
 
 class VertSequenceWithoutFlex(CellsTestPage):
@@ -59,23 +68,27 @@ class VertSequenceWithoutFlex(CellsTestPage):
         middleCard = cells.Card(cells.Sequence(textItems))
         firstButton = cells.Button("First Button", lambda: None)
         secondButton = cells.Button("Another Button", lambda: None)
-        return (firstButton + middleCard + secondButton)
+        return firstButton + middleCard + secondButton
 
     def text(self):
-        return ("The vertical sequence should not be a flex container and should",
-                " display all of its contents using as much space as it needs")
+        return (
+            "The vertical sequence should not be a flex container and should",
+            " display all of its contents using as much space as it needs",
+        )
 
 
 class VertSequenceWithoutFlexNestedSeq(CellsTestPage):
     def cell(self):
-        letteredTextItems = [cells.Text("Inner %s" % letter) for letter in ['A', 'B', 'C', 'D', 'E']]
+        letteredTextItems = [
+            cells.Text("Inner %s" % letter) for letter in ["A", "B", "C", "D", "E"]
+        ]
         numberedTextItems = [cells.Text("Item %s" % i) for i in range(50)]
         numberedTextItems.append(cells.Sequence(letteredTextItems))
 
         firstButton = cells.Button("Top Button", lambda: None)
         lastButton = cells.Button("Bottom Button", lambda: None)
 
-        return (firstButton + cells.Sequence(numberedTextItems) + lastButton)
+        return firstButton + cells.Sequence(numberedTextItems) + lastButton
 
     def text(self):
         return "Non Flex-Parent Sequences should flatten any nested Sequences and overflow normally"
@@ -87,11 +100,13 @@ class HorizSequenceWithFlex(CellsTestPage):
         middleArea = cells.HorizontalSequence(textItems)
         firstButton = cells.Button("First Button", lambda: None)
         secondButton = cells.Button("Another Button", lambda: None)
-        return (firstButton >> Flex(middleArea) >> secondButton)
+        return firstButton >> Flex(middleArea) >> secondButton
 
     def text(self):
-        return ("The vertical sequence should display two shrinkwrapped buttons sandwiching ",
-                "a flexed-out sequence containing a scrollable list of inner buttons")
+        return (
+            "The vertical sequence should display two shrinkwrapped buttons sandwiching ",
+            "a flexed-out sequence containing a scrollable list of inner buttons",
+        )
 
 
 class HorizSequenceWithoutFlex(CellsTestPage):
@@ -102,13 +117,20 @@ class HorizSequenceWithoutFlex(CellsTestPage):
         return cells.HorizontalSequence([firstButton] + buttonItems + [secondButton])
 
     def text(self):
-        return ("The vertical sequence should not be a flex container",
-                " and should display all of its contents using as much space as it needs")
+        return (
+            "The vertical sequence should not be a flex container",
+            " and should display all of its contents using as much space as it needs",
+        )
 
 
 class HorizSequenceBasicConcat(CellsTestPage):
     def cell(self):
-        result = (cells.Text("Hi") >> cells.Text("Bye") >> cells.Text("Go Away") >> cells.Button("Away", lambda: None))
+        result = (
+            cells.Text("Hi")
+            >> cells.Text("Bye")
+            >> cells.Text("Go Away")
+            >> cells.Button("Away", lambda: None)
+        )
         return result
 
     def text(self):
@@ -117,7 +139,9 @@ class HorizSequenceBasicConcat(CellsTestPage):
 
 class MixedSequenceComposition(CellsTestPage):
     def cell(self):
-        result = (cells.Text("Hi") >> cells.Text("Bye")) + (cells.Text("Go Away") >> cells.Button("Away", lambda: None))
+        result = (cells.Text("Hi") >> cells.Text("Bye")) + (
+            cells.Text("Go Away") >> cells.Button("Away", lambda: None)
+        )
         return result
 
     def text(self):

--- a/object_database/web/cells_demo/flex_subscribed_sequence.py
+++ b/object_database/web/cells_demo/flex_subscribed_sequence.py
@@ -23,10 +23,9 @@ class HorizontalSubscribedSequenceNotFlex(CellsTestPage):
         top_button = cells.Button("Add Item", lambda: x.set(x.get() + (len(x.get()),)))
         bottom_button = cells.Button("This does nothing", lambda: None)
         sub_sequence = cells.HorizontalSubscribedSequence(
-            lambda: x.get(),
-            lambda item: cells.Text("Item: {}".format(item))
+            lambda: x.get(), lambda item: cells.Text("Item: {}".format(item))
         )
-        return (top_button >> sub_sequence >> bottom_button)
+        return top_button >> sub_sequence >> bottom_button
 
     def text(self):
         return "Should display a horizontal sequence that is NOT flexed"
@@ -38,10 +37,9 @@ class VerticalSubscribedSequenceNotFlex(CellsTestPage):
         top_button = cells.Button("Add Item", lambda: x.set(x.get() + (len(x.get()),)))
         bottom_button = cells.Button("This does nothing", lambda: None)
         sub_sequence = cells.SubscribedSequence(
-            lambda: x.get(),
-            lambda item: cells.Text("Item: {}".format(item))
+            lambda: x.get(), lambda item: cells.Text("Item: {}".format(item))
         )
-        return (top_button + sub_sequence + bottom_button)
+        return top_button + sub_sequence + bottom_button
 
     def text(self):
         return "Should display a vertical sequence that is NOT flexed"
@@ -53,39 +51,36 @@ class VerticalSubscribedSequenceFlexed(CellsTestPage):
         top_button = cells.Button("Add Item", lambda: x.set(x.get() + (len(x.get()),)))
         bottom_button = cells.Button("This does nothing", lambda: None)
         sub_sequence = cells.SubscribedSequence(
-            lambda: x.get(),
-            lambda item: cells.Text("Item: {}".format(item))
+            lambda: x.get(), lambda item: cells.Text("Item: {}".format(item))
         )
-        return (top_button + Flex(sub_sequence) + bottom_button)
+        return top_button + Flex(sub_sequence) + bottom_button
 
     def text(self):
         return "Should display a vertical sequence that is NOT flexed"
 
 
 class VertSubscribedSequenceNonFlexNestedFlex(CellsTestPage):
-
     def text(self):
-        return "You should be able to add Flexed SubscribedSequences to a flex subscribedsequence"
+        return (
+            "You should be able to add Flexed SubscribedSequences to a flex subscribedsequence"
+        )
 
     def newNested(self):
         nested_slot = cells.Slot(())
         top_button = cells.Button(
             "Add Nested Item",
             lambda: nested_slot.set(nested_slot.get() + (len(nested_slot.get()),)),
-            small=True)
+            small=True,
+        )
         bottom_button = cells.Button("Does Nothing", lambda: None, small=True)
         sub_sequence = cells.SubscribedSequence(
-            lambda: nested_slot.get(),
-            lambda item: cells.Text("SubItem {}".format(item))
+            lambda: nested_slot.get(), lambda item: cells.Text("SubItem {}".format(item))
         )
         return Flex(top_button + sub_sequence + bottom_button)
 
     def cell(self):
         x = cells.Slot(())
-        top_button = cells.Button("Add Item",
-                                  lambda: x.set(x.get() + (self.newNested(),)))
+        top_button = cells.Button("Add Item", lambda: x.set(x.get() + (self.newNested(),)))
         bottom_button = cells.Button("This does nothing", lambda: None)
-        sub_sequence = cells.SubscribedSequence(
-            lambda: x.get(),
-            lambda item: item)
+        sub_sequence = cells.SubscribedSequence(lambda: x.get(), lambda item: item)
         return cells.Sequence([Flex(top_button + Flex(sub_sequence) + bottom_button)])

--- a/object_database/web/cells_demo/insets.py
+++ b/object_database/web/cells_demo/insets.py
@@ -18,12 +18,11 @@ from object_database.web.cells.util import Padding, Margin
 
 
 class BasicPadding(CellsTestPage):
-
     def cell(self):
         buttons = [
             Padding(10, cells.Button("First", lambda: None)),
             Padding(10, cells.Button("Second", lambda: None)),
-            Padding(10, cells.Button("Third", lambda: None))
+            Padding(10, cells.Button("Third", lambda: None)),
         ]
         return cells.HorizontalSequence(buttons)
 
@@ -36,7 +35,7 @@ class BasicMargin(CellsTestPage):
         buttons = [
             Margin(10, cells.Button("First", lambda: None)),
             Margin(10, cells.Button("Second", lambda: None)),
-            Margin(10, cells.Button("Third", lambda: None))
+            Margin(10, cells.Button("Third", lambda: None)),
         ]
         return cells.HorizontalSequence(buttons)
 

--- a/object_database/web/cells_demo/key_action.py
+++ b/object_database/web/cells_demo/key_action.py
@@ -17,18 +17,19 @@ from object_database.web.CellsTestPage import CellsTestPage
 
 
 class PressAltT(CellsTestPage):
-
     def cell(self):
         lastKeystroke = cells.Slot()
         subCell = cells.Subscribed(lambda: lastKeystroke.get())
-        card = cells.Card(
-            subCell,
-            cells.Text("Press Alt+t to update timestamp from browser")
-        )
+        card = cells.Card(subCell, cells.Text("Press Alt+t to update timestamp from browser"))
 
-        return cells.Sequence([
-            card,
-            cells.KeyAction('Alt+t', lambda x: lastKeystroke.set(x['timeStamp']), ['timeStamp'])])
+        return cells.Sequence(
+            [
+                card,
+                cells.KeyAction(
+                    "Alt+t", lambda x: lastKeystroke.set(x["timeStamp"]), ["timeStamp"]
+                ),
+            ]
+        )
 
     def text(self):
         return "Should print the current timestamp in the card when pushing Alt+t"

--- a/object_database/web/cells_demo/modal_dialogs.py
+++ b/object_database/web/cells_demo/modal_dialogs.py
@@ -30,7 +30,10 @@ class BasicModal(CellsTestPage):
         return cells.Card(button + modal)
 
     def text(self):
-        return "When you click Toggle, you should see a basic modal appear and it should be closable"
+        return (
+            "When you click Toggle, you should see a basic modal appear "
+            "and it should be closable"
+        )
 
 
 class ModalWithUpdateField(CellsTestPage):
@@ -53,5 +56,6 @@ class ModalWithUpdateField(CellsTestPage):
 
     def text(self):
         return (
-            "You should see a button that lets you edit the 'Some Text' text in a modal popup."
+            "You should see a button that lets you edit the "
+            "'Some Text' text in a modal popup."
         )

--- a/object_database/web/cells_demo/modal_dialogs.py
+++ b/object_database/web/cells_demo/modal_dialogs.py
@@ -25,10 +25,7 @@ class BasicModal(CellsTestPage):
 
         button = cells.Button("Toggle Modal", buttonCallback)
         modal = cells.Modal(
-            "Basic Modal",
-            cells.Text("Modal Body"),
-            isShowing,
-            Close=buttonCallback
+            "Basic Modal", cells.Text("Modal Body"), isShowing, Close=buttonCallback
         )
         return cells.Card(button + modal)
 
@@ -50,10 +47,11 @@ class ModalWithUpdateField(CellsTestPage):
             "Text Updater",
             cells.SingleLineTextBox(sharedContent),
             show=isShowing,
-            Close=buttonCallback
+            Close=buttonCallback,
         )
-        return cells.Card(
-            button + textDisplay + modal)
+        return cells.Card(button + textDisplay + modal)
 
     def text(self):
-        return "You should see a button that lets you edit the 'Some Text' text in a modal popup."
+        return (
+            "You should see a button that lets you edit the 'Some Text' text in a modal popup."
+        )

--- a/object_database/web/cells_demo/octicon.py
+++ b/object_database/web/cells_demo/octicon.py
@@ -18,7 +18,7 @@ from object_database.web.CellsTestPage import CellsTestPage
 
 class BasicOcticon(CellsTestPage):
     def cell(self):
-        return cells.Card(cells.Octicon('shield', color='green'), padding=4)
+        return cells.Card(cells.Octicon("shield", color="green"), padding=4)
 
     def text(self):
         return "You should see a single octicon."
@@ -26,11 +26,16 @@ class BasicOcticon(CellsTestPage):
 
 class MultiOcticon(CellsTestPage):
     def cell(self):
-        return cells.Card(cells.HorizontalSequence([
-            cells.Octicon('shield', color='green'),
-            cells.Octicon('stop', color='red'),
-            cells.Octicon('alert', color='yellow')
-        ]), padding=4)
+        return cells.Card(
+            cells.HorizontalSequence(
+                [
+                    cells.Octicon("shield", color="green"),
+                    cells.Octicon("stop", color="red"),
+                    cells.Octicon("alert", color="yellow"),
+                ]
+            ),
+            padding=4,
+        )
 
     def text(self):
         return "You should see a single octicon."

--- a/object_database/web/cells_demo/panel.py
+++ b/object_database/web/cells_demo/panel.py
@@ -56,7 +56,8 @@ class NestedVertFlexPanel(CellsTestPage):
     def text(self):
         return (
             "Should see vertical sequence of two panels, the second is ",
-            "flexed, first is shrinkwrapped vertically, and both expand fully on horizontal axis",
+            "flexed, first is shrinkwrapped vertically, and both expand "
+            "fully on horizontal axis",
         )
 
 

--- a/object_database/web/cells_demo/panel.py
+++ b/object_database/web/cells_demo/panel.py
@@ -18,54 +18,69 @@ from object_database.web.CellsTestPage import CellsTestPage
 
 class BasicPanel(CellsTestPage):
     def cell(self):
-        return cells.Panel(cells.Text("Button in a Panel") + cells.Button("A Button", lambda: None))
+        return cells.Panel(
+            cells.Text("Button in a Panel") + cells.Button("A Button", lambda: None)
+        )
 
     def text(self):
-        return ("Should see Text and Button Vert Sequence inside of a bordered panel,",
-                " taking up greedy space in both dimensions")
+        return (
+            "Should see Text and Button Vert Sequence inside of a bordered panel,",
+            " taking up greedy space in both dimensions",
+        )
 
 
 class BasicPanelInFlexSequence(CellsTestPage):
     def cell(self):
-        outer = cells.Sequence([
-            cells.Button("Top Button", lambda: None),
-            cells.Flex(cells.Panel(
-                cells.Text("A Flexing Panel"))),
-            cells.Button("Bottom Button", lambda: None)
-        ])
+        outer = cells.Sequence(
+            [
+                cells.Button("Top Button", lambda: None),
+                cells.Flex(cells.Panel(cells.Text("A Flexing Panel"))),
+                cells.Button("Bottom Button", lambda: None),
+            ]
+        )
         return outer
 
     def text(self):
-        return ("Should see a flex parent vert sequence where the Panel is flexing as",
-                " the child, no longer taking up 100% in both dimensions (since we are flexing)")
+        return (
+            "Should see a flex parent vert sequence where the Panel is flexing as",
+            " the child, no longer taking up 100% in both dimensions (since we are flexing)",
+        )
 
 
 class NestedVertFlexPanel(CellsTestPage):
     def cell(self):
-        return cells.Panel(cells.Text("Button in a Panel") +
-                           cells.Button("A Button", lambda: None)) + cells.Flex(cells.Panel(cells.Text("something else")))
+        return cells.Panel(
+            cells.Text("Button in a Panel") + cells.Button("A Button", lambda: None)
+        ) + cells.Flex(cells.Panel(cells.Text("something else")))
 
     def text(self):
-        return ("Should see vertical sequence of two panels, the second is ",
-                "flexed, first is shrinkwrapped vertically, and both expand fully on horizontal axis")
+        return (
+            "Should see vertical sequence of two panels, the second is ",
+            "flexed, first is shrinkwrapped vertically, and both expand fully on horizontal axis",
+        )
 
 
 class NestedVertHorizPanel(CellsTestPage):
     def cell(self):
-        return cells.Panel(cells.Text("Button in a Panel") +
-                           cells.Button("A Button", lambda: None)) >> cells.Flex(
-                               cells.Panel(cells.Text("something else")))
+        return cells.Panel(
+            cells.Text("Button in a Panel") + cells.Button("A Button", lambda: None)
+        ) >> cells.Flex(cells.Panel(cells.Text("something else")))
 
     def text(self):
-        return ("Should see horizontal sequence of two panels, the second is flexed,",
-                " first is shrinkwrapped horizontally, and both expand fully on horizontal axis")
+        return (
+            "Should see horizontal sequence of two panels, the second is flexed,",
+            " first is shrinkwrapped horizontally, and both expand fully on horizontal axis",
+        )
 
 
 class HorizPanelNonWrapSequence(CellsTestPage):
     def cell(self):
         def make_panel(num):
             return cells.Panel(
-                cells.Text("Panel {}".format(num)) + cells.Button("Button {}".format(num), lambda: None))
+                cells.Text("Panel {}".format(num))
+                + cells.Button("Button {}".format(num), lambda: None)
+            )
+
         panels = [make_panel(i) for i in range(50)]
         return cells.HorizontalSequence(panels, wrap=False)
 
@@ -77,7 +92,10 @@ class HorizPanelDoesWrapSequence(CellsTestPage):
     def cell(self):
         def make_panel(num):
             return cells.Panel(
-                cells.Text("Panel {}".format(num)) + cells.Button("Button {}".format(num), lambda: None))
+                cells.Text("Panel {}".format(num))
+                + cells.Button("Button {}".format(num), lambda: None)
+            )
+
         panels = [make_panel(i) for i in range(50)]
         return cells.HorizontalSequence(panels)
 

--- a/object_database/web/cells_demo/resizable_panel.py
+++ b/object_database/web/cells_demo/resizable_panel.py
@@ -17,15 +17,9 @@ from object_database.web.CellsTestPage import CellsTestPage
 
 
 class BasicHResizePanel(CellsTestPage):
-
     def cell(self):
         return cells.ResizablePanel(
-            cells.Card(
-                cells.Text("First")
-            ),
-            cells.Card(
-                cells.Text("Second")
-            )
+            cells.Card(cells.Text("First")), cells.Card(cells.Text("Second"))
         )
 
     def text(self):
@@ -35,13 +29,9 @@ class BasicHResizePanel(CellsTestPage):
 class BasicVResizePanel(CellsTestPage):
     def cell(self):
         return cells.ResizablePanel(
-            cells.Card(
-                cells.Text("First")
-            ),
-            cells.Card(
-                cells.Text("Second")
-            ),
-            split="horizontal"
+            cells.Card(cells.Text("First")),
+            cells.Card(cells.Text("Second")),
+            split="horizontal",
         )
 
     def text(self):

--- a/object_database/web/cells_demo/scrollable.py
+++ b/object_database/web/cells_demo/scrollable.py
@@ -19,9 +19,7 @@ from object_database.web.CellsTestPage import CellsTestPage
 class basicScrollable(CellsTestPage):
     def cell(self):
         return cells.Scrollable(
-            cells.Sequence([
-                cells.Card("This is a card", padding=2) for index in range(20)
-            ])
+            cells.Sequence([cells.Card("This is a card", padding=2) for index in range(20)])
         )
 
     def text(self):
@@ -30,18 +28,32 @@ class basicScrollable(CellsTestPage):
 
 class multiScrollable(CellsTestPage):
     def cell(self):
-        return cells.SplitView([
-            (cells.Card(
-                cells.Scrollable(cells.Sequence([
-                    cells.Card("Row %s of 20" % (item + 1)) for item in range(20)
-                ])),
-                padding=10), 1),
-            (cells.Card(
-                cells.Scrollable(cells.Sequence([
-                    cells.Card("Row %s of 10" % (item + 1)) for item in range(10)
-                ])),
-                padding=10), 10),
-        ])
+        return cells.SplitView(
+            [
+                (
+                    cells.Card(
+                        cells.Scrollable(
+                            cells.Sequence(
+                                [cells.Card("Row %s of 20" % (item + 1)) for item in range(20)]
+                            )
+                        ),
+                        padding=10,
+                    ),
+                    1,
+                ),
+                (
+                    cells.Card(
+                        cells.Scrollable(
+                            cells.Sequence(
+                                [cells.Card("Row %s of 10" % (item + 1)) for item in range(10)]
+                            )
+                        ),
+                        padding=10,
+                    ),
+                    10,
+                ),
+            ]
+        )
 
     def text(self):
         return "You should see some scrollable content."

--- a/object_database/web/cells_demo/sequence.py
+++ b/object_database/web/cells_demo/sequence.py
@@ -21,7 +21,7 @@ class SplitSequence(CellsTestPage):
         return cells.Sequence(
             [
                 cells.Card(cells.Text("item 1", text_color="red")),
-                cells.Card(cells.Text("item 2", text_color="blue"))
+                cells.Card(cells.Text("item 2", text_color="blue")),
             ]
         )
 
@@ -34,7 +34,7 @@ class HorizontalSplitSequence(CellsTestPage):
         return cells.HorizontalSequence(
             [
                 cells.Card(cells.Text("item 1", text_color="red")),
-                cells.Card(cells.Text("item 2", text_color="blue"))
+                cells.Card(cells.Text("item 2", text_color="blue")),
             ]
         )
 

--- a/object_database/web/cells_demo/sheet.py
+++ b/object_database/web/cells_demo/sheet.py
@@ -20,8 +20,7 @@ import time
 class NewBasicSheet(CellsTestPage):
     def cell(self):
         # Create the datasource
-        datasource = [["{},{}".format(i, j) for j in range(100)] for i in
-                      range(10)]
+        datasource = [["{},{}".format(i, j) for j in range(100)] for i in range(10)]
 
         def colFun(start_column, end_column, num_columns=10):
             columns = []
@@ -31,8 +30,7 @@ class NewBasicSheet(CellsTestPage):
                 columns.append("Column {}".format(i))
             return columns
 
-        def rowFun(start_row, end_row, start_column, end_column, num_rows=100,
-                   num_columns=10):
+        def rowFun(start_row, end_row, start_column, end_column, num_rows=100, num_columns=10):
             rows = []
             if start_row >= num_rows or start_column >= num_columns:
                 return rows
@@ -43,6 +41,7 @@ class NewBasicSheet(CellsTestPage):
                 r = ["row_%s" % i] + r
                 rows.append(r)
             return rows
+
         return cells.Sheet(colFun, rowFun, colWidth=75, rowHeight=30)
 
     def text(self):
@@ -62,8 +61,7 @@ class NewBasicSheetWithDelay(CellsTestPage):
                 columns.append("Column {}".format(i))
             return columns
 
-        def rowFun(start_row, end_row, start_column, end_column, num_rows=100,
-                   num_columns=10):
+        def rowFun(start_row, end_row, start_column, end_column, num_rows=100, num_columns=10):
             rows = []
             if start_row >= num_rows or start_column >= num_columns:
                 return rows
@@ -75,6 +73,7 @@ class NewBasicSheetWithDelay(CellsTestPage):
                 rows.append(r)
             time.sleep(0.2)
             return rows
+
         return cells.Sheet(colFun, rowFun, colWidth=75, rowHeight=30)
 
     def text(self):
@@ -93,18 +92,21 @@ class BasicSheet(CellsTestPage):
                 columns.append("column_%s" % i)
             return columns
 
-        def rowFun(start_row, end_row, start_column, end_column,
-                   num_rows=100, num_columns=num_columns):
+        def rowFun(
+            start_row, end_row, start_column, end_column, num_rows=100, num_columns=num_columns
+        ):
             rows = []
             if start_row >= num_rows or start_column > num_columns:
                 return rows
             end_column = min(end_column, num_columns)
             end_row = min(end_row, num_rows)
             for i in range(start_row, end_row):
-                r = ["index_%s" % i] + ["entry_%s_%s" % (i, j) for j in
-                                        range(start_column, end_column)]
+                r = ["index_%s" % i] + [
+                    "entry_%s_%s" % (i, j) for j in range(start_column, end_column)
+                ]
                 rows.append(r)
             return rows
+
         return cells.Sheet(colFun, rowFun, colWidth=70, rowHeight=25)
 
     def text(self):
@@ -124,16 +126,23 @@ class BiggerSheet(CellsTestPage):
                 columns.append("column_%s" % i)
             return columns
 
-        def rowFun(start_row, end_row, start_column, end_column,
-                   num_rows=num_rows, num_columns=num_columns):
+        def rowFun(
+            start_row,
+            end_row,
+            start_column,
+            end_column,
+            num_rows=num_rows,
+            num_columns=num_columns,
+        ):
             rows = []
             if start_row >= num_rows or start_column > num_columns:
                 return rows
             end_column = min(end_column, num_columns)
             end_row = min(end_row, num_rows)
             for i in range(start_row, end_row):
-                r = ["index_%s" % i] + ["entry_%s_%s" % (i, j) for j in
-                                        range(start_column, end_column)]
+                r = ["index_%s" % i] + [
+                    "entry_%s_%s" % (i, j) for j in range(start_column, end_column)
+                ]
                 rows.append(r)
             return rows
 

--- a/object_database/web/cells_demo/split_view.py
+++ b/object_database/web/cells_demo/split_view.py
@@ -40,7 +40,10 @@ class BasicRow(CellsTestPage):
         )
 
     def text(self):
-        return "You should see two Cards on top of each other, the first twice as long as the second"
+        return (
+            "You should see two Cards on top of each other, "
+            "the first twice as long as the second"
+        )
 
 
 class NestedRowToColumn(CellsTestPage):

--- a/object_database/web/cells_demo/split_view.py
+++ b/object_database/web/cells_demo/split_view.py
@@ -18,10 +18,12 @@ from object_database.web.CellsTestPage import CellsTestPage
 
 class BasicColumn(CellsTestPage):
     def cell(self):
-        return cells.SplitView([
-            (cells.Card(cells.Text('First Element')), 1),
-            (cells.Card(cells.Text('Second Element')), 2)
-        ])
+        return cells.SplitView(
+            [
+                (cells.Card(cells.Text("First Element")), 1),
+                (cells.Card(cells.Text("Second Element")), 2),
+            ]
+        )
 
     def text(self):
         return "You should see two cards, the second twice as wide as the first"
@@ -29,10 +31,13 @@ class BasicColumn(CellsTestPage):
 
 class BasicRow(CellsTestPage):
     def cell(self):
-        return cells.SplitView([
-            (cells.Card(cells.Text('First Element')), 2),
-            (cells.Card(cells.Text('Second Element')), 1)
-        ], split="horizontal")
+        return cells.SplitView(
+            [
+                (cells.Card(cells.Text("First Element")), 2),
+                (cells.Card(cells.Text("Second Element")), 1),
+            ],
+            split="horizontal",
+        )
 
     def text(self):
         return "You should see two Cards on top of each other, the first twice as long as the second"
@@ -40,20 +45,36 @@ class BasicRow(CellsTestPage):
 
 class NestedRowToColumn(CellsTestPage):
     def cell(self):
-        return cells.SplitView([
-            (cells.Card(
-                cells.SplitView([
-                    (cells.Card("Row 1 Column 1"), 1),
-                    (cells.Card("Row 2 Column 1"), 1)
-                ], split="horizontal"),
-                padding=10), 2),
-            (cells.Card(
-                cells.SplitView([
-                    (cells.Card("Row 1 Column 2"), 4),
-                    (cells.Card("Row 2 Column 2"), 1)
-                ], split="horizontal"),
-                padding=10), 1)
-        ])
+        return cells.SplitView(
+            [
+                (
+                    cells.Card(
+                        cells.SplitView(
+                            [
+                                (cells.Card("Row 1 Column 1"), 1),
+                                (cells.Card("Row 2 Column 1"), 1),
+                            ],
+                            split="horizontal",
+                        ),
+                        padding=10,
+                    ),
+                    2,
+                ),
+                (
+                    cells.Card(
+                        cells.SplitView(
+                            [
+                                (cells.Card("Row 1 Column 2"), 4),
+                                (cells.Card("Row 2 Column 2"), 1),
+                            ],
+                            split="horizontal",
+                        ),
+                        padding=10,
+                    ),
+                    1,
+                ),
+            ]
+        )
 
     def text(self):
         return "You should see a SplitView row of two SplitView columns"

--- a/object_database/web/cells_demo/table.py
+++ b/object_database/web/cells_demo/table.py
@@ -23,7 +23,7 @@ class MultiPageTable(CellsTestPage):
             rowFun=lambda: list(range(100)),
             headerFun=lambda x: x,
             rendererFun=lambda w, field: "hi",
-            maxRowsPerPage=50
+            maxRowsPerPage=50,
         )
 
     def text(self):

--- a/object_database/web/cells_demo/table.py
+++ b/object_database/web/cells_demo/table.py
@@ -27,4 +27,7 @@ class MultiPageTable(CellsTestPage):
         )
 
     def text(self):
-        return "You should see a table with two columns, two pages of 50 rows and all fields saying 'hi'"
+        return (
+            "You should see a table with two columns, "
+            "two pages of 50 rows and all fields saying 'hi'"
+        )

--- a/object_database/web/cells_demo/text.py
+++ b/object_database/web/cells_demo/text.py
@@ -26,8 +26,7 @@ class BasicText(CellsTestPage):
 
 class EmbeddedColoredText(CellsTestPage):
     def cell(self):
-        return cells.Card(cells.Text("This is some text", text_color="blue"),
-                          padding=0)
+        return cells.Card(cells.Text("This is some text", text_color="blue"), padding=0)
 
     def text(self):
         return "You should see some colored text in a Card."

--- a/object_database/web/cells_demo/timestamp.py
+++ b/object_database/web/cells_demo/timestamp.py
@@ -52,4 +52,7 @@ class Milliseconds(CellsTestPage):
         )
 
     def text(self):
-        return "You should see '2019-07-16 08:00:00' followed by 1, 2, 10, 20, 100, 200 milliseconds."
+        return (
+            "You should see '2019-07-16 08:00:00' followed by "
+            "1, 2, 10, 20, 100, 200 milliseconds."
+        )

--- a/object_database/web/cells_demo/timestamp.py
+++ b/object_database/web/cells_demo/timestamp.py
@@ -34,13 +34,12 @@ class DefinedTimestamp(CellsTestPage):
         nyc = pytz.timezone("America/New_York")
         timestamp = nyc.localize(datetime(2019, 7, 16, 0, 0, 0)).timestamp()
 
-        return cells.Sequence([
-            cells.Timestamp(timestamp + 3600 * i)
-            for i in range(24)]
-        )
+        return cells.Sequence([cells.Timestamp(timestamp + 3600 * i) for i in range(24)])
 
     def text(self):
-        return "You should see 24 hours of timestamps all correctly displayed with their hours."
+        return (
+            "You should see 24 hours of timestamps all correctly displayed with their hours."
+        )
 
 
 class Milliseconds(CellsTestPage):
@@ -48,9 +47,8 @@ class Milliseconds(CellsTestPage):
         nyc = pytz.timezone("America/New_York")
         timestamp = nyc.localize(datetime(2019, 7, 16, 8, 0, 0)).timestamp()
 
-        return cells.Sequence([
-            cells.Timestamp(timestamp + i / 1000)
-            for i in [1, 2, 10, 20, 100, 200]]
+        return cells.Sequence(
+            [cells.Timestamp(timestamp + i / 1000) for i in [1, 2, 10, 20, 100, 200]]
         )
 
     def text(self):

--- a/object_database/web/flask_util.py
+++ b/object_database/web/flask_util.py
@@ -12,12 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.from collections import defaultdict
 
-from flask import (
-    abort,
-    has_request_context,
-    request,
-    url_for,
-)
+from flask import abort, has_request_context, request, url_for
 
 from urllib.parse import urlparse, urljoin, urlencode, parse_qs, urlsplit, urlunsplit
 
@@ -32,7 +27,7 @@ def is_safe_url(target, require_https=None, forbid_cross_site=None):
     require_https = False if require_https is None else require_https
     forbid_cross_site = True if forbid_cross_site is None else forbid_cross_site
 
-    allowed_schemes = ('https', ) if require_https else ('https', 'http')
+    allowed_schemes = ("https",) if require_https else ("https", "http")
 
     ref_url = urlparse(request.host_url)
     test_url = urlparse(urljoin(request.host_url, target))
@@ -42,8 +37,14 @@ def is_safe_url(target, require_https=None, forbid_cross_site=None):
     return test_url.scheme in allowed_schemes and cross_site_check
 
 
-def next_url(fallback_url=None, fallback_endpoint='index', next_key='next',
-             logger=None, require_https=None, forbid_cross_site=None):
+def next_url(
+    fallback_url=None,
+    fallback_endpoint="index",
+    next_key="next",
+    logger=None,
+    require_https=None,
+    forbid_cross_site=None,
+):
     target_url = request.args.get(next_key)
 
     if not target_url:
@@ -55,7 +56,9 @@ def next_url(fallback_url=None, fallback_endpoint='index', next_key='next',
         return abort(400)
 
     # is_safe_url should check if the url is safe for redirects.
-    if not is_safe_url(target_url, require_https=require_https, forbid_cross_site=forbid_cross_site):
+    if not is_safe_url(
+        target_url, require_https=require_https, forbid_cross_site=forbid_cross_site
+    ):
         if logger:
             logger.error("ERROR: not safe for redirect: {}".format(target_url))
         return abort(400)

--- a/setup.py
+++ b/setup.py
@@ -28,76 +28,71 @@ class BuildExtension(build_ext):
     """
 
     def run(self):
-        self.include_dirs.append(
-            pkg_resources.resource_filename('numpy', 'core/include'))
+        self.include_dirs.append(pkg_resources.resource_filename("numpy", "core/include"))
 
-        # the typed_python includes are inline. We want to find them as #include <typed_python/...>
-        # so we kluge this together this way. Better to modify typed_python to export its includes
-        # in a more reasonable way.
+        # The typed_python includes are inline.
+        # We want to find them as #include <typed_python/...>, so we kluge this
+        # together this way. Better to modify typed_python to export its
+        # includes in a more reasonable way.
         self.include_dirs.append(
-            os.path.dirname(os.path.dirname(pkg_resources.resource_filename('typed_python', '.')))
+            os.path.dirname(
+                os.path.dirname(pkg_resources.resource_filename("typed_python", "."))
+            )
         )
         build_ext.run(self)
 
 
 extra_compile_args = [
-    '-O2',
-    '-fstack-protector-strong',
-    '-Wformat',
-    '-Wdate-time',
-    '-Werror=format-security',
-    '-std=c++14',
-    '-Wno-sign-compare',
-    '-Wno-narrowing',
-    '-Wno-sign-compare',
-    '-Wno-terminate',
-    '-Wno-reorder',
-    '-Wno-bool-compare',
-    '-Wno-cpp'
+    "-O2",
+    "-fstack-protector-strong",
+    "-Wformat",
+    "-Wdate-time",
+    "-Werror=format-security",
+    "-std=c++14",
+    "-Wno-sign-compare",
+    "-Wno-narrowing",
+    "-Wno-sign-compare",
+    "-Wno-terminate",
+    "-Wno-reorder",
+    "-Wno-bool-compare",
+    "-Wno-cpp",
 ]
 
 ext_modules = [
     Extension(
-        'object_database._types',
-        sources=[
-            'object_database/all.cpp',
-        ],
-        define_macros=[
-            ("_FORTIFY_SOURCE", 2)
-        ],
-        extra_compile_args=extra_compile_args
-    ),
+        "object_database._types",
+        sources=["object_database/all.cpp"],
+        define_macros=[("_FORTIFY_SOURCE", 2)],
+        extra_compile_args=extra_compile_args,
+    )
 ]
 
-INSTALL_REQUIRES = [line.strip() for line in open('install-requires.txt')]
+INSTALL_REQUIRES = [line.strip() for line in open("install-requires.txt")]
 
 setuptools.setup(
-    name='object_database',
-    version='0.1',
-    description='Distributed software transactional memory.',
-    author='Braxton Mckee',
-    author_email='braxton.mckee@gmail.com',
-    url='https://github.com/aprioriinvestments/object_database',
+    name="object_database",
+    version="0.1",
+    description="Distributed software transactional memory.",
+    author="Braxton Mckee",
+    author_email="braxton.mckee@gmail.com",
+    url="https://github.com/aprioriinvestments/object_database",
     packages=setuptools.find_packages(),
-    cmdclass={'build_ext': BuildExtension},
+    cmdclass={"build_ext": BuildExtension},
     ext_modules=ext_modules,
-    setup_requires=['numpy', 'typed_python'],
+    setup_requires=["numpy", "typed_python"],
     install_requires=INSTALL_REQUIRES,
-
     # https://pypi.org/classifiers/
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
     ],
-
     license="Apache Software License v2.0",
     entry_points={
-        'console_scripts': [
-            'object_database_webtest=object_database.frontends.object_database_webtest:main',
-            'object_database_service_manager=object_database.frontends.service_manager:main',
+        "console_scripts": [
+            "object_database_webtest=object_database.frontends.object_database_webtest:main",
+            "object_database_service_manager=object_database.frontends.service_manager:main",
         ]
     },
-
     include_package_data=True,
-    zip_safe=False
+    zip_safe=False,
 )

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,2 +1,3 @@
 import coverage
+
 coverage.process_startup()

--- a/tox.ini
+++ b/tox.ini
@@ -26,16 +26,13 @@ log_date_format = %Y-%m-%d %H:%M:%S
 
 # The pycodestyle section is used by autopep8
 [pycodestyle]
-max-line-length = 99
+max-line-length = 95
 ignore =
-    E201,  # whitespace after '{', '(', etc
-    E202,  # whitespace before '}', ')', etc
-    E226,  # missing whitespace around arithmetic operator
-    E227,  # missing whitespace around bitwise or shift operator
-    E228,  # missing whitespace around modulo operator
-    E731,  # do not assign a lambda expression, use a def
-    W503,  # line break before binary operator
-    W504,  # line break after binary operator
+    E203,  # whitespace before ':' -- because of black
+    E231,  # missing whitespace after ',', ';', or ':' -- because of black
+    W503,  # line break before binary operator -- our preference
+    E731,  # lambda function instead of def -- our preference
+
 exclude =
     .git,
     .eggs,
@@ -51,14 +48,10 @@ statistics = True
 max-line-length = 139
 
 ignore =
-    E201,  # whitespace after '{', '(', etc
-    E202,  # whitespace before '}', ')', etc
-    E226,  # missing whitespace around arithmetic operator
-    E227,  # missing whitespace around bitwise or shift operator
-    E228,  # missing whitespace around modulo operator
-    E731,  # do not assign a lambda expression, use a def
-    W503,  # line break before binary operator
-    W504,  # line break after binary operator
+    E203,  # whitespace before ':' -- because of black
+    E231,  # missing whitespace after ',', ';', or ':' -- because of black
+    W503,  # line break before binary operator -- our preference
+    E731,  # lambda function instead of def -- our preference
 
 per-file-ignores=
     __init__.py: F401,

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ exclude =
 [flake8]
 statistics = True
 
-max-line-length = 139
+max-line-length = 95
 
 ignore =
     E203,  # whitespace before ':' -- because of black

--- a/unicodeprops.py
+++ b/unicodeprops.py
@@ -25,7 +25,7 @@ Uprops_PRINTABLE = 0x80
 Uprops_TITLE = 0x100
 
 first = 0
-last = 0x10ffff
+last = 0x10FFFF
 print("#pragma once")
 print("")
 print("// Generated from:")
@@ -40,7 +40,7 @@ print("#define Uprops_NUMERIC 0x{:04x}".format(Uprops_NUMERIC))
 print("#define Uprops_SPACE 0x{:04x}".format(Uprops_SPACE))
 print("#define Uprops_PRINTABLE 0x{:04x}".format(Uprops_PRINTABLE))
 print("#define Uprops_TITLE 0x{:04x}".format(Uprops_TITLE))
-print("static uint16_t uprops_runlength[] = {{".format(last+1))
+print("static uint16_t uprops_runlength[] = {{".format(last + 1))
 
 prev = None
 count = 0
@@ -79,9 +79,9 @@ print("0x{:x},{}\n}};\n".format(prev, count))
 sum += count
 entries += 1
 
-print("// check 0x{:x} == 0x{:x}\n".format(sum, last+1))
+print("// check 0x{:x} == 0x{:x}\n".format(sum, last + 1))
 
-print("static uint16_t uprops[0x{:x}];\n".format(last+1))
+print("static uint16_t uprops[0x{:x}];\n".format(last + 1))
 
 print("void initialize_uprops(void) {")
 print("    uint16_t *cur = uprops;")


### PR DESCRIPTION
## Motivation and Context
Good code formatting is important for code readability, but annoying to manually enforce across a team. We use `black` code formatter to automate the task.

## Approach
- Added a pre-commit script to ensure modified files are run through `black`
- Added a `black check` test to TravisCI to prevent regressions
- Updated the `flake8` ignores in `tox.ini` to stop complaining about things that `black` does.
- Reduced `flake8`'s line-length tolerance to 95, the same as black, and manually edited lines that were too long.

## How Has This Been Tested?
TravisCI
