### PR TITLE
Handle Orphaned Popovers (fixes 87)

### DIFF
--- a/object_database/web/content/components/Popover.js
+++ b/object_database/web/content/components/Popover.js
@@ -25,6 +25,18 @@ class Popover extends Component {
         this.onClickInPopover = this.onClickInPopover.bind(this);
     }
 
+    componentWillUnload(){
+        // If there is an open rendered
+        // popover on the screen, remove
+        // it.
+        let query = `[data-cell-target="${this.props.id}"].popover`;
+        let found = document.querySelector(query);
+        console.log(found);
+        if(found){
+            $(found).popover('hide');
+        }
+    }
+
     build(){
         return h('div',
             {
@@ -82,10 +94,15 @@ class Popover extends Component {
         event.stopPropagation();
     }
 
+    get template(){
+        return `<div class="popover" role="tooltip" data-cell-target="${this.props.id}"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>`;
+    }
+
     popoverSetup(element){
         // Note: we use jQuery here as
         // it is a requirement of the
         // Bootstrap popover module
+        let thisTemplate = this.template;
         $(element).popover({
             html: true,
             container: 'body',
@@ -101,7 +118,8 @@ class Popover extends Component {
                     return "bottom";
                 }
                 return placement;
-            }
+            },
+            template: thisTemplate
         });
         $(element).on('click', () => {
             $(element).popover('toggle');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements a fix for Issue #87.

## Motivation and Context
<!-- Why is this change required? -->
Users could get in a situation where a Popover is currently open, but the Cell structure that put it there changes or is discarded, and the Popover appears to be "orphaned" in the DOM (still displaying in perpetuity).
<!-- What problem does it solve? -->
  
### Bootstrap and Further Details ###
We are using Bootstrap Popovers in this UI. Part of that library's functionality is to create specific, separate element structures for the actual popovers and have them contained outside of our main application container, so that they can be accurately displayed anywhere on the body. This means that when our Component structures update DOM, the actual content of Popovers is, during normal behavior, unaffected. Therefore if a Popover was open and Component or ancestor Component that contained it gets discarded, the actual Popover remains.
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
The fix only involves two things. The first is to add some metadata to the rendered popover template, which will put data attributes in its rendered DOM element. Speficially, we add the `data-cell-target` attribute whose value is the ID of the corresponding Cell Component.
  
Then we use the `componentWillUnload` lifecycle callback to query for this element, and, if present, call the Bootstrap Popover `.popover('hide')` method on it. 

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
We have added a new CellsDemo for this case and automated tests of that demo.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.