### PR TITLE
Alex reactor fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ __pycache__
 build/
 
 
-nativepython.egg-info
 object_database.egg-info
 
 # Ignore node modules

--- a/object_database/reactor.py
+++ b/object_database/reactor.py
@@ -96,8 +96,7 @@ class Reactor:
         self.maxSleepTime = maxSleepTime
 
         self._transactionQueue = queue.Queue()
-        self._thread = threading.Thread(target=self.updateLoop)
-        self._thread.daemon = True
+        self._thread = threading.Thread(target=self.updateLoop, daemon=True)
         self._isStarted = False
         self._lastReadKeys = None
         self._nextWakeup = None
@@ -125,6 +124,9 @@ class Reactor:
         If this function returns False, then as soon as it would return True it wakes up
         again.
         """
+        if not isinstance(ts, (int, float)):
+            raise TypeError(f"Timestamp `ts` must be of type float but was of type {type(ts)}")
+
         curTime = getattr(_currentReactor, "timestamp", None)
         if curTime is None:
             raise Exception("No reactor is running.")


### PR DESCRIPTION
## Motivation and Context
We call `curTimestampIsAfter` with `ts=None` in some cases. Without this change we get `TypeError` message saying we cannot compare float to None, which is somewhat obscure. 

## Approach
The approach I followed was to support `ts` taking the value `None` and assuming all valid timestamps are after (greater than) `None`.

Alternatively, we could check that ts is indeed of type float and raise an exception otherwise.
