### PR TITLE
Sheet Scrolling and Selector Bugs and Improvements 

### DIFF
--- a/object_database/web/cells_demo/sheet.py
+++ b/object_database/web/cells_demo/sheet.py
@@ -149,3 +149,39 @@ class BiggerSheetLockedRowsColumns(CellsTestPage):
 
     def text(self):
         return "You should see a bigger sheet."
+
+
+class TwoColumnSheetLockedRowsColumns(CellsTestPage):
+    def cell(self):
+        num_columns = 2
+        num_rows = 10000
+
+        def rowFun(
+            start_row,
+            end_row,
+            start_column,
+            end_column,
+            num_rows=num_rows,
+            num_columns=num_columns,
+        ):
+            rows = []
+            if start_row >= num_rows or start_column > num_columns:
+                return rows
+            end_column = min(end_column, num_columns)
+            end_row = min(end_row, num_rows)
+            for i in range(start_row, end_row + 1):
+                r = ["entry_%s_%s" % (j, i) for j in range(start_column, end_column + 1)]
+                rows.append(r)
+            return rows
+
+        return cells.Sheet(
+            rowFun,
+            colWidth=80,
+            totalColumns=num_columns,
+            totalRows=num_rows,
+            numLockRows=1,
+            numLockColumns=1,
+        )
+
+    def text(self):
+        return "You should see a bigger sheet."

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -133,7 +133,7 @@
 .sheet-cell {
     border: solid 1px lightblue;
     text-align: center;
-    overflow: ellipsis;
+    overflow: hidden;
     text-overflow: ellipsis;
     padding-right: 2px;
     padding-left: 2px;
@@ -199,18 +199,13 @@ td.locked {
 
 .sheet-wrapper th {
     background-color: #dcdcdc75;
-    text-overflow: ellipsis;
-    text-align: left;
+    font-size: .8rem;
     padding-left: 5px;
-    border-right: 2px solid #568eca;
-}
-
-.sheet-wrapper thead {
     border-bottom: 2px solid #568eca;
 }
 
 th.header-info{
-    text-align: center;
+    text-align: right;
     padding-right: 5px;
 }
 

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -133,7 +133,7 @@
 .sheet-cell {
     border: solid 1px lightblue;
     text-align: center;
-    overflow: hidden;
+    overflow: ellipsis;
     text-overflow: ellipsis;
     padding-right: 2px;
     padding-left: 2px;
@@ -199,13 +199,18 @@ td.locked {
 
 .sheet-wrapper th {
     background-color: #dcdcdc75;
-    font-size: .8rem;
+    text-overflow: ellipsis;
+    text-align: left;
     padding-left: 5px;
+    border-right: 2px solid #568eca;
+}
+
+.sheet-wrapper thead {
     border-bottom: 2px solid #568eca;
 }
 
 th.header-info{
-    text-align: right;
+    text-align: center;
     padding-right: 5px;
 }
 

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -627,12 +627,12 @@ class Sheet extends Component {
         // information.
         if(this.isSelecting){
             let targetCoord = [parseInt(event.target.dataset.x), parseInt(event.target.dataset.y)];
-			this.selector.clearStyling();
+            this.selector.clearStyling();
             this.selector.selectionFrame.fromPointToPoint(
                 this.selector.selectionFrame.cursor,
                 targetCoord
             );
-			this.selector.addStyling();
+            this.selector.addStyling();
         }
     }
 

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -438,7 +438,7 @@ class Sheet extends Component {
         if (!event.shiftKey){
             // if the cursor is out of view we translate the view to the cursor
             // and do nothing else!
-            if (this.fetchBlock.length === 0 && !this.selector.cursorInView()){
+            if (this.fetchBlock.length === 0 && !this.selector.cursorInView() && !this.selector.cursorInLockedArea()){
                 this.selector.shiftViewToCursor();
                 return;
             }
@@ -815,7 +815,6 @@ class Sheet extends Component {
                     }
                 }
             }
-            console.log(this.selector);
         });
     }
 

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -656,17 +656,18 @@ class Sheet extends Component {
         let th = head.querySelector(`#sheet-${this.props.id}-head-current`);
         let content = this.dataFrame.get(cursor);
         let coordinates = `(${cursor.x}x${cursor.y}): `;
-        if (content !== undefined){
-            let fontSize = parseFloat(window.getComputedStyle(th).getPropertyValue("font-size"));
-            let newFontSize = '.8em';
-            let contentLength = content.length + coordinates.length;
-            if (fontSize * contentLength > (this.props.colWidth - 5)){
-                newFontSize = `${2 * (this.props.colWidth)/(contentLength)}px`;
+        let fontSize = '.8rem';
+        if (th.colSpan < 2){
+            if (content === undefined){
+                content = "undefined";
             }
-            th.style.fontSize = newFontSize;
-        } else {
-            content = "";
+            let computedFontSize = parseFloat(window.getComputedStyle(th).getPropertyValue("font-size"));
+            let contentLength = content.length + coordinates.length;
+            if (computedFontSize * contentLength > (this.props.colWidth - 5)){
+                fontSize = `${2 * (this.props.colWidth)/(contentLength)}px`;
+            }
         }
+        th.style.fontSize = fontSize;
         th.textContent = `${coordinates}${content}`;
     }
 

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -234,8 +234,10 @@ class Sheet extends Component {
      */
     initializeSheet(projector, body, head){
         // make sure the header spans the entire width
-        let headerCurrent = head.querySelector(`#sheet-${this.props.id}-head-current`);
-        headerCurrent.colSpan = this.maxNumColumns - 1;
+        let headerCurrentCoordinate = head.querySelector(`#sheet-${this.props.id}-head-current-coordinate`);
+        headerCurrentCoordinate.colSpan = this.maxNumColumns - 1;
+        let headerCurrentValue = head.querySelector(`#sheet-${this.props.id}-head-current-value`);
+        headerCurrentValue.colSpan = this.maxNumColumns - 1;
         let headerInfo = head.querySelector(`#sheet-${this.props.id}-head-info`);
         headerInfo.colSpan = 1;
         headerInfo.textContent = `${this.totalColumns}x${this.totalRows}`;
@@ -284,8 +286,11 @@ class Sheet extends Component {
         let rows = ["Just a sec..."];
         let header = [
             h("tr", {style: `height: ${this.props.rowHeight}px`}, [
-                h("th", {id: `sheet-${this.props.id}-head-current`}, []),
-                h("th", {id: `sheet-${this.props.id}-head-info`, class: "header-info"}, [])
+                h("th", {id: `sheet-${this.props.id}-head-current-coordinate`}, []),
+                h("th", {id: `sheet-${this.props.id}-head-info`, "rowSpan": 2, class: "header-info"}, [])
+            ]),
+            h("tr", {style: `height: ${this.props.rowHeight}px`}, [
+                h("th", {id: `sheet-${this.props.id}-head-current-value`}, []),
             ])
         ];
         return (
@@ -653,8 +658,21 @@ class Sheet extends Component {
     /* I handle updates to the display header */
     _updateHeader(body, head){
         let cursor = this.selector.selectionFrame.cursor;
-        let th = head.querySelector(`#sheet-${this.props.id}-head-current`);
-        th.textContent = `(${cursor.x}x${cursor.y}): ${this.dataFrame.get(cursor)}`;
+        let thCoord = head.querySelector(`#sheet-${this.props.id}-head-current-coordinate`);
+        let thValue = head.querySelector(`#sheet-${this.props.id}-head-current-value`);
+        let content = this.dataFrame.get(cursor);
+        if (content !== undefined){
+            let fontSize = parseFloat(window.getComputedStyle(thValue).getPropertyValue("font-size"));
+            let newFontSize = '.8rem';
+            if (fontSize * content.length > (this.props.colWidth - 5)){
+                newFontSize = `${this.props.colWidth/(content.length)}px`;
+            }
+            // th.style.fontSize = newFontSize;
+        } else {
+            content = "";
+        }
+        thCoord.textContent = `(${cursor.x}, ${cursor.y})`;
+        thValue.textContent = `${content}`;
     }
 
     /* Simply resets the `isSelecting` to false, in the

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -815,6 +815,7 @@ class Sheet extends Component {
                     }
                 }
             }
+            console.log(this.selector);
         });
     }
 

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -234,10 +234,8 @@ class Sheet extends Component {
      */
     initializeSheet(projector, body, head){
         // make sure the header spans the entire width
-        let headerCurrentCoordinate = head.querySelector(`#sheet-${this.props.id}-head-current-coordinate`);
-        headerCurrentCoordinate.colSpan = this.maxNumColumns - 1;
-        let headerCurrentValue = head.querySelector(`#sheet-${this.props.id}-head-current-value`);
-        headerCurrentValue.colSpan = this.maxNumColumns - 1;
+        let headerCurrent = head.querySelector(`#sheet-${this.props.id}-head-current`);
+        headerCurrent.colSpan = this.maxNumColumns - 1;
         let headerInfo = head.querySelector(`#sheet-${this.props.id}-head-info`);
         headerInfo.colSpan = 1;
         headerInfo.textContent = `${this.totalColumns}x${this.totalRows}`;
@@ -286,11 +284,8 @@ class Sheet extends Component {
         let rows = ["Just a sec..."];
         let header = [
             h("tr", {style: `height: ${this.props.rowHeight}px`}, [
-                h("th", {id: `sheet-${this.props.id}-head-current-coordinate`}, []),
-                h("th", {id: `sheet-${this.props.id}-head-info`, "rowSpan": 2, class: "header-info"}, [])
-            ]),
-            h("tr", {style: `height: ${this.props.rowHeight}px`}, [
-                h("th", {id: `sheet-${this.props.id}-head-current-value`}, []),
+                h("th", {id: `sheet-${this.props.id}-head-current`}, []),
+                h("th", {id: `sheet-${this.props.id}-head-info`, class: "header-info"}, [])
             ])
         ];
         return (
@@ -658,21 +653,21 @@ class Sheet extends Component {
     /* I handle updates to the display header */
     _updateHeader(body, head){
         let cursor = this.selector.selectionFrame.cursor;
-        let thCoord = head.querySelector(`#sheet-${this.props.id}-head-current-coordinate`);
-        let thValue = head.querySelector(`#sheet-${this.props.id}-head-current-value`);
+        let th = head.querySelector(`#sheet-${this.props.id}-head-current`);
         let content = this.dataFrame.get(cursor);
+        let coordinates = `(${cursor.x}x${cursor.y}): `;
         if (content !== undefined){
-            let fontSize = parseFloat(window.getComputedStyle(thValue).getPropertyValue("font-size"));
-            let newFontSize = '.8rem';
-            if (fontSize * content.length > (this.props.colWidth - 5)){
-                newFontSize = `${this.props.colWidth/(content.length)}px`;
+            let fontSize = parseFloat(window.getComputedStyle(th).getPropertyValue("font-size"));
+            let newFontSize = '.8em';
+            let contentLength = content.length + coordinates.length;
+            if (fontSize * contentLength > (this.props.colWidth - 5)){
+                newFontSize = `${2 * (this.props.colWidth)/(contentLength)}px`;
             }
-            // th.style.fontSize = newFontSize;
+            th.style.fontSize = newFontSize;
         } else {
             content = "";
         }
-        thCoord.textContent = `(${cursor.x}, ${cursor.y})`;
-        thValue.textContent = `${content}`;
+        th.textContent = `${coordinates}${content}`;
     }
 
     /* Simply resets the `isSelecting` to false, in the

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1586,7 +1586,7 @@ class Selector {
         }
     }
 
-      triggerNeedsUpdate(direction, shift){
+    triggerNeedsUpdate(direction, shift){
           if(this.onNeedsUpdate){
               this.onNeedsUpdate(direction, shift);
           }

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1541,7 +1541,10 @@ class Selector {
                     if(shrinkToCursor){
                         this.shrinkToCursor();
                     }
-                } else {
+                // NOTE: we make sure that data is not being fetched since
+                // this can cause a race condition where the cursor could move
+                // off view
+                } else if (this.sheet.fetchBlock.length === 0) {
                     this.selectionFrame.translate(shift);
                     this.clearStyling();
                     if(shrinkToCursor){

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1551,7 +1551,7 @@ class Selector {
      * to shrink the selection frame to be just
      * the size of the cursor after shifting.
      * Defaults to false.
-     */
+     **/
     shiftLeft(amount = 1, shrinkToCursor = false){
         if (this.cursorInView() || this.cursorInLockedArea()){
             let shift = [amount * -1, 0];
@@ -1719,22 +1719,20 @@ class Selector {
     isAtDataRight(){
         return this.selectionFrame.corner.x === this.sheet.dataFrame.corner.x;
     }
-
-  	/**
-  	 * Returns true if the cursor is in any of the locked areas.
-  	 */
-  	cursorInLockedArea(){
-  		let lockRowsY = Math.max(0, this.sheet.props.numLockRows - 1);
-  		let lockColumnsX = Math.max(this.sheet.props.numLockColumns - 1);
-  		let x = this.selectionFrame.cursor.x;
-  		let y = this.selectionFrame.cursor.y;
-  		return (x >= 0) && (x <= lockColumnsX) || (y >= 0) && (y <= lockRowsY);
-  	}
-
-  	/**
-  	 * Returns true if the cursor is in the current view.
-  	 */
-  	cursorInView(){
+    /**
+     * Returns true if the cursor is in any of the locked areas.
+     **/
+    cursorInLockedArea(){
+        let lockRowsY = Math.max(0, this.sheet.props.numLockRows - 1);
+        let lockColumnsX = Math.max(this.sheet.props.numLockColumns - 1);
+        let x = this.selectionFrame.cursor.x;
+        let y = this.selectionFrame.cursor.y;
+        return (x >= 0) && (x <= lockColumnsX) || (y >= 0) && (y <= lockRowsY);
+    }
+    /**
+     * Returns true if the cursor is in the current view.
+     **/
+    cursorInView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let bottomRow = body.lastChild;
         let cornerElement = bottomRow.lastChild;
@@ -1747,49 +1745,46 @@ class Selector {
         let y = this.selectionFrame.cursor.y;
         return (x >= originX) && (x <= cornerX) && (y >= originY) && (y <= cornerY);
     }
-
-  	/**
-  	 * Returns true if the cursor is above the current view.
-  	 */
-  	cursorAboveView(){
+    /*
+     *
+     * Returns true if the cursor is above the current view.
+     **/
+    cursorAboveView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let originElement = body.querySelectorAll("td:not(.locked)")[0];
         let y = this.selectionFrame.cursor.y;
         return y < parseInt(originElement.dataset["y"]);
-  	}
-
-  	/**
-  	 * Returns true if the cursor is below the current view.
-  	 */
-  	cursorBelowView(){
+    }
+    /**
+     * Returns true if the cursor is below the current view.
+     **/
+    cursorBelowView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let bottomRow = body.lastChild;
         let cornerElement = bottomRow.lastChild;
         let y = this.selectionFrame.cursor.y;
         return y > parseInt(cornerElement.dataset["y"]);
-  	}
-
-  	/**
-  	 * Returns true if the cursor is left of the current view.
-  	 */
-  	cursorLeftOfView(){
+    }
+    /**
+     * Returns true if the cursor is left of the current view.
+     **/
+    cursorLeftOfView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let originElement = body.querySelectorAll("td:not(.locked)")[0];
         let x = this.selectionFrame.cursor.x;
         return x < parseInt(originElement.dataset["x"]);
     }
-  	/**
-  	 * Returns true if the cursor is right of the current view.
-  	 */
-  	cursorRightOfView(){
+    /**
+     * Returns true if the cursor is right of the current view.
+     **/
+    cursorRightOfView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let bottomRow = body.lastChild;
         let cornerElement = bottomRow.lastChild;
         let x = this.selectionFrame.cursor.x;
         return x > parseInt(cornerElement.dataset["x"]);
-  	}
+    }
 }
-
 
 export {
     Point,

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1086,21 +1086,13 @@ class Selector {
                     element.classList.add('active-selection');
                 }
                 if(this.selectionFrame.isAtLeft(elementPoint)){
-                    // if we are at the absolute left of the sheet we don't add
-                    // border-left to match the border-top behavior below
-                    if (elementPoint.x > 0) {
-                        element.classList.add('active-selection-left');
-                    }
+                    element.classList.add('active-selection-left');
                 }
                 if(this.selectionFrame.isAtRight(elementPoint)){
                     element.classList.add('active-selection-right');
                 }
                 if(this.selectionFrame.isAtTop(elementPoint)){
-                    // if we are at the absolute top of the sheet we don't add
-                    // the border-top since it interfeces with the header
-                    if (elementPoint.y > 0) {
-                        element.classList.add('active-selection-top');
-                    }
+                    element.classList.add('active-selection-top');
                 }
                 if(this.selectionFrame.isAtBottom(elementPoint)){
                     element.classList.add('active-selection-bottom');

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -986,11 +986,8 @@ class Selector {
      * clear the styling of the td element
      * that maps to the current selection frame
      * cursor.
-     * @param {boolean} clearCursor - Whether or not
-     * to clear the cursor styling too. Defaults to
-     * true
      */
-    clearStyling(clearCursor = false){
+    clearStyling(){
         // Clears all styling on the
         // current selectionFrame and
         // cursor.
@@ -1121,7 +1118,7 @@ class Selector {
      * the selection frame cursor
      */
     cursorTo(aPoint){
-        this.clearStyling(true);
+        this.clearStyling();
         this.shrinkToCursor();
         this.selectionFrame.fromPointToPoint(
             aPoint,
@@ -1425,7 +1422,7 @@ class Selector {
                 console.log("AT DATA TOP");
                 if(!this.isAtViewTop(true)){
                     console.log("NOT AT ABSOLUTE VIEW TOP");
-                    this.clearStyling(true);
+                    this.clearStyling();
                     this.selectionFrame.translate(shift);
                     if(shrinkToCursor){
                         this.shrinkToCursor();
@@ -1441,7 +1438,7 @@ class Selector {
                     }
                 } else {
                     this.selectionFrame.translate(shift);
-                    this.clearStyling(true);
+                    this.clearStyling();
                     if(shrinkToCursor){
                         this.shrinkToCursor();
                     }
@@ -1480,9 +1477,12 @@ class Selector {
                     if(shrinkToCursor){
                         this.shrinkToCursor();
                     }
-                } else {
+                // NOTE: we make sure that data is not being fetched since
+                // this can cause a race condition where the cursor could move
+                // off view
+                } else if (this.sheet.fetchBlock.length === 0) {
                     this.selectionFrame.translate(shift);
-                    this.clearStyling(true);
+                    this.clearStyling();
                     if(shrinkToCursor){
                         this.shrinkToCursor();
                     }
@@ -1523,7 +1523,7 @@ class Selector {
                     }
                 } else {
                     this.selectionFrame.translate(shift);
-                    this.clearStyling(true);
+                    this.clearStyling();
                     if(shrinkToCursor){
                         this.shrinkToCursor();
                     }
@@ -1551,13 +1551,14 @@ class Selector {
      * to shrink the selection frame to be just
      * the size of the cursor after shifting.
      * Defaults to false.
-     **/
+     */
     shiftLeft(amount = 1, shrinkToCursor = false){
+
         if (this.cursorInView() || this.cursorInLockedArea()){
-            let shift = [amount * -1, 0];
+  			let shift = [amount * -1, 0];
             if(this.isAtDataLeft()){
                 if(!this.isAtViewLeft(true)){
-                    this.clearStyling(true);
+                    this.clearStyling();
                     this.selectionFrame.translate(shift);
                     if(shrinkToCursor){
                         this.shrinkToCursor();
@@ -1573,7 +1574,7 @@ class Selector {
                     }
                 } else {
                     this.selectionFrame.translate(shift);
-                    this.clearStyling(true);
+                    this.clearStyling();
                     if(shrinkToCursor){
                         this.shrinkToCursor();
                     }
@@ -1585,26 +1586,26 @@ class Selector {
         }
     }
 
-    triggerNeedsUpdate(direction, shift){
+      triggerNeedsUpdate(direction, shift){
           if(this.onNeedsUpdate){
               this.onNeedsUpdate(direction, shift);
           }
     }
 
-    /**
-     * I shift the entire view to the location of the cursor.
-     * If the cursor is above the current view I place it at the
-     * top row of the shifted view.
-     * If the cursor is below the current view I place it at the
-     * bottom row of the shifted view.
-     * If the cursor is to left of the current view I place it at the
-     * left-left most column of the shifted view.
-     * If the cursor is to the right of the current view I place it at the
-     * right-most column of the shifted view.
-     **/
-    shiftViewToCursor(){
+  	/**
+  	 * I shift the entire view to the location of the cursor.
+  	 * If the cursor is above the current view I place it at the
+  	 * top row of the shifted view.
+  	 * If the cursor is below the current view I place it at the
+  	 * bottom row of the shifted view.
+  	 * If the cursor is to left of the current view I place it at the
+  	 * left-left most column of the shifted view.
+  	 * If the cursor is to the right of the current view I place it at the
+  	 * right-most column of the shifted view.
+  	 */
+  	shiftViewToCursor(){
         // we always shrink to cursor here
-        this.shrinkToCursor();
+  		  this.shrinkToCursor();
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let bottomRow = body.lastChild;
         let cornerElement = bottomRow.lastChild;
@@ -1720,20 +1721,21 @@ class Selector {
         return this.selectionFrame.corner.x === this.sheet.dataFrame.corner.x;
     }
 
-    /**
-     * Returns true if the cursor is in any of the locked areas.
-     **/
-    cursorInLockedArea(){
-        let lockRowsY = Math.max(0, this.sheet.props.numLockRows - 1);
-        let lockColumnsX = Math.max(this.sheet.props.numLockColumns - 1);
-        let x = this.selectionFrame.cursor.x;
-        let y = this.selectionFrame.cursor.y;
-        return (x >= 0) && (x <= lockColumnsX) || (y >= 0) && (y <= lockRowsY);
-    }
-    /**
-     * Returns true if the cursor is in the current view.
-     **/
-    cursorInView(){
+  	/**
+  	 * Returns true if the cursor is in any of the locked areas.
+  	 */
+  	cursorInLockedArea(){
+  		let lockRowsY = Math.max(0, this.sheet.props.numLockRows - 1);
+  		let lockColumnsX = Math.max(this.sheet.props.numLockColumns - 1);
+  		let x = this.selectionFrame.cursor.x;
+  		let y = this.selectionFrame.cursor.y;
+  		return (x >= 0) && (x <= lockColumnsX) || (y >= 0) && (y <= lockRowsY);
+  	}
+
+  	/**
+  	 * Returns true if the cursor is in the current view.
+  	 */
+  	cursorInView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let bottomRow = body.lastChild;
         let cornerElement = bottomRow.lastChild;
@@ -1746,46 +1748,49 @@ class Selector {
         let y = this.selectionFrame.cursor.y;
         return (x >= originX) && (x <= cornerX) && (y >= originY) && (y <= cornerY);
     }
-    /*
-     *
-     * Returns true if the cursor is above the current view.
-     **/
-    cursorAboveView(){
+
+  	/**
+  	 * Returns true if the cursor is above the current view.
+  	 */
+  	cursorAboveView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let originElement = body.querySelectorAll("td:not(.locked)")[0];
         let y = this.selectionFrame.cursor.y;
         return y < parseInt(originElement.dataset["y"]);
-    }
-    /**
-     * Returns true if the cursor is below the current view.
-     **/
-    cursorBelowView(){
+  	}
+
+  	/**
+  	 * Returns true if the cursor is below the current view.
+  	 */
+  	cursorBelowView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let bottomRow = body.lastChild;
         let cornerElement = bottomRow.lastChild;
         let y = this.selectionFrame.cursor.y;
         return y > parseInt(cornerElement.dataset["y"]);
-    }
-    /**
-     * Returns true if the cursor is left of the current view.
-     **/
-    cursorLeftOfView(){
+  	}
+
+  	/**
+  	 * Returns true if the cursor is left of the current view.
+  	 */
+  	cursorLeftOfView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let originElement = body.querySelectorAll("td:not(.locked)")[0];
         let x = this.selectionFrame.cursor.x;
         return x < parseInt(originElement.dataset["x"]);
     }
-    /**
-     * Returns true if the cursor is right of the current view.
-     **/
-    cursorRightOfView(){
+  	/**
+  	 * Returns true if the cursor is right of the current view.
+  	 */
+  	cursorRightOfView(){
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let bottomRow = body.lastChild;
         let cornerElement = bottomRow.lastChild;
         let x = this.selectionFrame.cursor.x;
         return x > parseInt(cornerElement.dataset["x"]);
-    }
+  	}
 }
+
 
 export {
     Point,

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1086,13 +1086,21 @@ class Selector {
                     element.classList.add('active-selection');
                 }
                 if(this.selectionFrame.isAtLeft(elementPoint)){
-                    element.classList.add('active-selection-left');
+                    // if we are at the absolute left of the sheet we don't add
+                    // border-left to match the border-top behavior below
+                    if (elementPoint.x > 0) {
+                        element.classList.add('active-selection-left');
+                    }
                 }
                 if(this.selectionFrame.isAtRight(elementPoint)){
                     element.classList.add('active-selection-right');
                 }
                 if(this.selectionFrame.isAtTop(elementPoint)){
-                    element.classList.add('active-selection-top');
+                    // if we are at the absolute top of the sheet we don't add
+                    // the border-top since it interfeces with the header
+                    if (elementPoint.y > 0) {
+                        element.classList.add('active-selection-top');
+                    }
                 }
                 if(this.selectionFrame.isAtBottom(elementPoint)){
                     element.classList.add('active-selection-bottom');
@@ -1591,17 +1599,17 @@ class Selector {
           }
     }
 
-  	/**
-  	 * I shift the entire view to the location of the cursor.
-  	 * If the cursor is above the current view I place it at the
-  	 * top row of the shifted view.
-  	 * If the cursor is below the current view I place it at the
-  	 * bottom row of the shifted view.
-  	 * If the cursor is to left of the current view I place it at the
-  	 * left-left most column of the shifted view.
-  	 * If the cursor is to the right of the current view I place it at the
-  	 * right-most column of the shifted view.
-  	 */
+    /**
+     * I shift the entire view to the location of the cursor.
+     * If the cursor is above the current view I place it at the
+     * top row of the shifted view.
+     * If the cursor is below the current view I place it at the
+     * bottom row of the shifted view.
+     * If the cursor is to left of the current view I place it at the
+     * left-left most column of the shifted view.
+     * If the cursor is to the right of the current view I place it at the
+     * right-most column of the shifted view.
+     **/
     shiftViewToCursor(){
         // we always shrink to cursor here
         this.shrinkToCursor();
@@ -1719,6 +1727,7 @@ class Selector {
     isAtDataRight(){
         return this.selectionFrame.corner.x === this.sheet.dataFrame.corner.x;
     }
+
     /**
      * Returns true if the cursor is in any of the locked areas.
      **/

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1553,9 +1553,8 @@ class Selector {
      * Defaults to false.
      */
     shiftLeft(amount = 1, shrinkToCursor = false){
-
         if (this.cursorInView() || this.cursorInLockedArea()){
-  			let shift = [amount * -1, 0];
+            let shift = [amount * -1, 0];
             if(this.isAtDataLeft()){
                 if(!this.isAtViewLeft(true)){
                     this.clearStyling(true);
@@ -1603,9 +1602,9 @@ class Selector {
   	 * If the cursor is to the right of the current view I place it at the
   	 * right-most column of the shifted view.
   	 */
-  	shiftViewToCursor(){
+    shiftViewToCursor(){
         // we always shrink to cursor here
-  		  this.shrinkToCursor();
+        this.shrinkToCursor();
         let body = document.getElementById(`sheet-${this.sheet.props.id}-body`);
         let bottomRow = body.lastChild;
         let cornerElement = bottomRow.lastChild;

--- a/object_database/web/content/components/util/SheetUtils.js
+++ b/object_database/web/content/components/util/SheetUtils.js
@@ -1170,8 +1170,14 @@ class Selector {
      * I expand the selection frame up by one
      */
     growUp(){
+        let amount = 1;
+        let diff = [0, -1 * amount];
         if(!this.isAtViewTop(true)){
-            let diff = [0, -1];
+            // if I am at the top of the view but there is data
+            // above I'll trigger a scroll up
+            if (this.isAtViewTop() && !this.isAtDataTop()){
+                this.triggerNeedsUpdate('up', amount);
+            }
             let toPoint = this.applyToOppositeCorner(diff);
             this.selectionFrame.fromPointToPoint(
                 this.selectionFrame.cursor,
@@ -1185,38 +1191,52 @@ class Selector {
      * I expand the selection frame right by one
      */
     growRight(){
-        if(!this.isAtViewRight()){
-            let diff = [1, 0];
-            let toPoint = this.applyToOppositeCorner(diff);
-            this.selectionFrame.fromPointToPoint(
-                this.selectionFrame.cursor,
-                toPoint,
-                false
-            );
+        let amount = 1;
+        let diff = [amount, 0];
+        if(this.isAtViewRight()){
+            if (!this.isAtDataRight()){
+                this.triggerNeedsUpdate('right', amount);
+            }
         }
+        let toPoint = this.applyToOppositeCorner(diff);
+        this.selectionFrame.fromPointToPoint(
+            this.selectionFrame.cursor,
+            toPoint,
+            false
+        );
     }
 
     /**
      * I expand the selection frame down by one
      */
     growDown(){
-        if(!this.isAtViewBottom()){
-            let diff = [0, 1];
-            let toPoint = this.applyToOppositeCorner(diff);
-            this.selectionFrame.fromPointToPoint(
-                this.selectionFrame.cursor,
-                toPoint,
-                false
-            );
+        let amount = 1;
+        let diff = [0, amount];
+        if(this.isAtViewBottom()){
+            if (!this.isAtDataBottom()){
+                this.triggerNeedsUpdate('down', amount);
+            }
         }
+        let toPoint = this.applyToOppositeCorner(diff);
+        this.selectionFrame.fromPointToPoint(
+            this.selectionFrame.cursor,
+            toPoint,
+            false
+        );
     }
 
     /**
      * I expand the selection frame left by one
      */
     growLeft(){
+        let amount = 1;
+        let diff = [-1 * amount, 0];
         if(!this.isAtViewLeft(true)){
-            let diff = [-1, 0];
+            // if I am at the left of the view but there is data
+            // left I'll trigger a scroll up
+            if (this.isAtViewLeft() && !this.isAtDataLeft()){
+                this.triggerNeedsUpdate('left', amount);
+            }
             let toPoint = this.applyToOppositeCorner(diff);
             this.selectionFrame.fromPointToPoint(
                 this.selectionFrame.cursor,


### PR DESCRIPTION

## Motivation and Context
This PR addresses a number of selector and Sheet level bugs and improvements. These include:

* a more dynamic header display text size for small number of column Sheets, to prevent resize flickering 
* pagination state bugs where a locked column or row can appear in the main view area (this can also double-up the selector, since it will highlight the 'original' column/row cells as well as the copies in the view)
* race condition on data updates when scrolling with the selector in the locked row and columns
* allowing sheet level scrolling to work with selector expansion, i.e. you can hit shift-arrow to expand the selector and it will trigger data updates to the view as necessary; it will also jump into the locked columns/rows (if available) when there is no more data left/right

## How Has This Been Tested?
In the UI/playground. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.