### PR TITLE
Use Valid Component Element IDs

### DIFF
--- a/object_database/web/content/components/AsyncDropdown.js
+++ b/object_database/web/content/components/AsyncDropdown.js
@@ -24,7 +24,7 @@ class AsyncDropdown extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "AsyncDropdown",
                 class: "cell btn-group"

--- a/object_database/web/content/components/Badge.js
+++ b/object_database/web/content/components/Badge.js
@@ -22,7 +22,7 @@ class Badge extends Component {
         return(
             h('span', {
                 class: `cell badge badge-${this.props.badgeStyle}`,
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Badge"
             }, [this.makeInner()])

--- a/object_database/web/content/components/Button.js
+++ b/object_database/web/content/components/Button.js
@@ -24,7 +24,7 @@ class Button extends Component {
     build(){
         return(
             h('button', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Button",
                 class: this._getHTMLClasses(),

--- a/object_database/web/content/components/ButtonGroup.js
+++ b/object_database/web/content/components/ButtonGroup.js
@@ -21,7 +21,7 @@ class ButtonGroup extends Component {
     build(){
         return(
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "ButtonGroup",
                 class: "btn-group",

--- a/object_database/web/content/components/Card.js
+++ b/object_database/web/content/components/Card.js
@@ -37,7 +37,7 @@ class Card extends Component {
         return h('div',
             {
                 class: "cell card",
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Card"
             }, [headerArea, bodyArea]);

--- a/object_database/web/content/components/CardTitle.js
+++ b/object_database/web/content/components/CardTitle.js
@@ -21,7 +21,7 @@ class CardTitle extends Component {
     build(){
         return(
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: "cell",
                 "data-cell-id": this.props.id,
                 "data-cell-type": "CardTitle"

--- a/object_database/web/content/components/CircleLoader.js
+++ b/object_database/web/content/components/CircleLoader.js
@@ -14,7 +14,7 @@ class CircleLoader extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "CircleLoader",
                 class: "spinner",

--- a/object_database/web/content/components/Clickable.js
+++ b/object_database/web/content/components/Clickable.js
@@ -24,7 +24,7 @@ class Clickable extends Component {
     build(){
         return(
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: "cell clickable",
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Clickable",

--- a/object_database/web/content/components/Code.js
+++ b/object_database/web/content/components/Code.js
@@ -22,7 +22,7 @@ class Code extends Component {
         return h('pre',
                  {
                      class: "cell code",
-                     id: this.props.id,
+                     id: this.getElementId(),
                      "data-cell-type": "Code"
                  }, [
                      h("code", {}, [this.makeCode()])

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -118,7 +118,7 @@ class CodeEditor extends Component {
             return h('div',
             {
                 class: "cell code-editor",
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "CodeEditor",
                 key: this

--- a/object_database/web/content/components/CollapsiblePanel.js
+++ b/object_database/web/content/components/CollapsiblePanel.js
@@ -29,7 +29,7 @@ class CollapsiblePanel extends Component {
         return (
             h('div', {
                 class: "cell collapsible-panel",
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "CollapsiblePanel",
                 "data-is-expanded": (this.props.isExpanded == true)

--- a/object_database/web/content/components/Columns.js
+++ b/object_database/web/content/components/Columns.js
@@ -22,7 +22,7 @@ class Columns extends Component {
         return (
             h('div', {
                 class: "cell container-fluid",
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Columns",
             }, [

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -62,6 +62,7 @@ class Component {
         this.namedChildrenDo = this.namedChildrenDo.bind(this);
         this.renderChildNamed = this.renderChildNamed.bind(this);
         this.renderChildrenNamed = this.renderChildrenNamed.bind(this);
+        this.getElementId = this.getElementId.bind(this);
         this.getInheritanceChain = this.getInheritanceChain.bind(this);
         this.getSubscribedChain = this.getSubscribedChain.bind(this);
         this.getTopSubscribedAncestor = this.getTopSubscribedAncestor.bind(this);
@@ -178,7 +179,7 @@ class Component {
      * I am consumed by updates in the handler.
      */
     getDOMElement(){
-        return document.getElementById(this.props.id);
+        return document.getElementById(this.getElementId());
     }
 
     /**
@@ -194,6 +195,18 @@ class Component {
                 this.constructor.propTypes
             );
         }
+    }
+
+    /**
+     * Respond with a string-formatted
+     * DOM valid id that can be used
+     * as the actual element id. Note
+     * that this is different from
+     * `data-cell-id`, which is just
+     * the true id.
+     */
+    getElementId(){
+        return `${this.constructor.elementIdPrefix}${this.props.id}`;
     }
 
     /**
@@ -415,6 +428,9 @@ class Component {
         });
     }
 };
+
+Component.elementIdPrefix = "cell-";
+
 
 /**
  * Given a dictionary of `customStyles`

--- a/object_database/web/content/components/Container.js
+++ b/object_database/web/content/components/Container.js
@@ -26,7 +26,7 @@ class Container extends Component {
         }
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Container",
                 class: "cell",

--- a/object_database/web/content/components/ContextualDisplay.js
+++ b/object_database/web/content/components/ContextualDisplay.js
@@ -22,7 +22,7 @@ class ContextualDisplay extends Component {
         return h('div',
             {
                 class: "cell contextual-display",
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "ContextualDisplay",
                 "data-context-object": this.props.objectType

--- a/object_database/web/content/components/Dropdown.js
+++ b/object_database/web/content/components/Dropdown.js
@@ -29,7 +29,7 @@ class Dropdown extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Dropdown",
                 class: "cell cell-dropdown dropdown btn-group",

--- a/object_database/web/content/components/Expands.js
+++ b/object_database/web/content/components/Expands.js
@@ -35,7 +35,7 @@ class Expands extends Component {
     build(){
         return(
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: 'cell expands',
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Expands",

--- a/object_database/web/content/components/Grid.js
+++ b/object_database/web/content/components/Grid.js
@@ -31,7 +31,7 @@ class Grid extends Component {
         }
         return (
             h('table', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Grid",
                 class: "cell table-sm table-striped cell-grid"

--- a/object_database/web/content/components/HeaderBar.js
+++ b/object_database/web/content/components/HeaderBar.js
@@ -26,7 +26,7 @@ class HeaderBar extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: "cell header-bar bg-light",
                 "data-cell-id": this.props.id,
                 "data-cell-type": "HeaderBar"

--- a/object_database/web/content/components/Highlighted.js
+++ b/object_database/web/content/components/Highlighted.js
@@ -28,7 +28,7 @@ class Highlighted extends Component {
     build(){
         return(
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Highlighted",
                 class: this.getClasses()

--- a/object_database/web/content/components/HorizontalSequence.js
+++ b/object_database/web/content/components/HorizontalSequence.js
@@ -24,7 +24,7 @@ class HorizontalSequence extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: this.makeClasses(),
                 'data-cell-id': this.props.id,
                 'data-cell-type': "HorizontalSequence"

--- a/object_database/web/content/components/LoadContentsFromUrl.js
+++ b/object_database/web/content/components/LoadContentsFromUrl.js
@@ -13,7 +13,7 @@ class LoadContentsFromUrl extends Component {
     build(){
         return(
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "LoadContentsFromUrl",
             }, [h('div', {id: this.props['loadTargetId']}, [])]

--- a/object_database/web/content/components/Main.js
+++ b/object_database/web/content/components/Main.js
@@ -21,7 +21,7 @@ class Main extends Component {
     build(){
         return (
             h('main', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: "py-md-2",
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Main"

--- a/object_database/web/content/components/Modal.js
+++ b/object_database/web/content/components/Modal.js
@@ -27,7 +27,7 @@ class Modal extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 'data-cell-id': this.props.id,
                 'data-cell-type': "Modal",
                 class: this.makeClasses(),

--- a/object_database/web/content/components/Octicon.js
+++ b/object_database/web/content/components/Octicon.js
@@ -22,7 +22,7 @@ class Octicon extends Component {
         return(
             h('span', {
                 class: this._getHTMLClasses(),
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Octicon",
                 "aria-hidden": true,

--- a/object_database/web/content/components/Padding.js
+++ b/object_database/web/content/components/Padding.js
@@ -13,7 +13,7 @@ class Padding extends Component {
     build(){
         return (
             h('span', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Padding",
                 class: "px-2"

--- a/object_database/web/content/components/PageView.js
+++ b/object_database/web/content/components/PageView.js
@@ -24,7 +24,7 @@ class PageView extends Component {
 
     build(){
         return h('div', {
-            id: this.props.id,
+            id: this.getElementId(),
             'data-cell-id': this.props.id,
             'data-cell-type': "PageView",
             class: 'cell page-view'

--- a/object_database/web/content/components/Panel.js
+++ b/object_database/web/content/components/Panel.js
@@ -19,7 +19,7 @@ class Panel extends Component {
 
     build(){
         return h('div', {
-            id: this.props.id,
+            id: this.getElementId(),
             "data-cell-id": this.props.id,
             "data-cell-type": "Panel",
             class: this.getClasses()

--- a/object_database/web/content/components/Plot.js
+++ b/object_database/web/content/components/Plot.js
@@ -48,7 +48,7 @@ class Plot extends Component {
         }
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Plot",
                 class: "cell"

--- a/object_database/web/content/components/Popover.js
+++ b/object_database/web/content/components/Popover.js
@@ -29,7 +29,7 @@ class Popover extends Component {
         return h('div',
             {
                 class: "cell popover-cell",
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Popover"
             }, [

--- a/object_database/web/content/components/ResizablePanel.js
+++ b/object_database/web/content/components/ResizablePanel.js
@@ -42,7 +42,7 @@ class ResizablePanel extends Component {
         }
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: `cell resizable-panel${classString}`,
                 'data-cell-type': 'ResizablePanel',
                 'data-cell-id': this.props.id,

--- a/object_database/web/content/components/RootCell.js
+++ b/object_database/web/content/components/RootCell.js
@@ -18,6 +18,12 @@ class RootCell extends Component {
         this.makeChild = this.makeChild.bind(this);
     }
 
+    getDOMElement(){
+        // Override default behavior, since
+        // id is always "root_cell"
+        return document.getElementById(this.props.id);
+    }
+
     build(){
         return (
             h('div', {

--- a/object_database/web/content/components/Scrollable.js
+++ b/object_database/web/content/components/Scrollable.js
@@ -26,7 +26,7 @@ class Scrollable extends Component {
         }
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: "cell overflow",
                 style: style,
                 "data-cell-id": this.props.id,

--- a/object_database/web/content/components/Sequence.js
+++ b/object_database/web/content/components/Sequence.js
@@ -25,7 +25,7 @@ class Sequence extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: this.makeClasses(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Sequence"

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -86,8 +86,7 @@ class Sheet extends Component {
     }
 
     componentDidLoad(){
-        console.log(`#componentDidLoad called for Sheet ${this.props.id}`);
-        this.container = document.getElementById(this.props.id).parentNode;
+        this.container = this.getDOMElement().parentNode;
         this.maxNumColumns = this._calcMaxNumColumns(this.container.offsetWidth);
         this.maxNumRows = this._calcMaxNumRows(this.container.offsetHeight);
         // new
@@ -290,7 +289,7 @@ class Sheet extends Component {
         ];
         return (
             h("div", {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Sheet",
                 class: "cell sheet-wrapper",
@@ -901,7 +900,7 @@ class SheetRow extends Component {
         });
         return (
             h("tr",
-                {id: this.props.id, class: "sheet-row", style: this.style},
+                {id: this.getElementId(), class: "sheet-row", style: this.style},
                 rowData
             )
         );
@@ -945,7 +944,7 @@ class SheetCell extends Component {
         return (
             h("td",
                 {
-                    id: this.props.id,
+                    id: this.getElementId(),
                     class: this.class,
                     style: this.style
                 },

--- a/object_database/web/content/components/SingleLineTextBox.js
+++ b/object_database/web/content/components/SingleLineTextBox.js
@@ -18,7 +18,7 @@ class SingleLineTextBox extends Component {
         let attrs =
             {
                 class: "cell",
-                id: this.props.id.toString(),
+                id: this.getElementId().toString(),
                 type: "text",
                 "data-cell-id": this.props.id,
                 value: (this.props.defaultValue || ""),

--- a/object_database/web/content/components/Span.js
+++ b/object_database/web/content/components/Span.js
@@ -14,7 +14,7 @@ class Span extends Component {
     build(){
         return (
             h('span', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Span",
                 class: "cell"

--- a/object_database/web/content/components/SplitView.js
+++ b/object_database/web/content/components/SplitView.js
@@ -28,7 +28,7 @@ class SplitView extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: this.makeClasses(),
                 'data-cell-id': this.props.id,
                 'data-cell-type': "SplitView"

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -29,7 +29,7 @@ class Subscribed extends Component {
             // layouts
             return(
                 h('div', {
-                    id: this.props.id,
+                    id: this.getElementId(),
                     'data-cell-id': this.props.id,
                     'data-cell-type': "Subscribed",
                     'class': 'cell subscribed',

--- a/object_database/web/content/components/SubscribedSequence.js
+++ b/object_database/web/content/components/SubscribedSequence.js
@@ -24,7 +24,7 @@ class SubscribedSequence extends Component {
         return h('div',
             {
                 class: this.makeClass(),
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "SubscribedSequence"
             }, this.makeChildren()

--- a/object_database/web/content/components/Table.js
+++ b/object_database/web/content/components/Table.js
@@ -32,7 +32,7 @@ class Table extends Component {
     build(){
         return(
             h('table', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Table",
                 class: "cell table-hscroll table-sm table-striped"

--- a/object_database/web/content/components/Tabs.js
+++ b/object_database/web/content/components/Tabs.js
@@ -25,7 +25,7 @@ class Tabs extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Tabs",
                 class: "container-fluid mb-3"

--- a/object_database/web/content/components/Text.js
+++ b/object_database/web/content/components/Text.js
@@ -16,9 +16,10 @@ class Text extends Component {
         return(
             h('div', {
                 class: "cell",
-                id: this.props.id,
+                id: this.getElementId(),
                 style: this.style,
-                "data-cell-id": this.props.id,
+                "data-cell-id": `${this.props.id}`,
+                "data-fuck-you": "asshole",
                 "data-cell-type": "Text"
             }, [this.props.rawText])
         );

--- a/object_database/web/content/components/Timestamp.js
+++ b/object_database/web/content/components/Timestamp.js
@@ -31,7 +31,7 @@ class Timestamp extends Component {
             {
                 class: "cell",
                 style: this.style,
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Timestamp",
                 onmouseover: this.handleMouseover

--- a/object_database/web/content/components/Traceback.js
+++ b/object_database/web/content/components/Traceback.js
@@ -17,7 +17,7 @@ class  Traceback extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Traceback",
                 class: "alert alert-primary traceback"

--- a/object_database/web/content/components/_NavTab.js
+++ b/object_database/web/content/components/_NavTab.js
@@ -30,7 +30,7 @@ class _NavTab extends Component {
         }
         return (
             h('li', {
-                id: this.props.id,
+                id: this.getElementId(),
                 class: "nav-item",
                 "data-cell-id": this.props.id,
                 "data-cell-type": "_NavTab"

--- a/object_database/web/content/components/_PlotUpdater.js
+++ b/object_database/web/content/components/_PlotUpdater.js
@@ -73,7 +73,7 @@ class _PlotUpdater extends Component {
         return h('div',
             {
                 class: "cell",
-                id: this.props.id,
+                id: this.getElementId(),
                 style: "display: none",
                 "data-cell-id": this.props.id,
                 "data-cell-type": "_PlotUpdater"

--- a/object_database/web/content/components/tests/component-tests.js
+++ b/object_database/web/content/components/tests/component-tests.js
@@ -18,7 +18,8 @@ class SubComponent extends Component {
     build(){
         return (
             h('div', {
-                id: this.props.id,
+                id: this.getElementId(),
+                'data-cell-id': `${this.props.id}`,
                 class: "test-component subcomponent"
             }, [`Child: ${this.props.id}`])
         );
@@ -92,7 +93,7 @@ describe("Base Component Class", () => {
             let component = new SubComponent({id: 'component'});
             let result = component.render();
             assert.exists(result);
-            assert.equal(result.properties.id, 'component');
+            assert.equal(result.properties['data-cell-id'], 'component');
         });
     });
 
@@ -122,7 +123,7 @@ describe("Base Component Class", () => {
             });
             let result = parent.renderedChildren;
             result.forEach((childHyperscript) => {
-                let id = childHyperscript.properties.id;
+                let id = childHyperscript.properties['data-cell-id'];
                 assert.propertyVal(childHyperscript.properties, 'key', `parent1-child-${id}`);
             });
         });
@@ -146,7 +147,7 @@ describe("Module `render` function", () => {
     it("Can render a component", () => {
         let result = render(component);
         assert.exists(result);
-        assert.equal(result.properties.id, 'subcomponent');
+        assert.equal(result.properties['data-cell-id'], 'subcomponent');
     });
     it("Should have only rendered once for now", () => {
         assert.equal(component.numRenders, 1);

--- a/object_database/web/content/components/tests/sheet-tests.js
+++ b/object_database/web/content/components/tests/sheet-tests.js
@@ -1102,7 +1102,7 @@ describe.skip("Sheet and Update Data Tests", () => {
         handler.receive(createMessage);
     });
     after(() => {
-        let rootEl = document.getElementById('page_root');
+        let rootEl = document.querySelector('[data-cell-id="page_root"]');
         if(rootEl){
             rootEl.remove();
         }
@@ -1122,7 +1122,7 @@ describe.skip("Sheet and Update Data Tests", () => {
         handler.receive(updateMessage);
         let stored = handler.activeComponents[child.id];
         assert.exists(stored);
-        let sheet = document.getElementById(simpleSheet.id);
+        let sheet = document.querySelector(`[data-cell-id="${simpleSheet.id}"]`);
         assert.exists(sheet);
         let head = document.getElementById(`sheet-${simpleSheet.id}-head`);
         assert.exists(head);

--- a/object_database/web/content/tests/NewCellHandlerTests.js
+++ b/object_database/web/content/tests/NewCellHandlerTests.js
@@ -6,10 +6,16 @@ const maquette = require('maquette');
 const h = maquette.h;
 const NewCellHandler = require('../NewCellHandler.js').default;
 const AllComponents = require('../ComponentRegistry').default;
+const Component = require('../components/Component').default;
 const chai = require('chai');
 const assert = chai.assert;
 let projector = maquette.createProjector();
 const registry = require('../ComponentRegistry').ComponentRegistry;
+
+const findComponentElementById = (id) => {
+    let query = `${Component.elementIdPrefix}${id}`;
+    return document.getElementById(query);
+};
 
 /* Example Messages and Structures */
 let simpleRoot = {
@@ -127,7 +133,7 @@ describe("Basic Test DOM Tests", () => {
         let root = document.createElement('div');
         root.id = "page_root";
         document.body.append(root);
-        let found = document.getElementById('page_root');
+        let found = document.getElementById("page_root");
         assert.exists(found);
         assert.equal(found, root);
     });
@@ -553,7 +559,7 @@ describe("Basic Structure Handling DOM Tests", () => {
             let textChild = pageRoot.firstElementChild;
             assert.exists(textChild);
             assert.equal(textChild.textContent, "FARTS");
-            assert.equal(textChild.id, 8);
+            assert.equal(textChild.dataset.cellId, 8);
         });
     });
 });
@@ -588,7 +594,7 @@ describe("Properties Update Tests", () => {
         });
         let updateMessage = makeUpdateMessage(parent);
         handler.receive(updateMessage);
-        let el = document.getElementById(newText.id);
+        let el = findComponentElementById(newText.id);
         assert.exists(el);
         assert.equal(el.textContent, "HELLO");
     });
@@ -609,7 +615,7 @@ describe("Properties Update Tests", () => {
         handler.receive(updateMessage);
         let root = document.getElementById('page_root');
         assert.equal(root.children.length, 1);
-        let textChild = document.getElementById(newText.id);
+        let textChild = findComponentElementById(newText.id);
         assert.equal(textChild.textContent, "WORLD");
     });
 });
@@ -673,7 +679,7 @@ describe("Pre-render Additions Tests", () => {
         });
         let updateMessage = makeUpdateMessage(parent);
         handler.receive(updateMessage);
-        let el = document.getElementById(target.id);
+        let el = findComponentElementById(target.id);
         assert.isTrue(el.classList.contains('flex-child'));
     });
 
@@ -709,7 +715,7 @@ describe("Pre-render Additions Tests", () => {
         });
         let updateMessage = makeUpdateMessage(parent);
         handler.receive(updateMessage);
-        let el = document.getElementById(target.id);
+        let el = findComponentElementById(target.id);
         assert.exists(el.attributes.style);
         assert.equal(el.style.color, 'brown');
         assert.equal(el.style.width, '100%');
@@ -742,7 +748,7 @@ describe("Pre-render Additions Tests", () => {
         });
         let updateMessage = makeUpdateMessage(parent);
         handler.receive(updateMessage);
-        let el = document.getElementById(target.id);
+        let el = findComponentElementById(target.id);
         assert.exists(el.getAttribute('data-tag'));
         assert.equal(el.dataset.tag, "test");
     });

--- a/object_database/web/content/tests/SubscribedTests.js
+++ b/object_database/web/content/tests/SubscribedTests.js
@@ -86,7 +86,7 @@ describe("Subscribed Tests", () => {
             document.body.append(rootEl);
         });
         after(() => {
-            let rootEl = document.getElementById('page_root');
+            let rootEl = document.querySelector('[data-cell-id="page_root"]');
             rootEl.remove();
         });
         it("Can create components for basic structure", () => {
@@ -209,7 +209,7 @@ describe("Subscribed Tests", () => {
             document.body.append(rootEl);
         });
         after(() => {
-            let rootEl = document.getElementById('page_root');
+            let rootEl = document.querySelector('[data-cell-id="page_root"]');
             rootEl.remove();
         });
         var childSub = Object.assign({}, subscribedTemplate, {
@@ -268,7 +268,7 @@ describe("Subscribed Tests", () => {
         it("The present placeholder should have the child Subscribed's id", () => {
             let placeholder = document.querySelector('[data-cell-type="Subscribed"]');
             assert.exists(placeholder);
-            assert.equal(placeholder.id, childSub.id);
+            assert.equal(placeholder.dataset.cellId, childSub.id);
         });
 
         it("The present placeholder should have a subscribed-to attr mapped to parent Subscribed", () => {
@@ -319,7 +319,7 @@ describe("Subscribed Tests", () => {
         it("There should be a single Text in the DOM with the proper id", () => {
             let foundTexts = document.querySelectorAll('[data-cell-type="Text"]');
             assert.equal(1, foundTexts.length);
-            assert.equal(foundTexts[0].id, '5');
+            assert.equal(foundTexts[0].dataset.cellId, '5');
         });
 
         it("Can update the Text of the parent Subscribed, overwriting child", () => {
@@ -337,7 +337,7 @@ describe("Subscribed Tests", () => {
         it("There should be a single Text in the DOM with the proper id", () => {
             let foundTexts = document.querySelectorAll('[data-cell-type="Text"]');
             assert.equal(1, foundTexts.length);
-            assert.equal(foundTexts[0].id, text1.id);
+            assert.equal(foundTexts[0].dataset.cellId, text1.id);
         });
 
         it("There should be no Subscribed placeholders in the DOM", () => {
@@ -358,7 +358,7 @@ describe("Subscribed Tests", () => {
         it("Has a single placeholder corresponding to the parent Subscribed", () => {
             let placeholders = document.querySelectorAll('[data-cell-type="Subscribed"]');
             assert.equal(1, placeholders.length);
-            assert.equal(placeholders[0].id, parentSub.id);
+            assert.equal(placeholders[0].dataset.cellId, parentSub.id);
         });
 
         it("There are no subscribed-to elements in the DOM", () => {

--- a/object_database/web/content/tests/lifecycle.js
+++ b/object_database/web/content/tests/lifecycle.js
@@ -163,7 +163,7 @@ describe("Component Lifecycle Tests", () => {
             document.body.append(rootEl);
         });
         after(() => {
-            let rootEl = document.getElementById('page_root');
+            let rootEl = document.querySelector('[data-cell-id="page_root"]');
             rootEl.remove();
         });
         it('Calls #componentDidLoad', () => {
@@ -198,7 +198,7 @@ describe("Component Lifecycle Tests", () => {
             document.body.append(rootEl);
         });
         after(() => {
-            let rootEl = document.getElementById('page_root');
+            let rootEl = document.querySelector('[data-cell-id="page_root"]');
             rootEl.remove();
         });
         it('Did not call #componentDidLoad', () => {
@@ -242,7 +242,7 @@ describe("Component Lifecycle Tests", () => {
             document.body.append(rootEl);
         });
         after(() => {
-            let rootEl = document.getElementById('page_root');
+            let rootEl = document.querySelector('[data-cell-id="page_root"]');
             rootEl.remove();
         });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements a fix to Issue #2 

## Motivation and Context
<!-- Why is this change required? -->
While it is technically OK to have the`id` attribute of a DOM element begin with the string form of a number (for example, `<div id="2">`), it is **invalid** CSS, and breaks any complex querying by selectors.

For example, `document.getElementById("1")` will work as expected.
But `document.querySelector('#1 > .some-child')` with throw a breaking error.
  
The purpose of this PR is to ensure that Components are rendering elements with proper `id` attributes without breaking the rest of the system.
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
### Two Identifiers ###
We now make a distinction between two possible identifiers that can appear in the DOM.
1.  `elementId` -- This is the String form of the Cell id, but with a certain prefix (see below). In the current implementation, the prefix is `cell-`, so Cell Component 4 becomes `id="cell-4"`
2. `Component.id` -- This is just the Cell id (though in string form), and is always an integer,  except in the case of the RootCell. In root DOM elements/velements for a given component, this value will always be placed in the `data-cell-id` attribute.
  
### Finding Things by Id ###
When searching for Components by id outside of the DOM context (such as in the CellHandler), use the normal id, which is available always at `Component.props.id`. These ids are still how the CellHandler keeps track of components.
  
When searching for the root DOM node for a given rendered Component, you have a couple of options:
1. Use `document.getElementById()` and pass in the composed elementId, which is available on Component instances using `.getElementId()`, which will produce something like `"cell-3"`.
2. Use a query selector with the data attribute for the regular id, ie `document.querySelector('[data-cell-id="3"]')`.
  
### The Contract ###
We say as a rule that all references to Cell Components in the system should use the normal id, and that the normal id should always be the (string representation of) the normal Cell identity integer. There is one and only one exception: the `id` attribute of the resulting root DOM element/velement for a given rendered Component. That's it.
  
### Concrete Example ###
Here is what a Text Component should render:
```html
<span id="cell-44" class="cell text-cell" data-cell-id="44">
    Hello, world
</span>
```

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
We have updated the tests to be clearer about which DOM id values to compare results with. These tests are all passing.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.