### PR TITLE
Sheet selector nav bug/race condition

### DIFF
--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -435,10 +435,10 @@ class Sheet extends Component {
         if (!event.shiftKey){
 			// if the cursor is out of view we translate the view to the cursor
 			// and do nothing else!
-			if (!this.selector.cursorInView()){
-				this.selector.shiftViewToCursor();
-				return;
-			}
+			// if (!this.selector.cursorInView()){
+			//	this.selector.shiftViewToCursor();
+			//	return;
+			//}
 			this.selector.selectionFrame.translate(translation);
             this.selector.shrinkToCursor();
         }

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1602,7 +1602,6 @@ class Selector {
 	 * right-most column of the shifted view.
 	 */
 	shiftViewToCursor(){
-		return;
 		// we always shrink to cursor here
 		this.shrinkToCursor();
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);


### PR DESCRIPTION
## Motivation and Context
This PR resolve the race condition/pagination bug described in issue #84, where a delay from the server could cause the Sheet to think that the selector cursor is off view. We want pagination to be compatible with selector navigation, expansion and related. To follow the google sheets UX we need the Sheet to jump to the cursor whenever the user hits pageUp/Down but the cursor is off view because just previously the user was expanding the selector (leaving the cursor off view). 

## Approach
Here a block (list) of request ids is created for each Sheet view data update, as the responses come back the corresponding ids are removed from the block. This allows us to know when the Sheet full view data update is complete. If this is the case then we can safely check whether the cursor is off view and proceed accordingly. 

## How Has This Been Tested?
in the UI, both locally and with a remote server. 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.