### PR TITLE
Modal Enhancements

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1244,6 +1244,17 @@ class Modal(Cell):
         )
         self.exportData["show"] = self.show.get()
 
+    def onMessage(self, messageFrame):
+        if messageFrame["event"] == "close":
+            self.show.set(False)
+        elif messageFrame["event"] == "accept":
+            # First, run the default action,
+            # which should be the one associated
+            # with the *first* button
+            if len(self.buttons) > 1:
+                self.buttons[0].onClick()
+            self.show.set(False)
+
 
 class Octicon(Cell):
     def __init__(self, which, color="black"):

--- a/object_database/web/cells_demo/modal_dialogs.py
+++ b/object_database/web/cells_demo/modal_dialogs.py
@@ -135,6 +135,7 @@ def test_modal_with_update_field(headless_browser):
     - modal is initially hidden
     - read the text on the card
     - click on the button to make the modal appear
+    - check that the SingleLineTextBox is in focus
     - check that the text in the SingleLineTextBox matches the text on the card
     - modify the text in the SingleLineTextBox
     - click on the modal button to hide the modal and update the card text
@@ -165,9 +166,12 @@ def test_modal_with_update_field(headless_browser):
         )
     )
 
-    # the text in the SingleLineTextBox matches the text on the card
+    # Check that the SLTB is in focus (it should be after showing)
     modal_text_query = modal_query + ' [data-cell-type="SingleLineTextBox"]'
     text_box = headless_browser.find_by_css(modal_text_query)
+    assert text_box == headless_browser.webdriver.switch_to.active_element
+
+    # the text in the SingleLineTextBox matches the text on the card
     assert text_box.get_attribute("value") == slot_text
 
     # modify the text in the SingleLineTextBox

