### PR TITLE
Subscribed Refactoring

### DIFF
--- a/object_database/web/CellsTestService.py
+++ b/object_database/web/CellsTestService.py
@@ -136,17 +136,28 @@ def reload():
 
 
 def selectionPanel(page):
-    availableCells = []
-    for _, category in sorted(getPages().items()):
-        for _, item in sorted(category.items()):
-            displayName = "{}.{}".format(item.category(), item.name())
-            url = "CellsTestService?{}".format(
-                urllib.parse.urlencode(dict(category=item.category(), name=item.name()))
-            )
-            clickable = cells.Clickable(displayName, url, makeBold=item is page)
-            availableCells.append(clickable)
+    substringFilter = cells.Slot("")
+
+    def getAvailableCells():
+        availableCells = []
+        for _, category in sorted(getPages().items()):
+            for _, item in sorted(category.items()):
+                displayName = "{}.{}".format(item.category(), item.name())
+                url = "CellsTestService?{}".format(
+                    urllib.parse.urlencode(dict(category=item.category(), name=item.name()))
+                )
+                clickable = cells.Clickable(displayName, url, makeBold=item is page)
+                # ignore case when filtering
+                if substringFilter.get().lower() in displayName.lower():
+                    availableCells.append(clickable)
+        return availableCells
+
     reloadInput = cells.Button(cells.Octicon("sync"), reload)
+    filterBox = cells.SingleLineTextBox(substringFilter)
+    header = cells.HorizontalSequence([reloadInput, filterBox])
 
     return cells.Panel(
-        cells.Sequence([reloadInput, cells.Flex(cells.Sequence(availableCells))])
+        cells.Sequence(
+            [header, cells.Subscribed(lambda: cells.Flex(cells.Sequence(getAvailableCells())))]
+        )
     )

--- a/object_database/web/cells/Messenger.py
+++ b/object_database/web/cells/Messenger.py
@@ -186,9 +186,11 @@ def _resolveExpandedChild(parent_id, cell_or_list, name_in_parent):
         return [
             _resolveExpandedChild(parent_id, cell, name_in_parent) for cell in cell_or_list
         ]
+    """
     if cell_or_list.__class__.__name__ == "Subscribed":
         next_child = cell_or_list.children["content"]
         return _resolveExpandedChild(parent_id, next_child, name_in_parent)
+    """
 
     return _getExpandedStructure(parent_id, cell_or_list, name_in_parent)
 
@@ -229,9 +231,11 @@ def _resolveUpdateChild(name_in_parent, child_or_list, parent_cell):
 
     # If the child is a Subscribed, we attempt to
     # "see through" it by moving onto its content
+    """
     if child_or_list.__class__.__name__ == "Subscribed":
         next_child = child_or_list.children["content"]
         return _resolveUpdateChild(name_in_parent, next_child, parent_cell)
+    """
 
     # If the child was just created, recursively grab
     # the whole subtree for it

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -2352,29 +2352,9 @@ class SingleLineTextBox(Cell):
     def recalculate(self):
         if self.pattern:
             self.exportData["pattern"] = self.pattern
-        if not self.defaultValue:
-            self.defaultValue = self.getDefaultText()
-            self.exportData["defaultValue"] = self.defaultValue
+        self.exportData["defaultValue"] = self.getText()
 
-    def subscribedSlotChanged(self, slot):
-        """Override the way we respond to a slot changing.
-
-        Instead of recalculating, which would rebuild the component, we
-        simply send a message to the server. Eventually this will used the 'data changed'
-        channel
-        """
-        pass
-
-    def subscribedOdbValueChanges(self, odbKey):
-        """Override the way we respond to an odb value changing.
-
-        Instead of recalculating, which would rebuild the component, we
-        simply send a message to the server. Eventually this will used the 'data changed'
-        channel
-        """
-        pass
-
-    def getDefaultText(self):
+    def getText(self):
         with ComputingCellContext(self):
             with self.view() as v:
                 try:

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -2348,6 +2348,7 @@ class SingleLineTextBox(Cell):
     def recalculate(self):
         if self.pattern:
             self.exportData["pattern"] = self.pattern
+        self.exportData["defaultValue"] = self.slot.get()
 
     def onMessage(self, msgFrame):
         self.slot.set(msgFrame["text"])

--- a/object_database/web/cells/subscribed_test.py
+++ b/object_database/web/cells/subscribed_test.py
@@ -56,29 +56,6 @@ class CellsSubscribedTests(unittest.TestCase):
 
         self.assertEqual(sub.children["content"].text, "True")
 
