### PR TITLE
Remove deprecated attributes from Cells

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -780,7 +780,6 @@ class Cell:
         self._height = None
         self._width = None
         self._overflow = None
-        self._color = None
         self.postscript = None
         self.garbageCollected = False
         self.subscriptions = set()
@@ -1088,9 +1087,6 @@ class Cell:
             else:
                 res.append("height:%s" % self._height)
 
-        if self._color is not None:
-            res.append("color:%s" % self._color)
-
         if self._background_color is not None:
             res.append("background-color:%s" % self._background_color)
 
@@ -1116,10 +1112,6 @@ class Cell:
 
     def height(self, height):
         self._height = height
-        return self
-
-    def color(self, color):
-        self._color = color
         return self
 
     def background_color(self, color):

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -776,7 +776,6 @@ class Cell:
         self._identity = None
         self._tag = None
         self._nowrap = None
-        self._background_color = None
         self._height = None
         self._width = None
         self._overflow = None
@@ -1087,9 +1086,6 @@ class Cell:
             else:
                 res.append("height:%s" % self._height)
 
-        if self._background_color is not None:
-            res.append("background-color:%s" % self._background_color)
-
         if self._overflow is not None:
             res.append("overflow:%s" % self._overflow)
 
@@ -1112,10 +1108,6 @@ class Cell:
 
     def height(self, height):
         self._height = height
-        return self
-
-    def background_color(self, color):
-        self._background_color = color
         return self
 
     def isActive(self):


### PR DESCRIPTION
## Motivation and Context
We have moved to using JS for styling `Cell` objects, and we should no longer be using `color()` and `background_color()`. This came up because some objects derived from `Cell`, in particular `Octicon` have a `color` member (which is a string), and it is confusing for some `Cell` objects to have a `color` attribute and other to have a method of the same name.

This was also discussed [here](https://github.com/APrioriInvestments/object_database/commit/e27a1a5b50293411ca44216e079fa540c57251b7)

## Approach
Remove the deprecated code

## How Has This Been Tested?
- TravisCI is happy after removing the deprecated code.