--- a/object_database/web/content/NewCellHandler.js
+++ b/object_database/web/content/NewCellHandler.js
@@ -13,7 +13,7 @@ import {
 } from './components/util/NamedChildren';
 
 class NewCellHandler {
-    constructor(h, projector, components){
+    constructor(h, projector, components, socket=null){
         // A constructor for
         // hyperscript objects
         this.h = h;
@@ -21,6 +21,10 @@ class NewCellHandler {
         // A Maquette VDOM
         // projector instance
         this.projector = projector;
+
+        // If we passed in a socket
+        // (CellSocket), make it the prop
+        this.socket = socket;
 
         // A dictionary of available
         // Cell Components by name
@@ -44,6 +48,7 @@ class NewCellHandler {
         this.connectionClosedView = this.connectionClosedView.bind(this);
         this.appendPostscript = this.appendPostscript.bind(this);
         this.handlePostscript = this.handlePostscript.bind(this);
+        this.sendMessageFor = this.sendMessageFor.bind(this);
         this.receive = this.receive.bind(this);
         this.cellUpdated = this.cellUpdated.bind(this);
         this.cellDiscarded = this.cellDiscarded.bind(this);
@@ -244,6 +249,13 @@ class NewCellHandler {
         }
     }
 
+    sendMessageFor(message, cellId){
+        if(this.socket){
+            message['target_cell'] = cellId.toString();
+            this.socket.sendString(JSON.stringify(message));
+        }
+    }
+
     /** Private Methods **/
 
     /**
@@ -323,7 +335,7 @@ class NewCellHandler {
             id: message.id,
             extraData: message.extraData
         });
-        let newComponent = new componentClass(componentProps);
+        let newComponent = new componentClass(componentProps, this);
         this._updateNamedChildren(newComponent, message);
         this.activeComponents[newComponent.props.id] = newComponent;
         return newComponent;

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -14,9 +14,13 @@ const render = (aComponent) => {
 };
 
 class Component {
-    constructor(props = {}, replacements = []){
+    constructor(props = {}, handler = null){
         this.isComponent = true;
         this._updateProps(props);
+
+        // If we have passed in a handler
+        // use it
+        this.handler = handler;
 
         // Whether or not the the component
         // is a Subscribed. We do this
@@ -62,6 +66,7 @@ class Component {
         this.namedChildrenDo = this.namedChildrenDo.bind(this);
         this.renderChildNamed = this.renderChildNamed.bind(this);
         this.renderChildrenNamed = this.renderChildrenNamed.bind(this);
+        this.sendMessage = this.sendMessage.bind(this);
         this.getElementId = this.getElementId.bind(this);
         this.getInheritanceChain = this.getInheritanceChain.bind(this);
         this.getSubscribedChain = this.getSubscribedChain.bind(this);
@@ -70,10 +75,6 @@ class Component {
         this._updateProps = this._updateProps.bind(this);
         this._updateData = this._updateData.bind(this);
         this._recursivelyMapNamedChildren = this._recursivelyMapNamedChildren.bind(this);
-    }
-
-    get usesReplacements(){
-        throw Error('#usesReplacements is now deprecated!');
     }
 
     build(){
@@ -207,6 +208,21 @@ class Component {
      */
     getElementId(){
         return `${this.constructor.elementIdPrefix}${this.props.id}`;
+    }
+
+    /**
+     * Send a message over the socket registered
+     * with the current handler. There must be
+     * a handler associated with this component
+     * and the handler must be bound to a socket.
+     * See NewCellHandler >> #sendMessageFor for
+     * more details, since that is what gets
+     * called here.
+     */
+    sendMessage(message){
+        if(this.handler){
+            this.handler.sendMessageFor(message, this.props.id);
+        }
     }
 
     /**

--- a/object_database/web/content/components/Modal.js
+++ b/object_database/web/content/components/Modal.js
@@ -3,6 +3,7 @@
  */
 
 import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
 /**
@@ -22,6 +23,15 @@ class Modal extends Component {
         this.makeBody = this.makeBody.bind(this);
         this.makeFooter = this.makeFooter.bind(this);
         this.makeClasses = this.makeClasses.bind(this);
+        this.focusFirstInput = this.focusFirstInput.bind(this);
+    }
+
+    componentDidLoad(){
+        this.focusFirstInput();
+    }
+
+    componentDidUpdate(){
+        this.focusFirstInput();
     }
 
     build(){
@@ -31,7 +41,7 @@ class Modal extends Component {
                 'data-cell-id': this.props.id,
                 'data-cell-type': "Modal",
                 class: this.makeClasses(),
-                tabindex: "-1",
+                //tabindex: "-1",
                 role: "dialog"
             }, [
                 h('div', {class: "modal-dialog", role: "document"}, [
@@ -71,6 +81,27 @@ class Modal extends Component {
         }
         return null;
     }
+
+    focusFirstInput(){
+        // If there are any input fields present
+        // in the Modal, find the first one of them
+        // and give it the focus, as long as the
+        // modal is currently being shown.
+        if(this.props.show){
+            console.log("Setting focus to first available input field");
+            let firstInputField = this.getDOMElement().querySelector('input[type="text"]');
+            if(firstInputField){
+                firstInputField.select();
+            }
+        }
+    }
 }
+
+Modal.propTypes = {
+    show: {
+        type: PropTypes.boolean,
+        description: "Whether or not the Modal should be displayed"
+    }
+};
 
 export {Modal, Modal as default}

--- a/object_database/web/content/components/Modal.js
+++ b/object_database/web/content/components/Modal.js
@@ -18,20 +18,69 @@ class Modal extends Component {
     constructor(props, ...args){
         super(props, ...args);
 
+        // Track the component show/hide
+        // state outside of the props
+        // for callback purposes
+        this.isShowing = this.props.show || false;
+
         // Bind component methods
         this.makeHeader = this.makeHeader.bind(this);
         this.makeBody = this.makeBody.bind(this);
         this.makeFooter = this.makeFooter.bind(this);
         this.makeClasses = this.makeClasses.bind(this);
         this.focusFirstInput = this.focusFirstInput.bind(this);
+        this.beforeShow = this.beforeShow.bind(this);
+        this.beforeHide = this.beforeHide.bind(this);
+        this.onShow = this.onShow.bind(this);
+        this.onHide = this.onHide.bind(this);
+        this.onEnterKey = this.onEnterKey.bind(this);
+        this.onEscapeKey = this.onEscapeKey.bind(this);
     }
 
     componentDidLoad(){
         this.focusFirstInput();
+        if(!this.isShowing && this.props.show){
+            // Then we have "shown" the Modal now.
+            // Call onShow method
+            this.onShow();
+        }
+        this.isShowing = this.props.show;
     }
 
     componentDidUpdate(){
         this.focusFirstInput();
+        if(!this.isShowing && this.props.show){
+            // In this case, we have gone from
+            // hidden to showing, so call
+            // onShow
+            this.onShow();
+        }
+        if(this.isShowing && !this.props.show){
+            // In this case we have gone from
+            // showing to hiding, so call
+            // onHide
+            this.onHide();
+        }
+    }
+
+    componentWillReceiveProps(oldProps, newProps){
+        // If we are going from showing to not
+        // showing, trigger the beforeHide method
+        if(oldProps.show && !newProps.show){
+            this.beforeHide();
+        }
+
+        // If we are going from not showing to
+        // showing, trigger the beforeShow method
+        if(oldProps.show == false && newProps.show){
+            this.beforeShow();
+        }
+
+        return newProps;
+    }
+
+    componentWillUnload(){
+        this.onHide();
     }
 
     build(){
@@ -93,6 +142,44 @@ class Modal extends Component {
             if(firstInputField){
                 firstInputField.select();
             }
+        }
+    }
+
+    beforeHide(){
+        // Nothing for now
+    }
+
+    beforeShow(){
+        // Nothing for now
+    }
+
+    onShow(){
+        // Bind global event listeners for
+        // Enter and Escape keys
+        document.addEventListener('keydown', this.onEnterKey);
+        document.addEventListener('keydown', this.onEscapeKey);
+    }
+
+    onHide(){
+        document.removeEventListener('keydown', this.onEnterKey);
+        document.removeEventListener('keydown', this.onEscapeKey);
+    }
+
+    onEnterKey(event){
+        if(event.key == 'Enter'){
+            console.log("Enter pushed in modal");
+            this.sendMessage({event: 'accept'});
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    }
+
+    onEscapeKey(event){
+        if(event.key == 'Escape'){
+            console.log("Escape pushed in modal");
+            this.sendMessage({event: 'close'});
+            event.preventDefault();
+            event.stopPropagation();
         }
     }
 }

--- a/object_database/web/content/main.js
+++ b/object_database/web/content/main.js
@@ -39,7 +39,7 @@ const initialRender = function(){
  **/
 let projector = maquette.createProjector();
 const cellSocket = new CellSocket();
-const cellHandler = new CellHandler(h, projector, ComponentRegistry);
+const cellHandler = new CellHandler(h, projector, ComponentRegistry, cellSocket);
 window._cellHandler = cellHandler;
 cellSocket.onPostscripts(cellHandler.handlePostscript);
 cellSocket.onMessage(cellHandler.receive);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements the enhancements asked for in Issue #99

## Motivation and Context
<!-- Why is this change required? -->
The specific feature enhancements for Modals are:
* If a modal has input fields, make sure the first of them gets the selection/cursor focus when it first opens
* Escape should trigger an event that closes the modal
* Enter should trigger a default event, then close the modal

<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
Most of the complexity in this PR deals with the eventing structure (esape/enter key actions). We have made some important Component/Socket infrastructure changes to adapt for it, and these changes can now be used by other components.
  
### Focus and Selection ###
A Modal with any input fields will now have the first of such inputs gain the focus & selection when the modal opens (shows). This is actually a simple matter for which we were able to use the normal Component lifecycle methods.
    
### Messages from Components to Cells ###
Until this PR, both Component and NewCellHandler instances had no way of sending specific messages to the Cells backend when some UI event occurs. For Cell/Components like Button or Clickable, we've been using inline JS that is sent over the wire as exportData props when a Component first renders. *The most important part of this PR is that we now have socket connections bound to NewCellHandler, and every instantiated Component has a reference to the NewCellHandler in which it is present.* In other words, components can now send messages directly to their corresponding Cell instance without using inline JS.
  
#### How to Send: Example ####
The base `Component` class now has a method called `sendMessage()`, whch takes a serializable javascript object and sends it to the corresponding Cell on the backend. It does this by delegating the call to the bound NewCellHandler instance, which itself has a method called `sendMessageFor()` which takes a serializable javascript object, but also the id of the Component/Cell. That latter method adds the required `target_cell` property to the message before stringifying it and sending.
  
Please note that we can now start moving the inline JS that remains within the Cells codebase because of this change.
  
### Escape and Enter ###
From the frontend, pushing Escape on an open modal sends an event message to the Modal cell whose event is called `close`. On the Cells side, this sets the `show` slot to False.
  
For an Enter event, we had to make some assumptions. From the frontend the pattern is similar to the Escape key: the Component sends a message to the Cell with an event called `accept`. If there are buttons in the modal, this event triggers the callback of **the first listen button callback** (ie, order matters). Then it sets the `show` slot to False, effectively closing the modal.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
All JS and Cells tests are passing. We also added a CellsTestPage demo test for the case of focussing the input of a shown modal. 
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.