### PR TITLE
working version of plot resizer

### DIFF
--- a/object_database/web/cells_demo/plot.py
+++ b/object_database/web/cells_demo/plot.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 object_database Authors
+#   Coyright 2017-2019 Nativepython Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -14,16 +14,122 @@
 
 from object_database.web import cells as cells
 from object_database.web.CellsTestPage import CellsTestPage
+from object_database.web.cells.util import Flex
+import random
 
 
 class BasicPlot(CellsTestPage):
     def cell(self):
-        return cells.Plot(
-            lambda: {
-                "single_array": [1, 2, 3, 1, 2, 3],
-                "xy": {"x": [1, 2, 3, 1, 2, 3], "y": [4, 5, 6, 7, 8, 9]},
-            }
-        )
+        data = {"x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "y": [5, 4, 3, 2, 1, 2, 3, 4, 5, 6]}
+        slot = cells.Slot(data)
+
+        def getData():
+            d = slot.get()
+            return {"data": d}
+
+        def updateData():
+            d = slot.get()
+            nextData = {"x": [], "y": []}
+            for dim, array in d.items():
+                nextNums = [i + 1 for i in array]
+                nextData[dim] = nextNums
+            slot.set(nextData)
+
+        button = cells.Button("Increment", updateData)
+
+        return button >> Flex(cells.Plot(getData))
 
     def text(self):
-        return "You should see a basic line plot."
+        return (
+            "You should see a basic plot with fake data.",
+            "\nIncrement X and Y values by pusing button",
+        )
+
+
+class TogglePlot(CellsTestPage):
+    def cell(self):
+        show = cells.Slot(True)
+        slot = cells.Slot({"x": [1, 2, 3, 4, 5], "y": [5, 4, 3, 2, 1]})
+
+        def getData():
+            d = slot.get()
+            return {"data": d}
+
+        def updateData():
+            d = slot.get()
+            nextData = {"x": [], "y": []}
+            for dim, array in d.items():
+                nextNums = [i + 1 for i in array]
+                nextData[dim] = nextNums
+            slot.set(nextData)
+
+        def togglePlot():
+            show.set(not show.get())
+
+        incrementBtn = cells.Button("Increment", updateData)
+        toggleBtn = cells.Button("Toggle Plot", togglePlot)
+        plot = cells.Plot(getData)
+        placeholder = cells.Panel(cells.Text("Empty!"))
+
+        leftPane = cells.Panel(cells.Margin(15, incrementBtn) + cells.Margin(15, toggleBtn))
+        rightPane = cells.Subscribed(lambda: plot if show.get() else placeholder)
+
+        return leftPane >> rightPane
+
+    def text(self):
+        return ("You should be able to toggle the Plot and ", "have the Plot re-appear")
+
+
+class InSubscribedSequence(CellsTestPage):
+    def cell(self):
+        def getRandomPlotData():
+            x = [random.randint(0, 100) for i in range(20)]
+            y = [random.randint(0, 100) for i in range(20)]
+            coords = {"x": x, "y": y}
+            return {"data": coords}
+
+        first_slot = cells.Slot(getRandomPlotData())
+        second_slot = cells.Slot(getRandomPlotData())
+        third_slot = cells.Slot(getRandomPlotData())
+
+        first_plot = cells.Plot(lambda: first_slot.get())
+        second_plot = cells.Plot(lambda: second_slot.get())
+        third_plot = cells.Plot(lambda: third_slot.get())
+
+        show_first = cells.Slot(True)
+        show_second = cells.Slot(True)
+        show_third = cells.Slot(True)
+
+        toggle_buttons = [
+            cells.Button("Toggle First", lambda: show_first.set(not show_first.get())),
+            cells.Button("Toggle Second", lambda: show_second.set(not show_second.get())),
+            cells.Button("Toggle Third", lambda: show_third.set(not show_third.get())),
+        ]
+
+        update_buttons = [
+            cells.Button("Update First", lambda: first_slot.set(getRandomPlotData())),
+            cells.Button("Update Second", lambda: second_slot.set(getRandomPlotData())),
+            cells.Button("Update Third", lambda: third_slot.set(getRandomPlotData())),
+        ]
+
+        def itemsFun():
+            plots = []
+            if show_first.get():
+                plots.append(first_plot)
+            if show_second.get():
+                plots.append(second_plot)
+            if show_third.get():
+                plots.append(third_plot)
+            return tuple(plots)
+
+        sub_seq = cells.SubscribedSequence(
+            itemsFun, lambda c: Flex(c), orientation="horizontal"
+        )
+
+        togglers = [Flex(c) for c in toggle_buttons]
+        updaters = [Flex(c) for c in update_buttons]
+        panel_seqs = cells.Panel(cells.Sequence(togglers) + cells.Sequence(updaters))
+        return panel_seqs >> Flex(sub_seq)
+
+    def text(self):
+        pass

--- a/object_database/web/cells_demo/plot.py
+++ b/object_database/web/cells_demo/plot.py
@@ -1,4 +1,4 @@
-#   Coyright 2017-2019 Nativepython Authors
+#   Copyright 2017-2019 object_database Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -14,122 +14,16 @@
 
 from object_database.web import cells as cells
 from object_database.web.CellsTestPage import CellsTestPage
-from object_database.web.cells.util import Flex
-import random
 
 
 class BasicPlot(CellsTestPage):
     def cell(self):
-        data = {"x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "y": [5, 4, 3, 2, 1, 2, 3, 4, 5, 6]}
-        slot = cells.Slot(data)
-
-        def getData():
-            d = slot.get()
-            return {"data": d}
-
-        def updateData():
-            d = slot.get()
-            nextData = {"x": [], "y": []}
-            for dim, array in d.items():
-                nextNums = [i + 1 for i in array]
-                nextData[dim] = nextNums
-            slot.set(nextData)
-
-        button = cells.Button("Increment", updateData)
-
-        return button >> Flex(cells.Plot(getData))
-
-    def text(self):
-        return (
-            "You should see a basic plot with fake data.",
-            "\nIncrement X and Y values by pusing button",
+        return cells.Plot(
+            lambda: {
+                "single_array": [1, 2, 3, 1, 2, 3],
+                "xy": {"x": [1, 2, 3, 1, 2, 3], "y": [4, 5, 6, 7, 8, 9]},
+            }
         )
 
-
-class TogglePlot(CellsTestPage):
-    def cell(self):
-        show = cells.Slot(True)
-        slot = cells.Slot({"x": [1, 2, 3, 4, 5], "y": [5, 4, 3, 2, 1]})
-
-        def getData():
-            d = slot.get()
-            return {"data": d}
-
-        def updateData():
-            d = slot.get()
-            nextData = {"x": [], "y": []}
-            for dim, array in d.items():
-                nextNums = [i + 1 for i in array]
-                nextData[dim] = nextNums
-            slot.set(nextData)
-
-        def togglePlot():
-            show.set(not show.get())
-
-        incrementBtn = cells.Button("Increment", updateData)
-        toggleBtn = cells.Button("Toggle Plot", togglePlot)
-        plot = cells.Plot(getData)
-        placeholder = cells.Panel(cells.Text("Empty!"))
-
-        leftPane = cells.Panel(cells.Margin(15, incrementBtn) + cells.Margin(15, toggleBtn))
-        rightPane = cells.Subscribed(lambda: plot if show.get() else placeholder)
-
-        return leftPane >> rightPane
-
     def text(self):
-        return ("You should be able to toggle the Plot and ", "have the Plot re-appear")
-
-
-class InSubscribedSequence(CellsTestPage):
-    def cell(self):
-        def getRandomPlotData():
-            x = [random.randint(0, 100) for i in range(20)]
-            y = [random.randint(0, 100) for i in range(20)]
-            coords = {"x": x, "y": y}
-            return {"data": coords}
-
-        first_slot = cells.Slot(getRandomPlotData())
-        second_slot = cells.Slot(getRandomPlotData())
-        third_slot = cells.Slot(getRandomPlotData())
-
-        first_plot = cells.Plot(lambda: first_slot.get())
-        second_plot = cells.Plot(lambda: second_slot.get())
-        third_plot = cells.Plot(lambda: third_slot.get())
-
-        show_first = cells.Slot(True)
-        show_second = cells.Slot(True)
-        show_third = cells.Slot(True)
-
-        toggle_buttons = [
-            cells.Button("Toggle First", lambda: show_first.set(not show_first.get())),
-            cells.Button("Toggle Second", lambda: show_second.set(not show_second.get())),
-            cells.Button("Toggle Third", lambda: show_third.set(not show_third.get())),
-        ]
-
-        update_buttons = [
-            cells.Button("Update First", lambda: first_slot.set(getRandomPlotData())),
-            cells.Button("Update Second", lambda: second_slot.set(getRandomPlotData())),
-            cells.Button("Update Third", lambda: third_slot.set(getRandomPlotData())),
-        ]
-
-        def itemsFun():
-            plots = []
-            if show_first.get():
-                plots.append(first_plot)
-            if show_second.get():
-                plots.append(second_plot)
-            if show_third.get():
-                plots.append(third_plot)
-            return tuple(plots)
-
-        sub_seq = cells.SubscribedSequence(
-            itemsFun, lambda c: Flex(c), orientation="horizontal"
-        )
-
-        togglers = [Flex(c) for c in toggle_buttons]
-        updaters = [Flex(c) for c in update_buttons]
-        panel_seqs = cells.Panel(cells.Sequence(togglers) + cells.Sequence(updaters))
-        return panel_seqs >> Flex(sub_seq)
-
-    def text(self):
-        pass
+        return "You should see a basic line plot."

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -128,7 +128,6 @@
     cursor: ew-resize;
 }
 
-
 /* Sheet (table) and related
 * =============================================================*/
 .sheet-cell {

--- a/object_database/web/content/components/Plot.js
+++ b/object_database/web/content/components/Plot.js
@@ -68,21 +68,25 @@ class Plot extends Component {
         return this.renderChildNamed('error');
     }
 
+
     setupPlot(){
+        console.log("calling plot setup")
         // TODO These are global var defined in page.html
         // we should do something about this.
         var ownId = this.props.id;
 
         var plotDiv = document.getElementById('plot' + this.props.id);
-        Plotly.plot(
+        Plotly.react(
             plotDiv,
             [],
             {
                 margin: {t : 30, l: 30, r: 30, b:30 },
-                xaxis: {rangeslider: {visible: false}}
+                xaxis: {rangeslider: {visible: false}},
             },
             { scrollZoom: true, dragmode: 'pan', displaylogo: false, displayModeBar: 'hover',
-                modeBarButtons: [ ['pan2d'], ['zoom2d'], ['zoomIn2d'], ['zoomOut2d'] ] }
+                modeBarButtons: [ ['pan2d'], ['zoom2d'], ['zoomIn2d'], ['zoomOut2d'] ],
+                //responsive: true
+            }
         );
         plotDiv.on('plotly_relayout',
             function(eventdata){

--- a/object_database/web/content/components/_PlotUpdater.js
+++ b/object_database/web/content/components/_PlotUpdater.js
@@ -28,6 +28,17 @@ class _PlotUpdater extends Component {
         } else {
             this.listenForPlot();
         }
+        const ro = new ResizeObserver(entries => {
+            initialPlotDiv.style.width = '100%';
+            initialPlotDiv.style.height = '100%';
+            Plotly.Plots.resize(initialPlotDiv)
+            initialPlotDiv.parentNode.style.width = '100%';
+            initialPlotDiv.parentNode.style.height = '100%';
+            Plotly.Plots.resize(initialPlotDiv.parentNode)
+            let plotDiv = document.getElementById(`plot${this.props.extraData.plotId}`);
+            this.runUpdate(initialPlotDiv);
+        });
+        ro.observe(initialPlotDiv.parentNode.parentNode);
     }
 
     componentDidUpdate(){


### PR DESCRIPTION
This is a somewhat hacky addition to make plots resize with window and parent DOM element size changes. 

## Approach
We are registering a resize listener on the plot container element and using the native Plotly resize api in the callback. 

## How Has This Been Tested?
Visually in playground. 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.