### PR TITLE
InProcessServiceManager should not create services with codebases by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ jobs:
         - ulimit -c unlimited -S       # enable core dumps
       install:
         - pip install pipenv codecov
+        - pip install typed_python==0.1.1
         - pipenv lock --dev --requirements > dev-reqs.txt
         - pip install --requirement dev-reqs.txt
         - pip install --editable .  # install object_database in 'editable' form.

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: "black check"
       install:
-        - pip install black
+        - pip install black==19.3b0
       script:
         - make black-check-local
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install: $(VIRTUAL_ENV) testcert.cert testcert.key install-dependencies pre-comm
 install-dependencies: $(VIRTUAL_ENV)
 	. $(VIRTUAL_ENV)/bin/activate; \
 		pip install pipenv==2018.11.26; \
-		pip install black; \
+		pip install black==19.3b0; \
 		pipenv install --dev --deploy; \
 		pip install -e .; \
 		nodeenv --python-virtualenv --prebuilt --node=10.15.3 $(NODE_ENV); \

--- a/Makefile
+++ b/Makefile
@@ -169,9 +169,6 @@ generatetesttypes: $(DT_SRC_PATH)/generate_types.py
 .PHONY: clean
 clean:
 	rm -rf build/
-	rm -rf nativepython.egg-info/
-	rm -f nose.*.log
-	rm -f typed_python/_types.cpython-*.so
 	rm -f object_database/_types.cpython-*.so
 	rm -f testcert.cert testcert.key
 	rm -rf $(VIRTUAL_ENV) .env

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,16 @@ TESTTYPES2 = $(DT_SRC_PATH)/ClientToServer0.hpp
 #  MAIN RULES
 
 .PHONY: install
-install: $(VIRTUAL_ENV) testcert.cert testcert.key pre-commit-install
+install: $(VIRTUAL_ENV) testcert.cert testcert.key install-dependencies pre-commit-install
+
+
+.PHONY: install-dependencies
+install-dependencies: $(VIRTUAL_ENV)
 	. $(VIRTUAL_ENV)/bin/activate; \
-		pip3 install pipenv==2018.11.26; \
-		pip3 install black; \
+		pip install pipenv==2018.11.26; \
+		pip install black; \
 		pipenv install --dev --deploy; \
-		pip3 install -e .; \
+		pip install -e .; \
 		nodeenv --python-virtualenv --prebuilt --node=10.15.3 $(NODE_ENV); \
 		npm install --global webpack webpack-cli; \
 		cd object_database/web/content; \

--- a/Pipfile
+++ b/Pipfile
@@ -32,7 +32,7 @@ redis = "*"
 requests = "*"
 websockets = "*"
 nodeenv = "*"
-typed_python = {git = "https://github.com/APrioriInvestments/typed_python.git",ref = "b118d0de45dfe89836afb0af45a1b23d081261fa"}
+typed_python = {editable = true,path = "./../typed_python"}
 gevent-websocket = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "36aa25da017b1442432ce3bee3da0700837f338a1f04887306212fff3d3ce2f1"
+            "sha256": "ca6eefc2adfca3de9257cfffa8bbe3b32e83899f3f58257d2e00bdbd9d0b0be3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,18 +18,18 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:2edee79d0e78c08b6d14d4dd91c0e4b3438dd4c90c859f06a397268b1cac17b2",
-                "sha256:3cd2078144c10417eb04e4bb263ea8e50a21c4aceafb52db33e3fe71e73b48aa"
+                "sha256:aa40df7958bb274fad45ce6cc9ae1c77aac3b4cf33c34684646b42583a52d7e0",
+                "sha256:cb8f2531c22a4cf7847f62a9e23c2611300b6fdbcad577f67a9b56b686f78dd5"
             ],
             "index": "pypi",
