### PR TITLE
Cached DOM Rewiring for Special Components

### DIFF
--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -28,6 +28,22 @@ class CodeEditorDemo(CellsTestPage):
         return "You should see a button that lets you see a text editor."
 
 
+class CodeEditorStashedDemo(CellsTestPage):
+    def cell(self):
+        isShown = cells.Slot(False)
+        editor = cells.CodeEditor()
+
+        return cells.Button(
+            "Toggle the editor", lambda: isShown.set(not isShown.get())
+        ) + cells.Flex(cells.Subscribed(lambda: editor if isShown.get() else None))
+
+    def text(self):
+        return (
+            "You should be able to Toggle a text editor, enter some text,",
+            " and have the same text editor re-appear on toggling again",
+        )
+
+
 class CodeEditorInHorizSequence(CellsTestPage):
     def cell(self):
         editorShown = cells.Slot(False)

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -222,6 +222,15 @@ class Component {
     }
 
     /**
+     * Getter that will respond true if this
+     * the component has not yet been rendered
+     * even once
+     */
+    get hasRenderedBefore() {
+        return this.numRenders > 0;
+    }
+
+    /**
      * Override default string representation
      */
     toString(){

--- a/object_database/web/content/components/Plot.js
+++ b/object_database/web/content/components/Plot.js
@@ -15,6 +15,10 @@ class Plot extends Component {
     constructor(props, ...args){
         super(props, ...args);
 
+        // Cache the created DOM node
+        // for later use
+        this._cachedDOMNode = null;
+
         // Bind component methods
         this.setupPlot = this.setupPlot.bind(this);
         this.makeChartUpdater = this.makeChartUpdater.bind(this);
@@ -23,9 +27,27 @@ class Plot extends Component {
 
     componentDidLoad() {
         this.setupPlot();
+        this._cachedDOMNode = this.getDOMElement();
+    }
+
+    componentDidUpdate(){
+        let placeholder = document.getElementById(`placeholder-${this.props.id}`);
+        if(placeholder){
+            placeholder.replaceWith(this._cachedDOMNode);
+        } else {
+            throw new Error(`Could not find replacement element for ${this.name}[${this.props.id}]`);
+        }
     }
 
     build(){
+        if(this.hasRenderedBefore){
+            console.log(`Rewiring ${this.name}[${this.props.id}] from cached DOM node`);
+            return h('div', {
+                class: 'cell-placeholder',
+                id: `placeholder-${this.props.id}`
+            }, []);
+        }
+        console.log(`Initial render of ${this.name}[${this.props.id}]`);
         return (
             h('div', {
                 id: this.props.id,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements a special build/render cycle for so-called "special components," which include `Plot`, `CodeEditor`, and  `OldSheet`.

## Motivation and Context
<!-- Why is this change required? -->
In the current setup, naive re-rendering of one of these special components removes the underlying module (Plotly, Ace, Handsontable) from being able to interact with the new DOM node that is created. Since re-renders happen all the time we need to prevent this. The effect of the bug is that the given tool will seem to "disappear" from view.
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
In order to rectify this, we leverage the existing Component lifecycle functions.
  
The steps these components take is as follows:
1. During the first call to `build()` we render the normal velement structure
2. During `componentDidLoad()`, we get the rendered DOM element and store it at `_cachedDOMNode`
3. During any subsequent call to `build()`, we render a placeholder div, set its id to `placeholder-<id>`
4. During subsequent `componentDidUpdate()` calls, we find the replacement div and call `replacementDiv.replaceWith(this._cachedDOMNode)`
  
This all should happen without much notice.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
Normal Node and Cells tests are passing.
  
Other tests included a bit of web console manipulation and checking, but full testing on the prod UI is probably necessary to sort things out.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.