-    def test_subscribed_not_in_desc(self):
-        slot = Slot(True)
-        trueContent = Button("Hello", lambda: None)
-        falseContent = Text("False")
-        sub = Subscribed(lambda: trueContent if slot.get() else falseContent)
-        self.cells.withRoot(sub)
-        res = self.cells.renderMessages()
-
-        self.assertEqual(len(res), 1)
-        self.assertEqual(res[0]["cellType"], "RootCell")
-        rootChild = res[0]["namedChildren"]["child"]
-        self.assertEqual(rootChild["cellType"], "Button")
-        self.assertEqual(rootChild["id"], trueContent.identity)
-
-        slot.set(False)
-        res = self.cells.renderMessages()
-
-        self.assertEqual(res[0]["type"], "#cellUpdated")
-        self.assertEqual(res[0]["cellType"], "RootCell")
-        nextRootChild = res[0]["namedChildren"]["child"]
-        self.assertEqual(nextRootChild["cellType"], "Text")
-        self.assertEqual(nextRootChild["id"], falseContent.identity)
-
     def test_basic_subscribed_lifecycle(self):
         slot = Slot(True)
         trueContent = Button("Hello", lambda: None)
@@ -100,7 +77,7 @@ class CellsSubscribedTests(unittest.TestCase):
         slot.set(False)
         self.cells._recalculateCells()
 
-        self.assertTrue(container.wasUpdated)
+        self.assertFalse(container.wasUpdated)
         self.assertTrue(sub.wasUpdated)
         self.assertTrue(trueContent.wasRemoved)
         self.assertTrue(falseContent.wasCreated)

--- a/object_database/web/cells_demo/text_box.py
+++ b/object_database/web/cells_demo/text_box.py
@@ -1,0 +1,13 @@
+from object_database.web import cells as cells
+from object_database.web.CellsTestPage import CellsTestPage
+
+
+class SingleLineTextBox(CellsTestPage):
+    def cell(self):
+        slot = cells.Slot("initial text")
+        return cells.SingleLineTextBox(slot) + cells.Subscribed(
+            lambda: cells.Card(slot.get(), header="Slot Contents")
+        )
+
+    def text(self):
+        return "A box in which you can edit text."

--- a/object_database/web/content/ComponentRegistry.js
+++ b/object_database/web/content/ComponentRegistry.js
@@ -38,6 +38,7 @@ import {Sequence} from './components/Sequence';
 import {Scrollable} from './components/Scrollable';
 import {SingleLineTextBox} from './components/SingleLineTextBox';
 import {Span} from './components/Span';
+import {Subscribed} from './components/Subscribed';
 import {SubscribedSequence} from './components/SubscribedSequence';
 import {Table} from './components/Table';
 import {Tabs} from './components/Tabs';