-            "version": "==1.10.0"
+            "version": "==1.10.14"
         },
         "botocore": {
             "hashes": [
-                "sha256:507b8f13583a64ec2c9c112ff6e3dd8b548060adc7e1f57f25fda9fa34c2dfdb",
-                "sha256:c4b2ffb0f6ed7169beb260485bf5a42ee72a0a02f49f48b0557ed5e32bcf9e79"
+                "sha256:48ad5efd98e0570df13a73e6463da2a9d9422f47a943b6ef74f950695c23dbb0",
+                "sha256:d789f30a5def264b9d21a917aeadc4e5fc2b6a03a61f222befcfaf80eaba86e5"
             ],
-            "version": "==1.13.0"
+            "version": "==1.13.14"
         },
         "certifi": {
             "hashes": [
@@ -327,18 +327,20 @@
         },
         "psutil": {
             "hashes": [
-                "sha256:028a1ec3c6197eadd11e7b46e8cc2f0720dc18ac6d7aabdb8e8c0d6c9704f000",
-                "sha256:503e4b20fa9d3342bcf58191bbc20a4a5ef79ca7df8972e6197cc14c5513e73d",
-                "sha256:863a85c1c0a5103a12c05a35e59d336e1d665747e531256e061213e2e90f63f3",
-                "sha256:954f782608bfef9ae9f78e660e065bd8ffcfaea780f9f2c8a133bb7cb9e826d7",
-                "sha256:b6e08f965a305cd84c2d07409bc16fbef4417d67b70c53b299116c5b895e3f45",
-                "sha256:bc96d437dfbb8865fc8828cf363450001cb04056bbdcdd6fc152c436c8a74c61",
-                "sha256:cf49178021075d47c61c03c0229ac0c60d5e2830f8cab19e2d88e579b18cdb76",
-                "sha256:d5350cb66690915d60f8b233180f1e49938756fb2d501c93c44f8fb5b970cc63",
-                "sha256:eba238cf1989dfff7d483c029acb0ac4fcbfc15de295d682901f0e2497e6781a"
+                "sha256:021d361439586a0fd8e64f8392eb7da27135db980f249329f1a347b9de99c695",
+                "sha256:145e0f3ab9138165f9e156c307100905fd5d9b7227504b8a9d3417351052dc3d",
+                "sha256:348ad4179938c965a27d29cbda4a81a1b2c778ecd330a221aadc7bd33681afbd",
+                "sha256:3feea46fbd634a93437b718518d15b5dd49599dfb59a30c739e201cc79bb759d",
+                "sha256:474e10a92eeb4100c276d4cc67687adeb9d280bbca01031a3e41fb35dfc1d131",
+                "sha256:47aeb4280e80f27878caae4b572b29f0ec7967554b701ba33cd3720b17ba1b07",
+                "sha256:73a7e002781bc42fd014dfebb3fc0e45f8d92a4fb9da18baea6fb279fbc1d966",
+                "sha256:d051532ac944f1be0179e0506f6889833cf96e466262523e57a871de65a15147",
+                "sha256:dfb8c5c78579c226841908b539c2374da54da648ee5a837a731aa6a105a54c00",
+                "sha256:e3f5f9278867e95970854e92d0f5fe53af742a7fc4f2eba986943345bcaed05d",
+                "sha256:e9649bb8fc5cea1f7723af53e4212056a6f984ee31784c10632607f472dec5ee"
             ],
             "index": "pypi",
-            "version": "==5.6.3"
+            "version": "==5.6.5"
         },
         "pyasn1": {
             "hashes": [
@@ -407,14 +409,14 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "typed-python": {
-            "git": "https://github.com/APrioriInvestments/typed_python.git",
-            "ref": "b118d0de45dfe89836afb0af45a1b23d081261fa"
+            "editable": true,
+            "path": "./../typed_python"
         },
         "urllib3": {
             "hashes": [
@@ -426,20 +428,20 @@
         },
         "websockets": {
             "hashes": [
-                "sha256:049e694abe33f8a1d99969fee7bfc0ae6761f7fd5f297c58ea933b27dd6805f2",
-                "sha256:73ce69217e4655783ec72ce11c151053fcbd5b837cc39de7999e19605182e28a",
-                "sha256:83e63aa73331b9ca21af61df8f115fb5fbcba3f281bee650a4ad16a40cd1ef15",
-                "sha256:882a7266fa867a2ebb2c0baaa0f9159cabf131cf18c1b4270d79ad42f9208dc5",
-                "sha256:8c77f7d182a6ea2a9d09c2612059f3ad859a90243e899617137ee3f6b7f2b584",
-                "sha256:8d7a20a2f97f1e98c765651d9fb9437201a9ccc2c70e94b0270f1c5ef29667a3",
-                "sha256:a7affaeffbc5d55681934c16bb6b8fc82bb75b175e7fd4dcca798c938bde8dda",
-                "sha256:c82e286555f839846ef4f0fdd6910769a577952e1e26aa8ee7a6f45f040e3c2b",
-                "sha256:e906128532a14b9d264a43eb48f9b3080d53a9bda819ab45bf56b8039dc606ac",
-                "sha256:e9102043a81cdc8b7c8032ff4bce39f6229e4ac39cb2010946c912eeb84e2cb6",
-                "sha256:f5cb2683367e32da6a256b60929a3af9c29c212b5091cf5bace9358d03011bf5"
+                "sha256:0e4fb4de42701340bd2353bb2eee45314651caa6ccee80dbd5f5d5978888fed5",
+                "sha256:20891f0dddade307ffddf593c733a3fdb6b83e6f9eef85908113e628fa5a8308",
+                "sha256:2db62a9142e88535038a6bcfea70ef9447696ea77891aebb730a333a51ed559a",
+                "sha256:3762791ab8b38948f0c4d281c8b2ddfa99b7e510e46bd8dfa942a5fff621068c",
+                "sha256:3db87421956f1b0779a7564915875ba774295cc86e81bc671631379371af1170",
+                "sha256:4f9f7d28ce1d8f1295717c2c25b732c2bc0645db3215cf757551c392177d7cb8",
+                "sha256:5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f",
+                "sha256:7ff46d441db78241f4c6c27b3868c9ae71473fe03341340d2dfdbe8d79310acc",
+                "sha256:965889d9f0e2a75edd81a07592d0ced54daa5b0785f57dc429c378edbcffe779",
+                "sha256:9b248ba3dd8a03b1a10b19efe7d4f7fa41d158fdaa95e2cf65af5a7b95a4f989",
+                "sha256:ce85b06a10fc65e6143518b96d3dca27b081a740bae261c2fb20375801a9d56d"
             ],
             "index": "pypi",
-            "version": "==8.0.2"
+            "version": "==8.1"
         },
         "werkzeug": {
             "hashes": [
@@ -548,11 +550,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
-                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
+                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
+                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
             ],
             "index": "pypi",
-            "version": "==3.7.8"
+            "version": "==3.7.9"
         },
         "flaky": {
             "hashes": [
@@ -622,11 +624,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:1d3c0587bda7c4e537a46c27f2c84aa006acc18facf9970bf947df596ce91f3f",
-                "sha256:fa78ff96e8e9ac94c748388597693f18b041a181c94a4f039ad20f45287ba44a"
+                "sha256:9f152687127ec90642a2cc3e4d9e1e6240c4eb153615cb02aa1ad41d331cbb6e",
+                "sha256:c2e4810d2d3102d354947907514a78c5d30424d299dc0fe48f5aa049826e9b50"
             ],
             "index": "pypi",
-            "version": "==1.18.3"
+            "version": "==1.20.0"
         },
         "py": {
             "hashes": [
@@ -651,18 +653,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:4acadc9a2b96c19fe00932a38ca63e601180c39a189a696abce1eaab641447e1",
+                "sha256:61b5ed888beab19ddccab3478910e2076a6b5a0295dffc43021890e136edf764"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.4"
         },
         "pytest": {
             "hashes": [
-                "sha256:7e4800063ccfc306a53c461442526c5571e1462f61583506ce97e4da6a1d88c8",
-                "sha256:ca563435f4941d0cb34767301c27bc65c510cb82e90b9ecf9cb52dc2c63caaa0"
+                "sha256:27abc3fef618a01bebb1f0d6d303d2816a99aa87a5968ebc32fe971be91eb1e6",
+                "sha256:58cee9e09242937e136dbb3dab466116ba20d6b7828c7620f23947f37eb4dae4"
             ],
             "index": "pypi",
-            "version": "==5.2.1"
+            "version": "==5.2.2"
         },
         "pyyaml": {
             "hashes": [
@@ -685,17 +687,17 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "soupsieve": {
             "hashes": [
-                "sha256:605f89ad5fdbfefe30cdc293303665eff2d188865d4dbe4eb510bba1edfbfce3",
-                "sha256:b91d676b330a0ebd5b21719cb6e9b57c57d433671f65b9c28dd3461d9a1ed0b6"
+                "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5",
+                "sha256:e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda"
             ],
-            "version": "==1.9.4"
+            "version": "==1.9.5"
         },
         "toml": {
             "hashes": [

--- a/object_database/algebraic_protocol.py
+++ b/object_database/algebraic_protocol.py
@@ -16,7 +16,6 @@ import asyncio
 import struct
 import threading
 import logging
-import traceback
 
 from typed_python import serialize, deserialize
 
@@ -55,7 +54,7 @@ class AlgebraicProtocol(asyncio.Protocol):
             with self.writelock:
                 self.transport.write(dataToSend)
         except Exception:
-            self._logger.error("Error in AlgebraicProtocol: %s", traceback.format_exc())
+            self._logger.exception("Error in AlgebraicProtocol:")
             self.transport.close()
 
     def messageReceived(self, msg):
@@ -84,9 +83,7 @@ class AlgebraicProtocol(asyncio.Protocol):
                     try:
                         self.messageReceived(deserialize(self.receiveType, bytes(toConsume)))
                     except Exception:
-                        self._logger.error(
-                            "Error in AlgebraicProtocol: %s", traceback.format_exc()
-                        )
+                        self._logger.exception("Error in AlgebraicProtocol:")
                         self.transport.close()
             else:
                 return

--- a/object_database/database_connection.py
+++ b/object_database/database_connection.py
@@ -27,7 +27,6 @@ from typed_python import Alternative, Dict, OneOf
 
 import threading
 import logging
-import traceback
 import time
 
 from object_database.view import DisconnectedException
@@ -446,9 +445,8 @@ class DatabaseConnection:
                     try:
                         q(TransactionResult.Disconnected())
                     except Exception:
-                        self._logger.error(
-                            "Transaction commit callback threw an exception:\n%s",
-                            traceback.format_exc(),
+                        self._logger.exception(
+                            "Transaction commit callback threw an exception:"
                         )
 
                 self._transaction_callbacks = {}
@@ -475,10 +473,7 @@ class DatabaseConnection:
                         else TransactionResult.RevisionConflict(key=msg.badKey)
                     )
                 except Exception:
-                    self._logger.error(
-                        "Transaction commit callback threw an exception:\n%s",
-                        traceback.format_exc(),
-                    )
+                    self._logger.exception("Transaction commit callback threw an exception:")
         elif msg.matches.Transaction:
             with self._lock:
                 self._markSchemaAndTypeMaxTids(
@@ -495,10 +490,8 @@ class DatabaseConnection:
                 try:
                     handler(msg.writes, msg.set_adds, msg.set_removes, msg.transaction_id)
                 except Exception:
-                    self._logger.error(
-                        "_onTransaction handler %s threw an exception:\n%s",
-                        handler,
-                        traceback.format_exc(),
+                    self._logger.exception(
+                        "_onTransaction handler %s threw an exception:", handler
                     )
 
         elif msg.matches.SchemaMapping:

--- a/object_database/database_test.py
+++ b/object_database/database_test.py
@@ -37,9 +37,9 @@ import object_database.messages as messages
 import queue
 import unittest
 import tempfile
+import logging
 import numpy
 import os
-import traceback
 import threading
 import random
 import time
@@ -2041,7 +2041,7 @@ class ObjectDatabaseTests:
 
                 isOK[0] = True
             except BaseException:
-                print("READ THREAD FAILED: ", traceback.format_exc())
+                logging.exception("READ THREAD FAILED:")
 
         r = threading.Thread(target=readerthread)
         r.daemon = True

--- a/object_database/frontends/service_entrypoint.py
+++ b/object_database/frontends/service_entrypoint.py
@@ -87,9 +87,10 @@ def main(argv):
         signal.signal(signal.SIGINT, shutdownCleanly)
         signal.signal(signal.SIGTERM, shutdownCleanly)
 
-        manager.runAndWaitForShutdown()
+        exitedGracefully = manager.runAndWaitForShutdown()
+        retval = 0 if exitedGracefully else 1
+        return retval
 
-        return 0
     except Exception:
         logger.error(
             "service_entrypoint failed with an exception:\n%s", traceback.format_exc()

--- a/object_database/frontends/service_entrypoint.py
+++ b/object_database/frontends/service_entrypoint.py
@@ -18,7 +18,6 @@ import argparse
 import logging
 import signal
 import sys
-import traceback
 
 from object_database import connect
 from object_database.util import validateLogLevel, configureLogging
@@ -92,9 +91,7 @@ def main(argv):
         return retval
 
     except Exception:
-        logger.error(
-            "service_entrypoint failed with an exception:\n%s", traceback.format_exc()
-        )
+        logger.exception("service_entrypoint failed with an exception:")
         return 1
 
 

--- a/object_database/frontends/service_manager.py
+++ b/object_database/frontends/service_manager.py
@@ -27,7 +27,6 @@ import sys
 import tempfile
 import threading
 import time
-import traceback
 
 from object_database.util import (
     configureLogging,
@@ -316,9 +315,7 @@ def main(argv=None):
                         serviceManager.stop(gracefully=False)
                         serviceManager = None
                     except Exception:
-                        logger.error(
-                            "Service manager cleanup failed:\n%s", traceback.format_exc()
-                        )
+                        logger.exception("Service manager cleanup failed:")
         except KeyboardInterrupt:
             logger.warning("Exiting due to KeyboardInterrupt")
             return 0
@@ -329,13 +326,13 @@ def main(argv=None):
             try:
                 serviceManager.stop(gracefully=True)
             except Exception:
-                logger.error("Failed to stop the service manager:\n%s", traceback.format_exc())
+                logger.exception("Failed to stop the service manager:")
 
         if databaseServer is not None:
             try:
                 databaseServer.stop()
             except Exception:
-                logger.error("Failed to stop the database server:\n%s", traceback.format_exc())
+                logger.exception("Failed to stop the database server:")
 
 
 if __name__ == "__main__":

--- a/object_database/inmem_server.py
+++ b/object_database/inmem_server.py
@@ -7,7 +7,6 @@ import time
 import queue
 import logging
 import threading
-import traceback
 
 
 class InMemoryChannel:
@@ -47,9 +46,7 @@ class InMemoryChannel:
                 try:
                     self._clientCallback(e)
                 except Exception:
-                    self._logger.error(
-                        "Pump thread failed for %s: %s", self, traceback.format_exc()
-                    )
+                    self._logger.exception("Pump thread failed for %s:", self)
                     return
 
     def pumpMessagesFromClient(self):
@@ -71,8 +68,7 @@ class InMemoryChannel:
                 try:
                     self._serverCallback(e)
                 except Exception:
-                    traceback.print_exc()
-                    self._logger.error("Pump thread failed: %s", traceback.format_exc())
+                    self._logger.exception("Pump thread failed:")
                     return
 
         self._server.dropConnection(self)

--- a/object_database/reactor.py
+++ b/object_database/reactor.py
@@ -12,7 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import traceback
 import threading
 import queue
 import logging
@@ -216,11 +215,10 @@ class Reactor:
                         and exceptionsInARow % 10 == 0
                         or exceptionsInARow % 100 == 0
                     ):
-                        logging.error(
+                        logging.exception(
                             "Unexpected exception in Reactor user code "
-                            "(%s occurrences in a row):\n%s",
+                            "(%s occurrences in a row):",
                             exceptionsInARow,
-                            traceback.format_exc(),
                         )
                     time.sleep(0.001 * exceptionsInARow)
 
@@ -228,7 +226,7 @@ class Reactor:
                     self._blockUntilRecalculate(readKeys, nextWakeup, self.maxSleepTime)
 
         except Exception:
-            logging.error("Unexpected exception in Reactor loop:\n%s", traceback.format_exc())
+            logging.exception("Unexpected exception in Reactor loop:")
 
     def _blockUntilRecalculate(self, readKeys, nextWakeup, timeout):
         """Wait until we're triggered, or hit a timeout.

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -33,7 +33,6 @@ import queue
 import time
 import logging
 import threading
-import traceback
 
 DEFAULT_GC_INTERVAL = 900.0
 
@@ -241,10 +240,7 @@ class Server:
                 except queue.Empty:
                     pass
             except Exception:
-                self._logger.error(
-                    "Unexpected error in serviceSubscription thread:\n%s",
-                    traceback.format_exc(),
-                )
+                self._logger.exception("Unexpected error in serviceSubscription thread:")
 
     def _removeOldDeadConnections(self):
         fieldId = self._currentTypeMap().fieldIdFor("core", "Connection", " exists")
@@ -364,10 +360,7 @@ class Server:
 
                 connectedChannel.sendInitializationMessage()
         except Exception:
-            self._logger.error(
-                "Failed during addConnection which should never happen:\n%s",
-                traceback.format_exc(),
-            )
+            self._logger.exception("Failed during addConnection which should never happen:")
 
     def _handleSubscriptionInForeground(self, channel, msg):
         # first see if this would be an easy subscription to handle
@@ -843,9 +836,7 @@ class Server:
                         msg.as_of_version,
                     )
             except Exception:
-                self._logger.error(
-                    "Unknown error committing transaction: %s", traceback.format_exc()
-                )
+                self._logger.exception("Unknown error committing transaction:")
                 isOK = False
                 badKey = "<NONE>"
 

--- a/object_database/service_manager/InProcessServiceManager.py
+++ b/object_database/service_manager/InProcessServiceManager.py
@@ -55,15 +55,18 @@ class InProcessServiceManager(ServiceManager):
         worker.start()
 
     def stop(self):
+        allExitedGracefully = True
         self.stopAllServices(10.0)
 
         for instanceId, workers in self.serviceWorkers.items():
             for worker in workers:
-                worker.stop()
+                exitedGracefully = worker.stop()
+                allExitedGracefully = allExitedGracefully and exitedGracefully
 
         self.serviceWorkers = {}
 
         ServiceManager.stop(self)
+        return allExitedGracefully
 
     def cleanup(self):
         self.storageRoot.cleanup()

--- a/object_database/service_manager/InProcessServiceManager.py
+++ b/object_database/service_manager/InProcessServiceManager.py
@@ -17,7 +17,6 @@ import tempfile
 
 from object_database.service_manager.ServiceManager import ServiceManager
 from object_database.service_manager.ServiceWorker import ServiceWorker
-from object_database.service_manager.Codebase import setCodebaseInstantiationDirectory
 
 
 class InProcessServiceManager(ServiceManager):
@@ -25,8 +24,6 @@ class InProcessServiceManager(ServiceManager):
         self.storageRoot = tempfile.TemporaryDirectory()
         self.sourceRoot = tempfile.TemporaryDirectory()
         self.auth_token = auth_token
-
-        setCodebaseInstantiationDirectory(self.sourceRoot.name)
 
         ServiceManager.__init__(
             self,
@@ -71,3 +68,25 @@ class InProcessServiceManager(ServiceManager):
     def cleanup(self):
         self.storageRoot.cleanup()
         self.sourceRoot.cleanup()
+
+    @staticmethod
+    def createOrUpdateService(
+        serviceClass,
+        serviceName,
+        target_count=None,
+        placement=None,
+        isSingleton=None,
+        coresUsed=None,
+        gbRamUsed=None,
+        inferCodebase=False,  # don't infer codebase by default
+    ):
+        ServiceManager.createOrUpdateService(
+            serviceClass,
+            serviceName,
+            target_count=target_count,
+            placement=placement,
+            isSingleton=isSingleton,
+            coresUsed=coresUsed,
+            gbRamUsed=gbRamUsed,
+            inferCodebase=inferCodebase,
+        )

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -237,9 +237,7 @@ class ServiceManager(object):
                 self.startServiceWorker(service, i._identity)
 
             except Exception:
-                self._logger.error(
-                    "Failed to start a worker for instance %s:\n%s", i, traceback.format_exc()
-                )
+                self._logger.exception("Failed to start a worker for instance %s:", i)
                 bad_instances[i] = traceback.format_exc()
 
         if bad_instances:
@@ -413,6 +411,14 @@ class ServiceManager(object):
         return res
 
     def startServiceWorker(self, service, instanceIdentity):
+        """
+        Args:
+            service (service_schema.Service): The service for which to start a worker
+            instanceIdentity (int): The identity of the instance we want to start.
+                The worker gets handed this identifier and calls `service_schema.
+                ServiceInstance.fromIdentity(instanceIdentity)` to recover the
+                relevant ServiceInstance from the object_database.
+        """
         raise NotImplementedError()
 
     def cleanup(self):

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -81,6 +81,7 @@ class ServiceManager(object):
         isSingleton=None,
         coresUsed=None,
         gbRamUsed=None,
+        inferCodebase=True,
     ):
         service = service_schema.Service.lookupAny(name=serviceName)
 
@@ -90,7 +91,10 @@ class ServiceManager(object):
         service.service_module_name = serviceClass.__module__
         service.service_class_name = serviceClass.__qualname__
 
-        if not service.service_module_name.startswith("object_database."):
+        if service.service_module_name.startswith("object_database."):
+            inferCodebase = False
+
+        if inferCodebase is True:
             # find the root of the codebase
             module = sys.modules[serviceClass.__module__]
 

--- a/object_database/service_manager/SubprocessServiceManager.py
+++ b/object_database/service_manager/SubprocessServiceManager.py
@@ -19,7 +19,6 @@ import sys
 import logging
 import threading
 import time
-import traceback
 
 from object_database.service_manager.ServiceManager import ServiceManager
 from object_database.service_manager.ServiceSchema import service_schema
@@ -350,11 +349,9 @@ class SubprocessServiceManager(ServiceManager):
                                 )
                                 shutil.rmtree(path)
                             except Exception:
-                                self._logger.error(
-                                    "Failed to remove storage at path %s "
-                                    "for dead service:\n%s",
+                                self._logger.exception(
+                                    "Failed to remove storage at path %s for dead service:",
                                     path,
-                                    traceback.format_exc(),
                                 )
 
         if self.sourceDir:
@@ -369,11 +366,10 @@ class SubprocessServiceManager(ServiceManager):
                                 )
                                 shutil.rmtree(path)
                             except Exception:
-                                self._logger.error(
+                                self._logger.exception(
                                     "Failed to remove source cache at path %s "
-                                    "for dead service:\n%s",
+                                    "for dead service:",
                                     path,
-                                    traceback.format_exc(),
                                 )
 
     def _isLiveService(self, instanceId):

--- a/object_database/service_manager/Task.py
+++ b/object_database/service_manager/Task.py
@@ -325,9 +325,7 @@ class TaskService(ServiceBase):
                     taskStatus.wakeup_timestamp = execResult.wakeup_timestamp
 
         except Exception:
-            self.logger.error(
-                "Task %s failed with exception:\n%s", task, traceback.format_exc()
-            )
+            self.logger.exception("Task %s failed with exception:", task)
             taskStatus.finish(
                 self.db,
                 TaskResult.Error(error=traceback.format_exc()),
@@ -384,10 +382,7 @@ class TaskDispatchService(ServiceBase):
                 except DisconnectedException:
                     return
                 except Exception:
-                    self.logger.error(
-                        "Unexpected exception in TaskDispatchService: %s",
-                        traceback.format_exc(),
-                    )
+                    self.logger.exception("Unexpected exception in TaskDispatchService:")
 
         def assignLoop():
             while not shouldStop.is_set():
@@ -397,10 +392,7 @@ class TaskDispatchService(ServiceBase):
                 except DisconnectedException:
                     return
                 except Exception:
-                    self.logger.error(
-                        "Unexpected exception in TaskDispatchService: %s",
-                        traceback.format_exc(),
-                    )
+                    self.logger.exception("Unexpected exception in TaskDispatchService:")
 
         def collectLoop():
             while not shouldStop.is_set():
@@ -410,10 +402,7 @@ class TaskDispatchService(ServiceBase):
                 except DisconnectedException:
                     return
                 except Exception:
-                    self.logger.error(
-                        "Unexpected exception in TaskDispatchService: %s",
-                        traceback.format_exc(),
-                    )
+                    self.logger.exception("Unexpected exception in TaskDispatchService:")
 
         threads = [
             threading.Thread(target=t)

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -17,7 +17,6 @@ import datetime
 import logging
 import os
 import time
-import traceback
 import uuid
 
 from typed_python import OneOf, ConstDict
@@ -517,7 +516,7 @@ class AwsWorkerBootService(ServiceBase):
                 if not self.pushTaskLoopForward():
                     time.sleep(1.0)
             except Exception:
-                self._logger.error("Failed: %s", traceback.format_exc())
+                self._logger.exception("Failed:")
                 time.sleep(5.0)
 
     @staticmethod
@@ -726,9 +725,7 @@ class AwsWorkerBootService(ServiceBase):
                             state.observedLimit = maxCount
                             state.desired = min(state.desired, maxCount)
                         else:
-                            self._logger.error(
-                                "Failed to boot a worker:\n%s", traceback.format_exc()
-                            )
+                            self._logger.exception("Failed to boot a worker:")
                             time.sleep(self.SLEEP_INTERVAL)
                             break
 
@@ -768,9 +765,7 @@ class AwsWorkerBootService(ServiceBase):
                             state.observedLimit = maxCount
                             state.desired = min(state.desired, maxCount)
                         else:
-                            self._logger.error(
-                                "Failed to boot a worker:\n%s", traceback.format_exc()
-                            )
+                            self._logger.exception("Failed to boot a worker:")
                             break
 
         time.sleep(self.SLEEP_INTERVAL)

--- a/object_database/tcp_server.py
+++ b/object_database/tcp_server.py
@@ -24,7 +24,6 @@ import ssl
 import time
 import threading
 import socket
-import traceback
 
 
 class ServerToClientProtocol(AlgebraicProtocol):
@@ -40,9 +39,7 @@ class ServerToClientProtocol(AlgebraicProtocol):
             try:
                 return handler(*args)
             except Exception:
-                self._logger.error(
-                    "Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc()
-                )
+                self._logger.exception("Unexpected exception in %s:", handler.__name__)
 
         self.handler = callHandler
 
@@ -91,11 +88,7 @@ class ClientToServerProtocol(AlgebraicProtocol):
                 try:
                     return handler(*args)
                 except Exception:
-                    self._logger.error(
-                        "Unexpected exception in %s:\n%s",
-                        handler.__name__,
-                        traceback.format_exc(),
-                    )
+                    self._logger.exception("Unexpected exception in %s:", handler.__name__)
 
             self.handler = callHandler
             for m in self.msgs:
@@ -247,9 +240,7 @@ class TcpServer(Server):
             try:
                 self.checkForDeadConnections()
             except Exception:
-                logging.error(
-                    "Caught exception in checkForDeadConnections:\n%s", traceback.format_exc()
-                )
+                logging.exception("Caught exception in checkForDeadConnections:")
 
     def stop(self):
         Server.stop(self)

--- a/object_database/util.py
+++ b/object_database/util.py
@@ -82,9 +82,9 @@ def setupLogging(
     else:
         logging.info("Failed to configure logging from file. Falling back to basicConfig")
         level = default_level or logging.INFO
-        frmt = (
-            default_format
-            or "[%(asctime)s] %(levelname)8s %(filename)30s:%(lineno)4s | %(message)s"
+        frmt = default_format or (
+            "[%(asctime)s] %(levelname)8s %(filename)30s:%(lineno)4s"
+            " | %(threadName)10s | %(message)s"
         )
         logging.basicConfig(level=level, format=frmt)
 
@@ -93,7 +93,7 @@ def configureLogging(preamble="", level=logging.INFO):
     frmt = (
         "[%(asctime)s] %(levelname)8s %(filename)30s:%(lineno)4s | "
         + (preamble + " | " if preamble else "")
-        + "%(message)s"
+        + "%(threadName)10s | %(message)s"
     )
 
     ownDir = os.path.dirname(os.path.abspath(__file__))

--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -15,7 +15,6 @@ import logging
 import time
 import argparse
 import functools
-import traceback
 import os
 import sys
 import gevent.socket
@@ -402,7 +401,7 @@ class ActiveWebService(ServiceBase):
                 cells.wait()
 
         except Exception:
-            self._logger.error("Websocket handler error: %s", traceback.format_exc())
+            self._logger.exception("Websocket handler error:")
 
         finally:
             self.sessionStates[sessionId].append(sessionState)

--- a/object_database/web/ActiveWebService_util.py
+++ b/object_database/web/ActiveWebService_util.py
@@ -11,7 +11,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import json
-import traceback
 
 from itertools import chain
 
@@ -462,7 +461,7 @@ def readThread(ws, cells, largeMessageAck, logger):
                     if cell is not None:
                         cell.onMessageWithTransaction(jsonMsg)
             except Exception:
-                logger.error("Exception in inbound message: %s", traceback.format_exc())
+                logger.exception("Exception in inbound message:")
 
             cells.triggerIfHasDirty()
 

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -236,10 +236,8 @@ class Cells:
                 try:
                     callback()
                 except Exception:
-                    self._logger.error(
-                        "Callback %s threw an unexpected exception:\n%s",
-                        callback,
-                        traceback.format_exc(),
+                    self._logger.exception(
+                        "Callback %s threw an unexpected exception:", callback
                     )
         except queue.Empty:
             return
@@ -557,14 +555,8 @@ class Cells:
                         child_cell.wasRemoved = False
 
             except Exception:
-                self._logger.error(
-                    "Node %s had exception during recalculation:\n%s",
-                    node,
-                    traceback.format_exc(),
-                )
-                self._logger.error(
-                    "Subscribed cell threw an exception:\n%s", traceback.format_exc()
-                )
+                self._logger.exception("Node %s had exception during recalculation:", node)
+                self._logger.exception("Subscribed cell threw an exception:")
                 tracebackCell = Traceback(traceback.format_exc())
                 node.children["content"] = tracebackCell
 
@@ -1042,11 +1034,8 @@ class Cell:
                         self._logger.error("OnMessage timed out. This should really fail.")
                         return
                 except Exception:
-                    self._logger.error(
-                        "Exception processing message %s to cell %s logic:\n%s",
-                        args,
-                        self,
-                        traceback.format_exc(),
+                    self._logger.exception(
+                        "Exception processing message %s to cell %s logic:", args, self
                     )
                     return
 
@@ -2010,9 +1999,7 @@ class Subscribed(Cell):
             except Exception:
                 tracebackCell = Traceback(traceback.format_exc())
                 self.children["content"] = tracebackCell
-                self._logger.error(
-                    "Subscribed inner function threw exception:\n%s", traceback.format_exc()
-                )
+                self._logger.exception("Subscribed inner function threw exception:")
 
             self._resetSubscriptionsToViewReads(v)
 
@@ -2188,9 +2175,7 @@ class SubscribedSequence(Cell):
         except SubscribeAndRetry:
             raise
         except Exception:
-            self._logger.error(
-                "SubscribedSequence itemsFun threw exception:\n%s", traceback.format_exc()
-            )
+            self._logger.exception("SubscribedSequence itemsFun threw exception:")
             self.items = []
 
     def _updateExistingItems(self):
@@ -2270,18 +2255,14 @@ class Grid(Cell):
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error(
-                    "Row fun calc threw an exception:\n%s", traceback.format_exc()
-                )
+                self._logger.exception("Row fun calc threw an exception:")
                 self.rows = []
             try:
                 self.cols = augmentToBeUnique(self.colFun())
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error(
-                    "Col fun calc threw an exception:\n%s", traceback.format_exc()
-                )
+                self._logger.exception("Col fun calc threw an exception:")
                 self.cols = []
 
             self._resetSubscriptionsToViewReads(v)
@@ -2471,7 +2452,7 @@ class Table(Cell):
                         r = self.cachedRenderFun(row, col)
                         keymemo[row] = SortWrapper(r.sortsAs())
                     except Exception:
-                        self._logger.error(traceback.format_exc())
+                        self._logger.exception("Exception in sortRows:")
                         keymemo[row] = SortWrapper(None)
 
                 return keymemo[row]
@@ -2486,7 +2467,7 @@ class Table(Cell):
             page = max(0, int(self.curPage.get()) - 1)
             page = min(page, (len(rows) - 1) // self.maxRowsPerPage)
         except Exception:
-            self._logger.error("Failed to parse current page: %s", traceback.format_exc())
+            self._logger.exception("Failed to parse current page: %s")
 
         return rows[page * self.maxRowsPerPage : (page + 1) * self.maxRowsPerPage]
 
@@ -2539,9 +2520,7 @@ class Table(Cell):
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error(
-                    "Col fun calc threw an exception:\n%s", traceback.format_exc()
-                )
+                self._logger.exception("Col fun calc threw an exception:")
                 self.cols = []
 
             try:
@@ -2552,9 +2531,7 @@ class Table(Cell):
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error(
-                    "Row fun calc threw an exception:\n%s", traceback.format_exc()
-                )
+                self._logger.exception("Row fun calc threw an exception:")
                 self.rows = []
 
             self._resetSubscriptionsToViewReads(v)
@@ -3328,7 +3305,7 @@ class _PlotUpdater(Cell):
                 # temporary js WS refactoring data
                 self.exportData["exceptionOccured"] = True
 
-                self._logger.error(traceback.format_exc())
+                self._logger.exception("Exception in recalculate")
                 self.linePlot.error.set(traceback.format_exc())
 
             self._resetSubscriptionsToViewReads(v)

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,9 @@ log_level = INFO
 log_format = [%(asctime)s.%(msecs)03d] %(levelname)8s %(filename)30s:%(lineno)4s | %(threadName)10s | %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 
+# Uncomment to enable in-process logging not to be captured when -s is used
+# log_cli = True
+
 
 # The pycodestyle section is used by autopep8
 [pycodestyle]


### PR DESCRIPTION
# Purpose & Approach
`pytest` may create a multiple in-proc ServiceManagers per session (which was failing due to the call to `setCodebaseInstantiationDirectory`). Moreover, building Codebase objects is expensive.  `InProcessServiceManager` is meant to be a fast alternative to `SubprocessServiceManager` for testing, so the solution is to allow `InProcessServiceManager` to create `Service` objects without a codebase by default.

# Testing
- Our private repo tests that use `InProcessServiceManager` are happy with this change.
- Our other private repo tests are also happy with the other changes.

# Extras
`install-pre-commit` should happen during `make install` *after* installing the project dependencies.