### PR TITLE
Issue #80 Fix

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1295,7 +1295,7 @@ class CollapsiblePanel(Cell):
 class Text(Cell):
     def __init__(self, text, text_color=None, sortAs=None):
         super().__init__()
-        self.text = text
+        self.text = str(text)
         self._sortAs = sortAs if sortAs is not None else text
         self.text_color = text_color
 

--- a/object_database/web/content/components/Text.js
+++ b/object_database/web/content/components/Text.js
@@ -19,9 +19,8 @@ class Text extends Component {
                 id: this.getElementId(),
                 style: this.style,
                 "data-cell-id": `${this.props.id}`,
-                "data-fuck-you": "asshole",
                 "data-cell-type": "Text"
-            }, [this.props.rawText])
+            }, [this.props.rawText ? this.props.rawText.toString() : null])
         );
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements a fix for Issue #80 

## Motivation and Context
<!-- Why is this change required? -->
Setting the value of the `Text` Cell to an integer (ie, `Text(0)`) caused the frontend to completely crash.
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
Solution was simple: Have the corresponding `Text` component call `toString()` on its text content before attempting to render it.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
Used CellsTestPage for testing
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.