### PR TITLE
fixing sheet copy focus bug

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3385,7 +3385,7 @@ class Panel(Cell):
         the bordered Panel area.
     """
 
-    def __init__(self, content):
+    def __init__(self, content, border=True):
         """
         Parameters
         ----------
@@ -3394,13 +3394,18 @@ class Panel(Cell):
             within the bordered Panel area.
             Will be set on instance as `content`
             property.
+        border: bool
+            If True, produce a border and padding. Otherwise, just use this as a grouping
+            element in the display.
         """
         super().__init__()
 
         self.content = Cell.makeCell(content)
+        self.applyBorder = border
 
     def recalculate(self):
         self.exportData["divStyle"] = self._divStyle()
+        self.exportData["applyBorder"] = self.applyBorder
         self.children["content"] = Cell.makeCell(self.content)
 
 

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -400,6 +400,9 @@ td.row-index-item {
     position: relative;
     width: 100%;
     height: 100%;
+}
+
+.cell-panel-border {
     border: 1px solid rgba(150, 150, 150, 0.3);
     padding: 10px;
     border-radius: 3px;

--- a/object_database/web/content/components/Panel.js
+++ b/object_database/web/content/components/Panel.js
@@ -28,8 +28,11 @@ class Panel extends Component {
     }
 
     getClasses(){
-        let classes = ["cell", "cell-panel"];
-        return classes.join(" ");
+        if (this.props.extraData.applyBorder) {
+            return "cell cell-panel cell-panel-border"
+        } else {
+            return "cell cell-panel"
+        }
     }
 }
 

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -71,6 +71,8 @@ class Sheet extends Component {
         this.arrowUpDownLeftRight = this.arrowUpDownLeftRight.bind(this);
         this.pageUpDown = this.pageUpDown.bind(this);
         this.copyToClipboad = this.copyToClipboad.bind(this);
+        this.onFocus = this.onFocus.bind(this);
+        this.onBlur = this.onBlur.bind(this);
         this._updateHeader = this._updateHeader.bind(this);
         this._addLockedElements = this._addLockedElements.bind(this);
         this._removeLockedElements = this._removeLockedElements.bind(this);
@@ -154,7 +156,7 @@ class Sheet extends Component {
         });
         ro.observe(this.container.parentNode);
         // window.addEventListener('resize', this.componentDidLoad);
-        document.addEventListener('copy', event => this.copyToClipboad(event));
+        // document.addEventListener('copy', event => this.copyToClipboad(event));
     }
 
     /* I resize the sheet by recalculating the number of columns and rows using the
@@ -297,6 +299,8 @@ class Sheet extends Component {
                     class: "sheet",
                     style: "table-layout:fixed",
                     tabindex: "-1",
+                    onfocus: this.onFocus,
+                    onblur: this.onBlur,
                     onkeydown: this.handleKeyDown,
                     onclick: this.handleClick,
                     onmouseover: this.handleCellMouseover,
@@ -328,11 +332,22 @@ class Sheet extends Component {
     }
 
     /* I copy the current this.selector cell values to the clipboard. */
-    copyToClipboad(){
-        let txt = this.selector.getSelectionClipboard();
-        event.clipboardData.setData('text/plain', txt);
+    copyToClipboad(event){
         event.preventDefault();
         event.stopPropagation();
+        let txt = this.selector.getSelectionClipboard();
+        event.clipboardData.setData('text/plain', txt);
+    }
+
+    onFocus(event){
+        console.log("sheet in focus")
+        document.addEventListener('copy', this.copyToClipboad)
+    };
+
+
+    onBlur(event){
+        console.log("sheet not in focus")
+        document.removeEventListener('copy', this.copyToClipboad);
     }
 
     /* I handle page Up/Down of the view */


### PR DESCRIPTION


## Motivation and Context
The copy event on Sheet was added at the `document` level regardless of whether the Sheet was in focus. This prevented other element copy events to fire properly.

## Approach
Each Sheet now add a copy event **only** when it comes into focus, and removes it when it comes out of focus. This fixes the bug above and will be compatible with multiple sheets in a view. 

## How Has This Been Tested?
In the UI. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.