### PR TITLE
Update pinned version of Node to latest LTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ install-dependencies: $(VIRTUAL_ENV)
 		pip install black==19.3b0; \
 		pipenv install --dev --deploy; \
 		pip install -e .; \
-		nodeenv --python-virtualenv --prebuilt --node=10.15.3 $(NODE_ENV); \
+		nodeenv --python-virtualenv --prebuilt --node=12.13.0 $(NODE_ENV); \
 		npm install --global webpack webpack-cli; \
 		cd object_database/web/content; \
 		npm install; \


### PR DESCRIPTION
## Motivation and Context
I had trouble installing object_database on Ubuntu 19.10 with python 3.6.9 and the latest nodeenv (1.3.3). After installing node in the virtual environment via the command `nodeenv --python-virtualenv --prebuilt --node=10.15.3 .nodeenv` in the Makefile, npm would be borked. Even running simply `npm -h` would error with a segmentation fault. There is not other node/nmp installation natively on the OS.

## Approach
By upgrading the pinned version of node we're installing to the latest LTS version, which is 12.13.0 at this time, we get a functioning `npm` and `make install` succeeds.

## How Has This Been Tested?
Ran `make clean; make install` on said Ubuntu 19.10 machine which was successful. Additionally, unit-tests were passing locally.
