### PR TITLE
Popover Fix

### DIFF
--- a/object_database/web/cells_demo/popover.py
+++ b/object_database/web/cells_demo/popover.py
@@ -1,0 +1,28 @@
+#   Copyright 2017-2019 object_database Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells as cells
+from object_database.web.CellsTestPage import CellsTestPage
+
+
+class SimplePopover(CellsTestPage):
+    def cell(self):
+        return cells.Popover("summary", "title", "detailed content")
+
+    def text(self):
+        return (
+            "Popover example. The popover should not disappear when you click on it, "
+            "for example when you're trying to select detailed text in the Popover "
+            "in order to copy it to your clipboard."
+        )

--- a/object_database/web/cells_demo/popover.py
+++ b/object_database/web/cells_demo/popover.py
@@ -26,3 +26,49 @@ class SimplePopover(CellsTestPage):
             "for example when you're trying to select detailed text in the Popover "
             "in order to copy it to your clipboard."
         )
+
+
+def test_popover_toggle_exists(headless_browser):
+    headless_browser.load_demo_page(SimplePopover)
+    query = '{} [data-toggle="popover"]'.format(headless_browser.demo_root_selector)
+    toggler = headless_browser.find_by_css(query)
+    assert toggler
+
+
+def test_popover_show_on_click(headless_browser):
+    # Test that the popover content
+    # shows on click
+    button = headless_browser.find_by_css(
+        '{} [data-toggle="popover"]'.format(headless_browser.demo_root_selector)
+    )
+    assert button
+    content_location = (headless_browser.by.CSS_SELECTOR, ".popover")
+    button.click()
+    headless_browser.wait(1).until(
+        headless_browser.expect.visibility_of_element_located(content_location)
+    )
+
+
+def test_popover_not_hide_on_content_click(headless_browser):
+    # Test that the popover -- now showing -- does not
+    # hide when clicking in the content area
+    content = headless_browser.find_by_css(".popover")
+    assert content
+    content.click()
+    content_location = (headless_browser.by.CSS_SELECTOR, ".popover")
+    headless_browser.wait(1)
+    headless_browser.expect.visibility_of_element_located(content_location)
+
+
+def test_popover_hides_on_toggle(headless_browser):
+    # Test that the popover content hides
+    # when the button is clicked
+    button = headless_browser.find_by_css(
+        '{} [data-toggle="popover"]'.format(headless_browser.demo_root_selector)
+    )
+    assert button
+    button.click()
+    content_location = (headless_browser.by.CSS_SELECTOR, ".popover")
+    headless_browser.wait(1).until(
+        headless_browser.expect.invisibility_of_element_located(content_location)
+    )

--- a/object_database/web/content/NewCellHandler.js
+++ b/object_database/web/content/NewCellHandler.js
@@ -36,7 +36,6 @@ class NewCellHandler {
         this._sessionId = null;
 
         // Bind component methods
-        this.updatePopovers = this.updatePopovers.bind(this);
         this.showConnectionClosed = this.showConnectionClosed.bind(this);
         this.connectionClosedView = this.connectionClosedView.bind(this);
         this.appendPostscript = this.appendPostscript.bind(this);
@@ -225,10 +224,8 @@ class NewCellHandler {
      * from the socket.
      */
     handlePostscript(message){
-        // Elsewhere, update popovers first
-        // Now we evaluate scripts coming
+        // Evaluate scripts coming
         // across the wire.
-        this.updatePopovers();
         while(this.postscripts.length){
             let postscript = this.postscripts.pop();
             try {
@@ -239,46 +236,6 @@ class NewCellHandler {
             }
         }
     }
-
-    /**
-     * Convenience method that updates
-     * Bootstrap-style popovers on
-     * the DOM.
-     * See inline comments
-     */
-    updatePopovers() {
-        // This function requires
-        // jQuery and perhaps doesn't
-        // belong in this class.
-        // TODO: Figure out a better way
-        // ALSO NOTE:
-        // -----------------
-        // `getChildProp` is a const function
-        // that is declared in a separate
-        // script tag at the bottom of
-        // page.html. That's a no-no!
-        $('[data-toggle="popover"]').popover({
-            html: true,
-            container: 'body',
-            title: function () {
-                return getChildProp(this, 'title');
-            },
-            content: function () {
-                return getChildProp(this, 'content');
-            },
-            placement: function (popperEl, triggeringEl) {
-                let placement = triggeringEl.dataset.placement;
-                if(placement == undefined){
-                    return "bottom";
-                }
-                return placement;
-            }
-        });
-        $('.popover-dismiss').popover({
-            trigger: 'focus'
-        });
-    }
-
 
     /** Private Methods **/
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements the behavior desired for Popovers in issue #74  

## Motivation and Context
<!-- Why is this change required? -->
Popover content areas would disappear if you clicked in them. For, this meant you could not highlight text inside Popover content when it was active since it would vanish on click. 
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
Clicking elsewhere on the document or on the original Popover toggler will now cause the Popover to vanish. Clicking in the Popover content area, when it is shown, does nothing.
  
### Popover Component ###
With this PR, the Popover component adds/removes event handlers as needed depending on the state of the popover. This allows us to implement the desired behavior. For more detail, see the custom methods in the Popover.js file.
  
### NewCellHandler Updates ###
Until now we had been relying on a method called `updatePopovers()` inside of the NewCellHandler. This functionality has been removed, and is now the sole responsibility of any single Popover component.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
Tested in the UI. We have added a CellsDemo example for Popover and also four tests for the demo.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

  
## Closes
#74 