### PR TITLE
Additional CellsTest for Modals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,12 @@ black-check: $(VIRTUAL_ENV)
 black-check-local:
 	black --check --target-version=py36  --line-length=95  object_database
 
+
+.PHONY: cells-demo
+cells-demo: $(VIRTUAL_ENV)
+	. $(VIRTUAL_ENV)/bin/activate; \
+		./object_database/frontends/object_database_webtest.py
+
 .PHONY: lib
 lib: object_database/_types.cpython-36m-x86_64-linux-gnu.so
 

--- a/object_database/web/cells_demo/modal_dialogs.py
+++ b/object_database/web/cells_demo/modal_dialogs.py
@@ -59,3 +59,38 @@ class ModalWithUpdateField(CellsTestPage):
             "You should see a button that lets you edit the "
             "'Some Text' text in a modal popup."
         )
+
+
+class ModalWithUpdateFieldAndCancel(CellsTestPage):
+    def cell(self):
+        isShowing = cells.Slot(False)
+        pageContent = cells.Slot("Some Text")
+        modalContent = cells.Slot("Some Text")
+
+        def buttonClick():
+            modalContent.set(pageContent.get())
+            isShowing.set(True)
+
+        def updateClick():
+            pageContent.set(modalContent.get())
+            isShowing.set(False)
+
+        def cancelClick():
+            isShowing.set(False)
+
+        button = cells.Button("Open Modal", buttonClick)
+        textDisplay = cells.Subscribed(lambda: cells.Text(pageContent.get()))
+        modal = cells.Modal(
+            "Text Updater",
+            cells.SingleLineTextBox(modalContent),
+            show=isShowing,
+            Cancel=cancelClick,
+            Update=updateClick,
+        )
+        return cells.Card(button + textDisplay + modal)
+
+    def text(self):
+        return (
+            "You should see a button that lets you edit the "
+            "'Some Text' text in a modal popup."
+        )


### PR DESCRIPTION
## Motivation and Context
Wrote an example of how to do a Modal with an Update and a Cancel button that optionally updates some state through a SingleLineTextBox. Because the SingleLineTextBox updates its associated slot as soon as focus is shifted away from it, in order for the cancel button to work (i.e., not update the external state), we need to have two slots that talk to each other.