@@ -90,6 +91,7 @@ const ComponentRegistry = {
     Scrollable,
     SingleLineTextBox,
     Span,
+    Subscribed,
     SubscribedSequence,
     Table,
     Tabs,

--- a/object_database/web/content/NewCellHandler.js
+++ b/object_database/web/content/NewCellHandler.js
@@ -156,13 +156,9 @@ class NewCellHandler {
         let velement = render(component);
         let domElement = component.getDOMElement();
 
-        if(component.isSubscribed){
-            this.updateSubscribedComponent(component);
-        } else {
-            this.projector.replace(domElement, () => {
-                return velement;
-            });
-        }
+        this.projector.replace(domElement, () => {
+            return velement;
+        });
 
         this._callDidLoadForNew();
         this._callDidUpdate();
@@ -212,12 +208,6 @@ class NewCellHandler {
         if(found){
             found.componentWillUnload();
             delete this.activeComponents[message.id];
-            // Try to find the corresponding element
-            // in the DOM and remove if present
-            let foundEl = found.getDOMElement();
-            if(foundEl){
-                foundEl.remove();
-            }
         }
         return found;
     }

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -10,10 +10,6 @@ import {h} from 'maquette';
 const render = (aComponent) => {
     let velement = aComponent.render();
     aComponent.numRenders += 1;
-    // For debugging purposes,
-    // Add the number of renders of this
-    // component as a data attribute
-    velement.properties['data-num-renders'] = aComponent.numRenders.toString();
     return velement;
 };
 

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -10,6 +10,10 @@ import {h} from 'maquette';
 const render = (aComponent) => {
     let velement = aComponent.render();
     aComponent.numRenders += 1;
+    // For debugging purposes,
+    // Add the number of renders of this
+    // component as a data attribute
+    velement.properties['data-num-renders'] = aComponent.numRenders.toString();
     return velement;
 };
 

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -93,6 +93,14 @@ class Component {
     render() {
         let velement = this.build();
 
+        // If the component's parent is a Subscribed,
+        // we need to give the velement the data
+        // attribute that maps to its Subscribed
+        if(this.parent && this.parent.isSubscribed){
+            let parentId = this.parent.props.id.toString();
+            velement.properties['data-subscribed-to'] = parentId;
+        }
+
         // All components that have a flexChild
         // property should add the class to their
         // root hyperscript's CSS.

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -25,6 +25,8 @@ class Component {
         // in NewCellHandler.
         this.isSubscribed = false;
         this.isWrappingComponent = false;
+        this.subscribedTo = null;
+        this.prevSubscribedTo = null;
 
         // Lifecycle handlers used by the
         // CellHandler
@@ -60,6 +62,9 @@ class Component {
         this.namedChildrenDo = this.namedChildrenDo.bind(this);
         this.renderChildNamed = this.renderChildNamed.bind(this);
         this.renderChildrenNamed = this.renderChildrenNamed.bind(this);
+        this.getInheritanceChain = this.getInheritanceChain.bind(this);
+        this.getSubscribedChain = this.getSubscribedChain.bind(this);
+        this.getTopSubscribedAncestor = this.getTopSubscribedAncestor.bind(this);
         this._setupChildRelationships = this._setupChildRelationships.bind(this);
         this._updateProps = this._updateProps.bind(this);
         this._updateData = this._updateData.bind(this);
@@ -92,10 +97,11 @@ class Component {
         // If the component's parent is a Subscribed,
         // we need to give the velement the data
         // attribute that maps to its Subscribed
-        if(this.parent && this.parent.isSubscribed){
-            let parentId = this.parent.props.id.toString();
-            velement.properties['data-subscribed-to'] = parentId;
+
+        if(this.subscribedTo){
+            velement.properties['data-subscribed-to'] = this.subscribedTo;
         }
+
 
         // All components that have a flexChild
         // property should add the class to their
@@ -311,6 +317,48 @@ class Component {
             let child = this.props.namedChildren[key];
             callback(key, child);
         });
+    }
+
+    /**
+     * Responds with an array of all ancestor
+     * components to the current one.
+     */
+    getInheritanceChain(){
+        let result = [];
+        let parent = this.parent;
+        while(parent){
+            result.push(parent);
+            parent = parent.parent;
+        }
+        return result;
+    }
+
+    /**
+     * Similar to getInheritanceChain,
+     * but only adds Components that are
+     * of type Subscribed
+     */
+    getSubscribedChain(){
+        let result = [];
+        let parent = this.parent;
+        while(parent && parent.isSubscribed){
+            result.push(parent);
+            parent = parent.parent;
+        }
+        return result;
+    }
+
+    /**
+     * Responds with a Component representing
+     * the top ancestor in the SubcribedChain.
+     * See #getSubscribedChain for more information.
+     */
+    getTopSubscribedAncestor(){
+        let result = this.getSubscribedChain();
+        if(result.length){
+            return result.pop();
+        }
+        return null;
     }
 
     /** Private Util Methods **/

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -198,6 +198,13 @@ class Component {
      */
     renderChildNamed(key){
         let foundChild = this.props.namedChildren[key];
+        /*if(foundChild && foundChild.isSubscribed){
+            let subVElement = render(foundChild);
+            let contentVElement = foundChild.renderContent();
+            contentVElement.key = `subscribedTo${foundChild.props.id}`;
+            subVElement.key = foundChild;
+            return [contentVElement, subVElement];
+        }*/
         if(foundChild){
             let velement = render(foundChild);
             velement.key = foundChild;
@@ -218,13 +225,17 @@ class Component {
         if(foundChildren){
             return this._recursivelyMapNamedChildren(foundChildren, child => {
                 let velement = render(child);
-
                 // In some cases velement
                 // will be null, as in non-display
                 // components.
                 if(velement){
                     velement.key = child;
                 }
+                /*if(child.isSubscribed){
+                    let contentVElement = child.renderContent();
+                    contentVElement.key = `subscribedTo${child.props.id}`;
+                    return [contentVElement, velement];
+                }*/
                 return velement;
             });
         }

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -435,10 +435,10 @@ class Sheet extends Component {
         if (!event.shiftKey){
 			// if the cursor is out of view we translate the view to the cursor
 			// and do nothing else!
-			if (!this.selector.cursorInView()){
-				this.selector.shiftViewToCursor();
-				return;
-			}
+			// if (!this.selector.cursorInView()){
+			//	this.selector.shiftViewToCursor();
+			//	return;
+			//}
 			this.selector.selectionFrame.translate(translation);
             this.selector.shrinkToCursor();
         }

--- a/object_database/web/content/components/SingleLineTextBox.js
+++ b/object_database/web/content/components/SingleLineTextBox.js
@@ -3,6 +3,7 @@
  */
 
 import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
 class SingleLineTextBox extends Component {
@@ -20,6 +21,7 @@ class SingleLineTextBox extends Component {
                 id: "text_" + this.props.id,
                 type: "text",
                 "data-cell-id": this.props.id,
+                value: (this.props.defaultValue || ""),
                 "data-cell-type": "SingleLineTextBox",
                 onchange: (event) => {this.changeHandler(event.target.value);}
             };
@@ -41,5 +43,12 @@ class SingleLineTextBox extends Component {
         );
     }
 }
+
+SingleLineTextBox.propTypes = {
+    defaultValue: {
+        type: PropTypes.string,
+        description: "Default value to insert into field"
+    }
+};
 
 export {SingleLineTextBox, SingleLineTextBox as default};

--- a/object_database/web/content/components/SingleLineTextBox.js
+++ b/object_database/web/content/components/SingleLineTextBox.js
@@ -18,7 +18,7 @@ class SingleLineTextBox extends Component {
         let attrs =
             {
                 class: "cell",
-                id: "text_" + this.props.id,
+                id: this.props.id.toString(),
                 type: "text",
                 "data-cell-id": this.props.id,
                 value: (this.props.defaultValue || ""),

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -22,49 +22,45 @@ class Subscribed extends Component {
     }
 
     build(){
-        return([
-            h('div', {
-                id: this.props.id,
-                'data-cell-id': this.props.id,
-                'data-cell-type': "Subscribed",
-                'class': 'cell subscribed',
-                'style': 'display:none;'
-            }, []),
-            this.renderContent()
-        ]);
+        if(this.contentIsEmpty){
+            // There is no content to display,
+            // so we render the placeholder
+            // that will not be displayed in
+            // layouts
+            console.log(`Building ${this.props.id} using placeholder`);
+            return(
+                h('div', {
+                    id: this.props.id,
+                    'data-cell-id': this.props.id,
+                    'data-cell-type': "Subscribed",
+                    'class': 'cell subscribed',
+                    'style': 'display:none;'
+                }, [])
+             );
+        } else {
+            console.log(`Building ${this.props.id} using child content`);
+            // There is valid child content,
+            // so we render that by proxy
+            // with a reference data attribute
+            let velement = this.renderContent();
+            velement.properties['data-subscribed-to'] = this.props.id;
+            return velement;
+        }
     }
 
-    render(){
-        // Override default behavior to that
-        // we render each element in the array
-        // that was built
-        let built = this.build();
-        let subVElement = built[0];
-        let contentVElement = built[1];
-
-        // See if the Subscribed itself
-        // has a parent that is Subscribed
-        if(this.parent && this.parent.isSubsribed){
-            contentVElement.properties['data-subscribed-to'] = this.props.id.toString();
+    getDOMElement(){
+        // Override the normal behavior.
+        // Here we return the element that is
+        // being subscribed to, if present.
+        // Otherwise we return the placeholder
+        // element.
+        let subscribedTo = `[data-subscribed-to="${this.props.id}"]`;
+        let subscribedToEl = document.querySelector(subscribedTo);
+        if(subscribedToEl){
+            return subscribedToEl;
+        } else {
+            return document.querySelector(`[data-cell-id="${this.props.id}"]`);
         }
-
-        // All component that have a flexChild
-        // property should add that class to their
-        // root displayed hyperscript css
-        if(this.props.flexChild){
-            contentVElement.properties.class += " flex-child";
-        }
-
-        // Here we would add any custom inline styles,
-        // but this should not really happen to Subscribeds.
-
-        // Add any custom queryTag that should be added as
-        // a data-attribute
-        if(this.props.queryTag){
-            subVElement.properties['data-tag'] = this.props.queryTag.toString();
-        }
-
-        return [contentVElement, subVElement];
     }
 
     renderContent(){
@@ -77,6 +73,16 @@ class Subscribed extends Component {
         } else {
             return null;
         }
+    }
+
+    get contentIsEmpty(){
+        // Return true only if the
+        // child content is undefined, null,
+        // or otherwise empty.
+        if(this.props.namedChildren.content){
+            return false;
+        }
+        return true;
     }
 }
 

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -1,0 +1,34 @@
+/**
+ * Subscribed Cell Component
+ * -------------------------
+ */
+import {Component} from './Component';
+import {h} from 'maquette';
+
+
+/**
+ * About Named Children
+ * ---------------------
+ * `content` (single) - The Subscribed content
+ */
+class Subscribed extends Component {
+    constructor(props, ...args){
+        super(props, ...args);
+    }
+
+    build(){
+        return(
+            h('div', {
+                id: this.props.id,
+                'data-cell-id': this.props.id,
+                'data-cell-type': "Subscribed",
+                'class': 'cell subscribed'
+            }, [this.renderChildNamed('content')])
+        );
+    }
+}
+
+export {
+    Subscribed,
+    Subscribed as default
+};

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -15,6 +15,7 @@ import {h} from 'maquette';
 class Subscribed extends Component {
     constructor(props, ...args){
         super(props, ...args);
+        this.isSubscribed = true;
     }
 
     build(){

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -2,7 +2,7 @@
  * Subscribed Cell Component
  * -------------------------
  */
-import {Component} from './Component';
+import {Component, render} from './Component';
 import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
@@ -16,17 +16,67 @@ class Subscribed extends Component {
     constructor(props, ...args){
         super(props, ...args);
         this.isSubscribed = true;
+
+        // Bind component methods
+        this.renderContent = this.renderContent.bind(this);
     }
 
     build(){
-        return(
+        return([
             h('div', {
                 id: this.props.id,
                 'data-cell-id': this.props.id,
                 'data-cell-type': "Subscribed",
-                'class': 'cell subscribed'
-            }, [this.renderChildNamed('content')])
-        );
+                'class': 'cell subscribed',
+                'style': 'display:none;'
+            }, []),
+            this.renderContent()
+        ]);
+    }
+
+    render(){
+        // Override default behavior to that
+        // we render each element in the array
+        // that was built
+        let built = this.build();
+        let subVElement = built[0];
+        let contentVElement = built[1];
+
+        // See if the Subscribed itself
+        // has a parent that is Subscribed
+        if(this.parent && this.parent.isSubsribed){
+            contentVElement.properties['data-subscribed-to'] = this.props.id.toString();
+        }
+
+        // All component that have a flexChild
+        // property should add that class to their
+        // root displayed hyperscript css
+        if(this.props.flexChild){
+            contentVElement.properties.class += " flex-child";
+        }
+
+        // Here we would add any custom inline styles,
+        // but this should not really happen to Subscribeds.
+
+        // Add any custom queryTag that should be added as
+        // a data-attribute
+        if(this.props.queryTag){
+            subVElement.properties['data-tag'] = this.props.queryTag.toString();
+        }
+
+        return [contentVElement, subVElement];
+    }
+
+    renderContent(){
+        // Return the rendered velement of
+        // the child content, if present.
+        let content = this.props.namedChildren.content;
+        if(content){
+            content.numRenders += 1;
+            return content.render();
+        } else {
+            return null;
+        }
     }
 }
 

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -3,6 +3,7 @@
  * -------------------------
  */
 import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
 

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1602,7 +1602,6 @@ class Selector {
 	 * right-most column of the shifted view.
 	 */
 	shiftViewToCursor(){
-		return;
 		// we always shrink to cursor here
 		this.shrinkToCursor();
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);

--- a/object_database/web/content/tests/SubscribedTests.js
+++ b/object_database/web/content/tests/SubscribedTests.js
@@ -1,0 +1,374 @@
+/**
+ * Subscribed Tests
+ * ----------------------------------------
+ * These tests handle full CellHandler, rendering
+ * and DOM integration for components that
+ * interact with Subscribeds
+ */
+require('jsdom-global')();
+const maquette = require('maquette');
+const h = maquette.h;
+const NewCellHandler = require('../NewCellHandler.js').default;
+const AllComponents = require('../ComponentRegistry').default;
+const chai = require('chai');
+const assert = chai.assert;
+let projector = maquette.createProjector();
+const registry = require('../ComponentRegistry').ComponentRegistry;
+
+/* Example Messages and Structures */
+let simpleRoot = {
+    id: "page_root",
+    cellType: "RootCell",
+    parentId: null,
+    nameInParent: null,
+    extraData: {},
+    namedChildren: {}
+};
+
+let subscribedTemplate = {
+    id: 'replaceme',
+    cellType: 'Subscribed',
+    parentId: null,
+    nameInParent: null,
+    extraData: {},
+    namedChildren: {}
+};
+
+let textTemplate = {
+    id: 'replaceme',
+    cellType: 'Text',
+    extraData: {
+        rawText: "TEXT1"
+    },
+    namedChildren: {}
+};
+
+let makeUpdateMessage = (compDescription) => {
+    return Object.assign({}, compDescription, {
+        channel: "#main",
+        type: "#cellUpdated",
+        shouldDisplay: true
+    });
+};
+
+let makeCreateMessage = (compDescription) => {
+    return Object.assign({}, compDescription, {
+        channel: "#main",
+        type: "#cellUpdated",
+        shouldDisplay: true
+    });
+};
+
+let makeDiscardedMessage = (compDescription) => {
+    return Object.assign({}, compDescription, {
+        channel: "#main",
+        type: "#cellDiscarded"
+    });
+};
+
+
+describe("Subscribed Tests", () => {
+    describe("Renders a single basic Subscribed", () => {
+        var sub = Object.assign({}, subscribedTemplate, {
+            id: '1',
+            nameInParent: 'child',
+            parentId: simpleRoot.id
+        });
+        var root = Object.assign({}, simpleRoot, {
+            namedChildren: {
+                child: sub
+            }
+        });
+        var handler = new NewCellHandler(h, projector, registry);
+        before(() => {
+            let rootEl = document.createElement('div');
+            rootEl.id = 'page_root';
+            document.body.append(rootEl);
+        });
+        after(() => {
+            let rootEl = document.getElementById('page_root');
+            rootEl.remove();
+        });
+        it("Can create components for basic structure", () => {
+            assert.exists(sub);
+            assert.exists(root);
+            let createMessage = makeCreateMessage(root);
+            handler.receive(createMessage);
+            let storedRoot = handler.activeComponents[root.id];
+            let storedSubscribed = handler.activeComponents[sub.id];
+            assert.exists(storedRoot);
+            assert.exists(storedSubscribed);
+        });
+
+        it("Subscrbed placeholder (empty) is present in the DOM", () => {
+            let foundSubEl = document.querySelector(`[data-cell-id="${sub.id}"]`);
+            assert.exists(foundSubEl);
+            assert.equal(foundSubEl.style.display, "none");
+        });
+
+        it("Subscribed chain is empty", () => {
+            let subComponent = handler.activeComponents[sub.id];
+            assert(subComponent);
+            let chain = subComponent.getSubscribedChain();
+            assert.isEmpty(chain);
+        });
+
+        it("No other DOM elements should have data-attrs for subscription", () => {
+            let found = document.querySelector(`[data-subscribed-to="${sub.id}"]`);
+            assert.notExists(found);
+        });
+
+        it("Can properly receive and update message for the Subscribed", () => {
+            let text = Object.assign({}, textTemplate, {
+                id: '2',
+                extraData: {
+                    rawText: 'Text2'
+                }
+            });
+            sub = Object.assign({}, sub, {
+                namedChildren: {
+                    content: text
+                }
+            });
+            let updateMessage = makeUpdateMessage(sub);
+            handler.receive(updateMessage);
+            let subComponent = handler.activeComponents[sub.id];
+            assert.exists(subComponent);
+            let textComponent = handler.activeComponents[text.id];
+            assert.exists(textComponent);
+        });
+
+        it('Subscribed placeholder is removed from the DOM', () => {
+            let placeholder = document.querySelector('[data-cell-id="${sub.id}"]');
+            assert.notExists(placeholder);
+        });
+
+        it('Subscribed Text content element is present in the DOM', () => {
+            let textId = 2;
+            let textEl = document.querySelector(`[data-cell-id="${textId}"]`);
+            assert.exists(textEl);
+        });
+
+        it('Subscribed Text element has correct mapped data attribute', () => {
+            let textEl = document.querySelector(`[data-subscribed-to="${sub.id}"]`);
+            assert.exists(textEl);
+        });
+
+        it("Subscribed Text component has correct Subscribed Chain", () => {
+            let subComponent = handler.activeComponents[sub.id];
+            let textComponent = handler.activeComponents['2'];
+            assert.exists(subComponent);
+            assert.exists(textComponent);
+            let chain = textComponent.getSubscribedChain();
+            assert.equal(1, chain.length);
+            assert.include(chain, subComponent);
+        });
+
+        it("Subscribed Text component top ancestor is the Subscribed", () => {
+            let subComponent = handler.activeComponents[sub.id];
+            let textComponent = handler.activeComponents['2'];
+            assert.exists(subComponent);
+            assert.exists(textComponent);
+            let topAncestor = textComponent.getTopSubscribedAncestor();
+            assert.equal(subComponent, topAncestor);
+        });
+
+        it("Can update again back to empty", () => {
+            sub = Object.assign({}, sub, {
+                namedChildren: {}
+            });
+            let updateMessage = makeUpdateMessage(sub);
+            handler.receive(updateMessage);
+            let subComponent = handler.activeComponents[sub.id];
+            assert.exists(subComponent);
+        });
+
+        it('Subscribed placeholder is again present in the DOM', () => {
+            let placeholder = document.querySelector(`[data-cell-id="${sub.id}"]`);
+            assert.exists(placeholder);
+        });
+
+        it("There are no other elements with mapped subscribed data-attrs", () => {
+            let found = document.querySelector(`[data-subscribed-to="${sub.id}"]`);
+            assert.notExists(found);
+        });
+
+        it("The Text element is definitely not present in the DOM", () => {
+            let textElById = document.querySelector(`[data-cell-id="2"]`);
+            assert.notExists(textElById);
+            let textElByType = document.querySelector('[data-cell-type="Text"]');
+            assert.notExists(textElByType);
+        });
+    });
+
+    describe("Two Nested Subscribed Tests", () => {
+        var handler = new NewCellHandler(h, projector, registry);
+        before(() => {
+            let rootEl = document.createElement('div');
+            rootEl.id = 'page_root';
+            document.body.append(rootEl);
+        });
+        after(() => {
+            let rootEl = document.getElementById('page_root');
+            rootEl.remove();
+        });
+        var childSub = Object.assign({}, subscribedTemplate, {
+            id: '2'
+        });
+        var parentSub = Object.assign({}, subscribedTemplate, {
+            id: '1'
+        });
+        var root = Object.assign({}, simpleRoot, {
+            namedChildren: {
+                child: parentSub
+            }
+        });
+
+        // Alternate child of parentSub
+        var text1 = Object.assign({}, textTemplate, {
+            id: '3',
+            extraData: {
+                rawText: 'Text3'
+            }
+        });
+
+        // Alternate child of childSub
+        var text2 = Object.assign({}, textTemplate, {
+            id: '4',
+            extraData: {
+                rawText: 'Text4'
+            }
+        });
+
+        it('Can render two empty nested Subscribeds', () => {
+            parentSub = Object.assign({}, parentSub, {
+                namedChildren: {
+                    content: childSub
+                }
+            });
+            root = Object.assign({}, root, {
+                namedChildren: {
+                    child: parentSub
+                }
+            });
+            let createMessage = makeCreateMessage(root);
+            handler.receive(createMessage);
+            let parentSubComp = handler.activeComponents[parentSub.id];
+            assert.exists(parentSubComp);
+            let childSubComp = handler.activeComponents[childSub.id];
+            assert.exists(childSubComp);
+        });
+
+        it("There should be a single Subscribed placeholder in the DOM", () => {
+            let placeholders = document.querySelectorAll('[data-cell-type="Subscribed"]');
+            assert.exists(placeholders);
+            assert.equal(1, placeholders.length);
+        });
+
+        it("The present placeholder should have the child Subscribed's id", () => {
+            let placeholder = document.querySelector('[data-cell-type="Subscribed"]');
+            assert.exists(placeholder);
+            assert.equal(placeholder.id, childSub.id);
+        });
+
+        it("The present placeholder should have a subscribed-to attr mapped to parent Subscribed", () => {
+            let placeholder = document.querySelector(`[data-subscribed-to="${parentSub.id}"]`);
+            assert.exists(placeholder);
+        });
+
+        it("Can update the child Subscribed to display text", () => {
+            childSub = Object.assign({}, childSub, {
+                namedChildren: {
+                    content: text2
+                }
+            });
+            let updateMessage = makeUpdateMessage(childSub);
+            handler.receive(updateMessage);
+            let text2Comp = handler.activeComponents[text2.id];
+            assert.exists(text2Comp);
+        });
+
+        it("There should be a Text in the dom with proper id", () => {
+            let foundText = document.querySelector(`[data-cell-id="${text2.id}"]`);
+            assert.exists(foundText);
+        });
+
+        it("There should be no Subscribed placeholders in the DOM", () => {
+            let placeholders = document.querySelectorAll('[data-cell-type="Subscribed"]');
+            assert.equal(0, placeholders.length);
+        });
+
+        it("Can update the Text of child Subscribed", () => {
+            text2 = Object.assign({}, text2, {
+                id: '5',
+                extraData: {
+                    rawText: 'Text5'
+                }
+            });
+            childSub = Object.assign({}, childSub, {
+                namedChildren: {
+                    content: text2
+                }
+            });
+            let updateMessage = makeUpdateMessage(childSub);
+            handler.receive(updateMessage);
+            let text2Comp = handler.activeComponents[text2.id];
+            assert.exists(text2Comp);
+        });
+
+        it("There should be a single Text in the DOM with the proper id", () => {
+            let foundTexts = document.querySelectorAll('[data-cell-type="Text"]');
+            assert.equal(1, foundTexts.length);
+            assert.equal(foundTexts[0].id, '5');
+        });
+
+        it("Can update the Text of the parent Subscribed, overwriting child", () => {
+            parentSub = Object.assign({}, parentSub, {
+                namedChildren: {
+                    content: text1
+                }
+            });
+            let updateMessage = makeUpdateMessage(parentSub);
+            handler.receive(updateMessage);
+            let text1Comp = handler.activeComponents[text1.id];
+            assert.exists(text1Comp);
+        });
+
+        it("There should be a single Text in the DOM with the proper id", () => {
+            let foundTexts = document.querySelectorAll('[data-cell-type="Text"]');
+            assert.equal(1, foundTexts.length);
+            assert.equal(foundTexts[0].id, text1.id);
+        });
+
+        it("There should be no Subscribed placeholders in the DOM", () => {
+            let placeholders = document.querySelectorAll('[data-cell-type="Subscribed"]');
+            assert.isEmpty(placeholders);
+        });
+
+        it("Can update parent Subscribed to be empty", () => {
+            parentSub = Object.assign({}, parentSub, {
+                namedChildren: {}
+            });
+            let updateMessage = makeUpdateMessage(parentSub);
+            handler.receive(updateMessage);
+            let parentComp = handler.activeComponents[parentSub.id];
+            assert.exists(parentComp);
+        });
+
+        it("Has a single placeholder corresponding to the parent Subscribed", () => {
+            let placeholders = document.querySelectorAll('[data-cell-type="Subscribed"]');
+            assert.equal(1, placeholders.length);
+            assert.equal(placeholders[0].id, parentSub.id);
+        });
+
+        it("There are no subscribed-to elements in the DOM", () => {
+            let subscribedToEls = document.querySelectorAll('[data-subscribed-to]');
+            assert.isEmpty(subscribedToEls);
+        });
+
+        it("There are no Texts in the DOM", () => {
+            let foundTexts = document.querySelectorAll('[data-cell-type="Text"]');
+            assert.isEmpty(foundTexts);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements and improved process for rendering Subscribed cells and their content.

## Motivation and Context
<!-- Why is this change required? -->
### A Bit Of History ###
When we first began to finalize a layout structure for Cells, we noticed that Susbcribed Components were screwing with front-end layouts. This is because, like all Cell Components, they rendered as `div` elements, inside of which they would show their (optional) children. Unlike other Cell Components, however, we didn't care about the Susbcribed itself -- we wanted it to be "invisible" in the DOM, and to have its children be the target of any layout that needs to happen.
  
In part to deal with this, we instituted a pattern on the back and front end that worked as follows. First, no information about Susbcribed Cells was ever sent over to the front end. Consequently, we removed the Subscribed component entirely. Instead, for any given Subscribed change, we compute which "non-Subscribed parent" is the closes ancestor and send an update for that. This is how things have been working for several months now.
  
### The Issue ###
Issue #68 highlights not only why this is a weird architectural design, but what can go wrong. Here we have a split panel at or near the root of a very deep Cells structure. On one side is a simple Subscribed and on the other is the deeply nested part. Under the current design, the whole panel -- both sides and everything -- gets completely rerendered when that basic Susbcribed changes. This is clearly a problem from many different angles.
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
There are some aspects of the approach that were discussed in the comments for #68 that we could not, in fact, implement, but I will barely mention these for the sake of brevity.
  
### Backend ###
We re-instutited the sending over of Subscribed information when there are updates. We no longer find the nearest "non-Subscribed parent" for a Subscribed that has updated (or any of its children that has updated), and instead just send it on over as-is.
  
### Subscribed Component and Rendering ###
This means that we've brought back the `Subscribed` component. But we don't want to render its content inside of a `div`, as we know that messes up layouts. The correct approach was to leverage `data-*` attributes and DOM lookups.
  
A given `Subscribed` component will render one of two things:
* A placeholder `div` set to `display:none;` in cases where the Subscribed doesn't currently have content to display;
* The DOM structure of the child in cases where the Subscribed does have content to display, along with a data attribute annotation: `data-subscribed-to=<subscribedId>`.
  
The data attribute tells us which element to replace when updates come across the wire. In cases where there previously was no child content, we instead target the placeholder for replacement (the placeholder has the normal Component structure of an id matching the Subscribed itself).
  
We have wrapped this functionality into overriding the `getDOMElement()` method on `Subscribed` components. It works like this:
* Query for the placeholder by Subscribed id. If you find it, return it;
* Otherwise, query for the element with the `data-subscribed-to=` that matches the Subscribed id. Return it if you find it;
* If the Subscribed itself has a `subscribedTo` attribute set on it, this means its a nested Subscribed. So call `getDOMElement()` on the parent and return the value.
  
### Result and Examples ###
The upshot is that things seem to work as you'd expect -- now only the individual Subscribeds are updated and their content toggles as necessary, even in the case of nested Subscribeds.
  
### `SingleLineTextBox` ###
This PR also fixes issue #79 partially as a consequence. That should be working now too.
  
The canonical example is `resizable_panel.ResizePanelWithButtons`, which allows you to toggle on and off nested Susbcribed structures.


## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
We made minor updates to the existing Cells tests, but added a dozen or so Node tests for the rendering of Subscribed and nested Subscribeds. These are all passing.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  
## Closes
#68 
#79 