### PR TITLE
issue 95 - CodeEditor setting and getting first VisibleRow

### DIFF
--- a/object_database/service_manager/SubprocessServiceManager.py
+++ b/object_database/service_manager/SubprocessServiceManager.py
@@ -272,7 +272,7 @@ class SubprocessServiceManager(ServiceManager):
 
                     if not serviceInstance.exists():
                         if workerProcess:
-                            self._logger.warning(
+                            self._logger.info(
                                 f"Worker Process '{identity}' shutting down because the "
                                 f"server removed its serviceInstance entirely. "
                                 f"Sending KILL signal."

--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -63,6 +63,7 @@ from object_database.web.cells.cells import (
     CircleLoader,
     Timestamp,
     HorizontalSequence,
+    WSMessageTester,
 )
 
 from object_database.web.cells.views.split_view import SplitView

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3350,25 +3350,17 @@ class Highlighted(Cell):
         self.children["content"] = Cell.makeCell(self.content)
 
 
-class WSMessageTester(Clickable):
-    def __init__(self, *args, small=False, active=True, style="primary", **kwargs):
-        self.content = "send message"
-        Clickable.__init__(self, content=self.content, *args, **kwargs)
-        self.small = small
-        self.active = active
-        self.style = style
+class WSMessageTester(Cell):
+    def __init__(self, methodToRun, **kwargs):
+        super().__init__()
+        self.content = "Go!"
+        self.content = Cell.makeCell(self.content)
+        self.methodToRun = methodToRun
+        self.kwargs = kwargs
+
+    def onMessage(self, msgFrame):
+        if msgFrame["event"] == "click":
+            self.methodToRun(**self.kwargs)
 
     def recalculate(self):
         self.children["content"] = self.content
-
-        isActive = False
-        if self.active:
-            isActive = True
-
-        # temporary js WS refactoring data
-        self.exportData["small"] = self.small
-        self.exportData["active"] = isActive
-        self.exportData["style"] = self.style
-
-        # TODO: this event handling situation must be refactored
-        self.exportData["events"] = {"onclick": self.calculatedOnClick()}

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -2834,6 +2834,7 @@ class CodeEditor(Cell):
         autocomplete=True,
         onTextChange=None,
         textToDisplayFunction=lambda: "",
+        firstVisibleRow=1,
     ):
         """Create a code editor
 
@@ -2858,6 +2859,7 @@ class CodeEditor(Cell):
         self.noScroll = noScroll
         self.fontSize = fontSize
         self.minLines = minLines
+        self.firstVisibleRow = firstVisibleRow
         self.readOnly = readOnly
         self.autocomplete = autocomplete
         self.onTextChange = onTextChange
@@ -2886,6 +2888,26 @@ class CodeEditor(Cell):
                     self.currentIteration = msgFrame["iteration"]
 
                 self.selectionSlot.set(msgFrame["selection"])
+        elif msgFrame["event"] == "scrolling":
+            self.firstVisibleRow = msgFrame["firstVisibleRow"]
+
+    def setFirstVisibleRow(self, rowNum):
+        """ Send a message to set the first visible row of the editor to
+        rowNum.
+
+        Parameters
+        ----------
+        rowNum : int
+        """
+        dataInfo = {"firstVisibleRow": rowNum}
+        # stage this piece of data to be sent when we recalculate
+        if self.exportData.get("dataInfo") is None:
+            self.exportData["dataInfo"] = [dataInfo]
+        else:
+            self.exportData["dataInfo"].append(dataInfo)
+
+        self.wasDataUpdated = True
+        self.markDirty()
 
     def setCurrentTextFromServer(self, text):
         if text is None:
@@ -2969,6 +2991,7 @@ class CodeEditor(Cell):
             self.exportData["fontSize"] = self.fontSize
         if self.minLines is not None:
             self.exportData["minLines"] = self.minLines
+        self.exportData["firstVisibleRow"] = self.firstVisibleRow
 
         self.exportData["keybindings"] = [k for k in self.keybindings.keys()]
 

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -2835,6 +2835,7 @@ class CodeEditor(Cell):
         onTextChange=None,
         textToDisplayFunction=lambda: "",
         firstVisibleRow=1,
+        onFirstRowChange=None,
     ):
         """Create a code editor
 
@@ -2851,6 +2852,9 @@ class CodeEditor(Cell):
 
         textToDisplayFunction - a function of no arguments that should return
             the current text we _ought_ to be displaying.
+
+        onFirstRowChange - a function that is called when the first visible row
+        changes. It takes one argument which is said row.
         """
         super().__init__()
         # contains (current_iteration_number: int, text: str)
@@ -2860,6 +2864,7 @@ class CodeEditor(Cell):
         self.fontSize = fontSize
         self.minLines = minLines
         self.firstVisibleRow = firstVisibleRow
+        self.onFirstRowChange = onFirstRowChange
         self.readOnly = readOnly
         self.autocomplete = autocomplete
         self.onTextChange = onTextChange
@@ -2890,6 +2895,8 @@ class CodeEditor(Cell):
                 self.selectionSlot.set(msgFrame["selection"])
         elif msgFrame["event"] == "scrolling":
             self.firstVisibleRow = msgFrame["firstVisibleRow"]
+            if self.onFirstRowChange is not None:
+                self.onFirstRowChange(self.firstVisibleRow)
 
     def setFirstVisibleRow(self, rowNum):
         """ Send a message to set the first visible row of the editor to

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3371,7 +3371,17 @@ class WSMessageTester(Cell):
 
     def onMessage(self, msgFrame):
         if msgFrame["event"] == "click":
+            # Run the method...
             self.methodToRun(**self.kwargs)
+            # ... and let the client know what you ran
+            dataInfo = {
+                "event": "WSTest",
+                "method": str(self.methodToRun),
+                "args": self.kwargs,
+            }
+            self.exportData["dataInfo"] = [dataInfo]
+            self.wasDataUpdated = True
+            self.markDirty()
 
     def recalculate(self):
         self.children["content"] = self.content

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3351,7 +3351,18 @@ class Highlighted(Cell):
 
 
 class WSMessageTester(Cell):
+    """A helper cell to test cell methods interactively in the browser."""
+
     def __init__(self, methodToRun, **kwargs):
+        """
+        Parameters:
+        ----------
+            methodToRun: cell method
+                The method of an initialized cell to run when the
+                WSMessageTester button is clicked.
+            kwargs: cell method kwargs
+
+        """
         super().__init__()
         self.content = "Go!"
         self.content = Cell.makeCell(self.content)

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3348,3 +3348,27 @@ class Highlighted(Cell):
 
     def recalculate(self):
         self.children["content"] = Cell.makeCell(self.content)
+
+
+class WSMessageTester(Clickable):
+    def __init__(self, *args, small=False, active=True, style="primary", **kwargs):
+        self.content = "send message"
+        Clickable.__init__(self, content=self.content, *args, **kwargs)
+        self.small = small
+        self.active = active
+        self.style = style
+
+    def recalculate(self):
+        self.children["content"] = self.content
+
+        isActive = False
+        if self.active:
+            isActive = True
+
+        # temporary js WS refactoring data
+        self.exportData["small"] = self.small
+        self.exportData["active"] = isActive
+        self.exportData["style"] = self.style
+
+        # TODO: this event handling situation must be refactored
+        self.exportData["events"] = {"onclick": self.calculatedOnClick()}

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -194,7 +194,7 @@ class CodeEditorBasicHorizSequence(CellsTestPage):
         )
 
 
-class CodeEditoriSetFirstVisibleRow(CellsTestPage):
+class CodeEditorSetFirstVisibleRow(CellsTestPage):
     def cell(self):
         contents = cells.Slot("No Text Entered Yet!")
         text = """def cell(self):
@@ -216,11 +216,21 @@ class CodeEditoriSetFirstVisibleRow(CellsTestPage):
             contents.set(content)
 
         return cells.CodeEditor(
-            onTextChange=onTextChange, textToDisplayFunction=lambda: text, firstVisibleRow=30
+            onTextChange=onTextChange, textToDisplayFunction=lambda: text, firstVisibleRow=5
         )
 
     def text(self):
-        return "Should see a CodeEditor and its content with the first row set to " "30"
+        return "Should see a CodeEditor and its content with the first row set to " "5"
+
+
+def test_set_first_row(headless_browser):
+    # Test that we can find the editor and
+    # add text to it.
+    demo_root = headless_browser.get_demo_root_for(CodeEditorSetFirstVisibleRow)
+    assert demo_root
+    first_line = headless_browser.find_by_css(".ace_gutter-active-line")
+    assert first_line
+    assert first_line.text == "5"
 
 
 class CodeEditorInSplitView(CellsTestPage):

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -234,32 +234,6 @@ class CodeEditorFirstVisibleRowChange(CellsTestPage):
         return "You should see a code editor and a mirror of its contents."
 
 
-def test_set_first_row_change(headless_browser):
-    # Test that we can find the editor and
-    # add text to it.
-    demo_root = headless_browser.get_demo_root_for(CodeEditorFirstVisibleRowChange)
-    assert demo_root
-    code_editor = headless_browser.find_by_css(
-        '{} [data-cell-type="CodeEditor"]'.format(headless_browser.demo_root_selector)
-    )
-    assert code_editor
-    text_display = headless_browser.find_by_css(
-        '{} [data-cell-type="Text"]'.format(headless_browser.demo_root_selector)
-    )
-    assert text_display
-    # check that we are display line '1' at the start
-    assert text_display.text.split(" ")[-1] == "1"
-    # scroll the editor
-    code_editor_id = code_editor.get_property("id")
-    # TODO: get the scrolling right
-    headless_browser.webdriver.execute_script(
-        "document.getElementById('%s').scrollTop += 100" % code_editor_id
-    )
-    text_display = headless_browser.find_by_css(
-        '{} [data-cell-type="Text"]'.format(headless_browser.demo_root_selector)
-    )
-
-
 class CodeEditorSetFirstVisibleRow(CellsTestPage):
     def cell(self):
         contents = cells.Slot("No Text Entered Yet!")

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -318,9 +318,10 @@ class ServerSideSetFirstVisibleRow(CellsTestPage):
             contents.set(content)
 
         return cells.CodeEditor(
-                textToDisplayFunction=textToDisplayFunction,
-                onTextChange=onTextChange, firstVisibleRow=5
-                )
+            textToDisplayFunction=textToDisplayFunction,
+            onTextChange=onTextChange,
+            firstVisibleRow=5
+        )
         """
         text *= 5
 
@@ -349,7 +350,13 @@ def test_set_first_row_serverside(headless_browser):
     assert first_line.text == "1"
     toggle_btn = headless_browser.find_by_css('[data-cell-type="WSTesterButton"]')
     toggle_btn.click()
-    headless_browser.wait(5)
-    first_line = headless_browser.find_by_css(".ace_gutter-active-line")
-    assert first_line
-    assert first_line.text == "10"
+
+    def textIsTen(*args):
+        first_line = headless_browser.find_by_css(".ace_gutter-active-line")
+        if not first_line:
+            return False
+
+        return first_line.text == "10"
+
+    headless_browser.wait(10).until(textIsTen)
+    assert textIsTen()

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -336,4 +336,20 @@ class ServerSideSetFirstVisibleRow(CellsTestPage):
         )
 
     def text(self):
-        return "Clicking 'Go!' you should see the code editor scroll down."
+        return "By clicking 'Go!' you should see the code editor scroll down."
+
+
+def test_set_first_row_serverside(headless_browser):
+    # Test that we can find the editor and set the first visible row
+    # programmatically from the server side
+    demo_root = headless_browser.get_demo_root_for(ServerSideSetFirstVisibleRow)
+    assert demo_root
+    first_line = headless_browser.find_by_css(".ace_gutter-active-line")
+    assert first_line
+    assert first_line.text == "1"
+    toggle_btn = headless_browser.find_by_css('[data-cell-type="WSTesterButton"]')
+    toggle_btn.click()
+    headless_browser.wait(5)
+    first_line = headless_browser.find_by_css(".ace_gutter-active-line")
+    assert first_line
+    assert first_line.text == "10"

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -194,6 +194,72 @@ class CodeEditorBasicHorizSequence(CellsTestPage):
         )
 
 
+class CodeEditorFirstVisibleRowChange(CellsTestPage):
+    def cell(self):
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
+
+        contents = cells.Slot("")
+
+        firstRow = cells.Slot("1")
+
+        def onTextChange(buffer, selection):
+            contents.set(buffer)
+
+        def onFirstRowChange(row):
+            firstRow.set(str(row))
+
+        return cells.ResizablePanel(
+            cells.CodeEditor(
+                textToDisplayFunction=lambda: text,
+                onTextChange=onTextChange,
+                onFirstRowChange=onFirstRowChange,
+            ),
+            cells.Subscribed(lambda: cells.Text("First visible row is " + firstRow.get())),
+        )
+
+    def text(self):
+        return "You should see a code editor and a mirror of its contents."
+
+
+def test_set_first_row_change(headless_browser):
+    # Test that we can find the editor and
+    # add text to it.
+    demo_root = headless_browser.get_demo_root_for(CodeEditorFirstVisibleRowChange)
+    assert demo_root
+    code_editor = headless_browser.find_by_css(
+        '{} [data-cell-type="CodeEditor"]'.format(headless_browser.demo_root_selector)
+    )
+    assert code_editor
+    text_display = headless_browser.find_by_css(
+        '{} [data-cell-type="Text"]'.format(headless_browser.demo_root_selector)
+    )
+    assert text_display
+    # check that we are display line '1' at the start
+    assert text_display.text.split(" ")[-1] == "1"
+    # scroll the editor
+    code_editor_id = code_editor.get_property("id")
+    # TODO: get the scrolling right
+    headless_browser.webdriver.execute_script(
+        "document.getElementById('%s').scrollTop += 100" % code_editor_id
+    )
+    text_display = headless_browser.find_by_css(
+        '{} [data-cell-type="Text"]'.format(headless_browser.demo_root_selector)
+    )
+
+
 class CodeEditorSetFirstVisibleRow(CellsTestPage):
     def cell(self):
         contents = cells.Slot("No Text Entered Yet!")

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -216,11 +216,11 @@ class CodeEditoriSetFirstVisibleRow(CellsTestPage):
             contents.set(content)
 
         return cells.CodeEditor(
-            onTextChange=onTextChange, textToDisplayFunction=lambda: text, firstVisibleRow=5
+            onTextChange=onTextChange, textToDisplayFunction=lambda: text, firstVisibleRow=30
         )
 
     def text(self):
-        return "Should see a CodeEditor and its content with the first row set to " "5"
+        return "Should see a CodeEditor and its content with the first row set to " "30"
 
 
 class CodeEditorInSplitView(CellsTestPage):

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -194,6 +194,35 @@ class CodeEditorBasicHorizSequence(CellsTestPage):
         )
 
 
+class CodeEditoriSetFirstVisibleRow(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+            onTextChange=onTextChange, textToDisplayFunction=lambda: text, firstVisibleRow=5
+        )
+
+    def text(self):
+        return "Should see a CodeEditor and its content with the first row set to " "5"
+
+
 class CodeEditorInSplitView(CellsTestPage):
     def cell(self):
         contents = cells.Slot("")

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -304,3 +304,36 @@ class CodeEditorInSplitViewWithHeader(CellsTestPage):
 
     def text(self):
         return "You should see a code editor and a mirror of its contents."
+
+
+class ServerSideSetFirstVisibleRow(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("")
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
+
+        def onTextChange(buffer, selection):
+            contents.set(buffer)
+
+        codeEditor = cells.CodeEditor(
+            onTextChange=onTextChange, textToDisplayFunction=lambda: text
+        )
+
+        return cells.ResizablePanel(
+            cells.WSMessageTester(codeEditor.setFirstVisibleRow, rowNum=10), codeEditor
+        )
+
+    def text(self):
+        return "Clicking 'Go!' you should see the code editor scroll down."

--- a/object_database/web/cells_demo/conftest.py
+++ b/object_database/web/cells_demo/conftest.py
@@ -54,10 +54,10 @@ TEST_SERVICE = """
 def bootup_server():
     token = genToken()
     port = 8020
-    loglevel_name = "INFO"
+    loglevel_name = "WARNING"
     with tempfile.TemporaryDirectory() as tmpDirName:
         server = startServiceManagerProcess(
-            tmpDirName, port, token, loglevelName=loglevel_name, logDir=False, verbose=False
+            tmpDirName, port, token, loglevelName=loglevel_name, logDir=False, verbose=True
         )
         database = connect("localhost", port, token, retry=True)
         database.subscribeToSchema(core_schema, service_schema, active_webservice_schema)
@@ -157,7 +157,10 @@ def bootup_webdriver():
     # driver = webdriver.Chrome(executable_path=chrome_path, chrome_options=options)
 
     # start upu the driver
-    driver = webdriver.Chrome(options=options)
+    driver = webdriver.Chrome(
+        options=options, desired_capabilities={"goog:loggingPrefs": {"browser": "ALL"}}
+    )
+
     return driver
 
 
@@ -185,6 +188,10 @@ class HeadlessTester:
     @property
     def by(self):
         return By
+
+    def dumpLogs(self):
+        for msg in self.webdriver.get_log("browser"):
+            print("SELENIUM LOG > ", msg)
 
     @property
     def demo_root_selector(self):
@@ -233,6 +240,7 @@ def headless_browser():
     # service and the web service
     tester = HeadlessTester()
     yield tester
+
     tester.webdriver.close()
     tester.server.terminate()
     tester.server.wait()

--- a/object_database/web/cells_demo/wsmessage_tester.py
+++ b/object_database/web/cells_demo/wsmessage_tester.py
@@ -16,7 +16,9 @@ from object_database.web import cells as cells
 from object_database.web.CellsTestPage import CellsTestPage
 
 
-class WSMessageTesterExample(CellsTestPage):
+class WSMessageTesterExampleCodeEditor(CellsTestPage):
+    """An example of updating CodeEditor text from the server."""
+
     def cell(self):
         contents = cells.Slot("")
         text = """def cell(self):
@@ -32,7 +34,8 @@ class WSMessageTesterExample(CellsTestPage):
                 onTextChange=onTextChange, firstVisibleRow=5
                 )
         """
-        text *= 5
+
+        newText = "You just updated me from the server."
 
         def onTextChange(buffer, selection):
             contents.set(buffer)
@@ -42,8 +45,9 @@ class WSMessageTesterExample(CellsTestPage):
         )
 
         return cells.ResizablePanel(
-            cells.WSMessageTester(codeEditor.setFirstVisibleRow, rowNum=10), codeEditor
+            cells.WSMessageTester(codeEditor.setCurrentTextFromServer, text=newText),
+            codeEditor,
         )
 
     def text(self):
-        return "You should see some buttons in various styles."
+        return ""

--- a/object_database/web/cells_demo/wsmessage_tester.py
+++ b/object_database/web/cells_demo/wsmessage_tester.py
@@ -1,0 +1,32 @@
+#   Copyright 2017-2019 object_database Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells as cells
+from object_database.web.CellsTestPage import CellsTestPage
+
+
+class WSMessageTesterExample(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("")
+
+        def onTextChange(buffer, selection):
+            contents.set(buffer)
+
+        return cells.ResizablePanel(
+            cells.WSMessageTester(onClick=lambda: None),
+            cells.CodeEditor(onTextChange=onTextChange),
+        )
+
+    def text(self):
+        return "You should see some buttons in various styles."

--- a/object_database/web/cells_demo/wsmessage_tester.py
+++ b/object_database/web/cells_demo/wsmessage_tester.py
@@ -19,13 +19,30 @@ from object_database.web.CellsTestPage import CellsTestPage
 class WSMessageTesterExample(CellsTestPage):
     def cell(self):
         contents = cells.Slot("")
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
 
         def onTextChange(buffer, selection):
             contents.set(buffer)
 
+        codeEditor = cells.CodeEditor(
+            onTextChange=onTextChange, textToDisplayFunction=lambda: text
+        )
+
         return cells.ResizablePanel(
-            cells.WSMessageTester(onClick=lambda: None),
-            cells.CodeEditor(onTextChange=onTextChange),
+            cells.WSMessageTester(codeEditor.setFirstVisibleRow, rowNum=10), codeEditor
         )
 
     def text(self):

--- a/object_database/web/content/ComponentRegistry.js
+++ b/object_database/web/content/ComponentRegistry.js
@@ -53,6 +53,7 @@ import {Timestamp} from './components/Timestamp';
 import {SplitView} from './components/SplitView';
 import {PageView} from './components/PageView';
 import {HorizontalSequence} from './components/HorizontalSequence';
+import {WSMessageTester} from './components/WSMessageTester';
 
 const ComponentRegistry = {
     AsyncDropdown,
@@ -103,7 +104,8 @@ const ComponentRegistry = {
     Plot,
     _PlotUpdater,
     Timestamp,
-    SplitView
+    SplitView,
+    WSMessageTester
 };
 
 export {ComponentRegistry, ComponentRegistry as default};

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -43,7 +43,7 @@ class CodeEditor extends Component {
             this.editor.last_edit_millis = Date.now();
             this.editor.setTheme("ace/theme/textmate");
             this.editor.session.setMode("ace/mode/python");
-            this.editor.setAutoScrollEditorIntoView(true);
+            // this.editor.setAutoScrollEditorIntoView(true);
             this.editor.session.setUseSoftTabs(true);
 
 
@@ -80,6 +80,14 @@ class CodeEditor extends Component {
                 this.editor.setOption("minLines", this.props.minLines);
             } else {
                 this.editor.setOption("minLines", Infinity);
+            }
+
+            if (this.props.firstVisibleRow !== undefined){
+                this.editor.resize(true);
+                this.editor.scrollToRow(this.props.firstVisibleRow)
+                this.editor.scrollToLine(this.props.firstVisibleRow, true, true, function () {});
+                this.editor.gotoLine(this.props.firstVisibleRow, 0, true);
+                // this.editor.clearSelection();
             }
 
             this.setupKeybindings();
@@ -212,7 +220,6 @@ class CodeEditor extends Component {
     }
 
     onScroll(event){
-        console.log(this.editor.getFirstVisibleRow());
         let responseData = {
             event: 'scrolling',
             'target_cell': this.props.id,
@@ -309,6 +316,11 @@ CodeEditor.propTypes = {
     fontSize: {
         description: "Set the font size for the Ace Editor",
         type: PropTypes.oneOf([PropTypes.number, PropTypes.string])
+    },
+
+    firstVisibleRow: {
+        description: "Set the first visible row of the Editor",
+        type: PropTypes.number
     },
 
     minLines: {

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -155,6 +155,19 @@ class CodeEditor extends Component {
 
     }
 
+    /* I handle data updating for the CodeEditor.
+     */
+    _updateData(dataInfos, projector) {
+        dataInfos.map((dataInfo) => {
+            if (dataInfo.firstVisibleRow){
+                let row = parseInt(dataInfo.firstVisibleRow);
+                this.editor.resize(true);
+                this.editor.scrollToRow(row - 1)
+                this.editor.gotoLine(row, 0, true);
+            }
+        })
+    }
+
     setTextFromServer(iteration, newBufferText) {
         this.editor.last_edit_millis = Date.now();
         this.editor.current_iteration = iteration;

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -84,10 +84,8 @@ class CodeEditor extends Component {
 
             if (this.props.firstVisibleRow !== undefined){
                 this.editor.resize(true);
-                this.editor.scrollToRow(this.props.firstVisibleRow)
-                this.editor.scrollToLine(this.props.firstVisibleRow, true, true, function () {});
+                this.editor.scrollToRow(this.props.firstVisibleRow - 1)
                 this.editor.gotoLine(this.props.firstVisibleRow, 0, true);
-                // this.editor.clearSelection();
             }
 
             this.setupKeybindings();

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -29,6 +29,7 @@ class CodeEditor extends Component {
         // any global KeyListener instance
         this._onBlur = this._onBlur.bind(this);
         this._onFocus = this._onFocus.bind(this);
+        this.onScroll = this.onScroll.bind(this);
         this.disableEventFiring = false;
     }
 
@@ -123,7 +124,10 @@ class CodeEditor extends Component {
                 "data-cell-type": "CodeEditor",
                 key: this
             },
-                 [h('div', { id: "editor" + this.props.id, class: "code-editor-inner" }, [])
+                 [h('div', {
+                     id: "editor" + this.props.id,
+                     class: "code-editor-inner"
+                 }, [])
         ]);
         }
     }
@@ -142,6 +146,7 @@ class CodeEditor extends Component {
         // force a focus. it would be better to pick a better way to trigger
         // this from the serverside after an action
         this.editor.focus();
+
     }
 
     setTextFromServer(iteration, newBufferText) {
@@ -206,6 +211,18 @@ class CodeEditor extends Component {
         }, this.SERVER_UPDATE_DELAY_MS + 2); //note the 2ms grace period
     }
 
+    onScroll(event){
+        console.log(this.editor.getFirstVisibleRow());
+        let responseData = {
+            event: 'scrolling',
+            'target_cell': this.props.id,
+            'firstVisibleRow': this.editor.getFirstVisibleRow() + 1,
+            'lastVisibleRow': this.editor.getLastVisibleRow() + 1
+        };
+
+        cellSocket.sendString(JSON.stringify(responseData));
+    }
+
     installChangeHandlers() {
         //this.editor.on('focus', this._onFocus);
         //this.editor.on('blur', this._onBlur);
@@ -214,6 +231,7 @@ class CodeEditor extends Component {
         this.editor.selection.on("changeCursor", this.onChange)
         this.editor.selection.on("changeSelection", this.onChange)
         this.editor.session.on("change", this.onChange);
+        this.editor.session.on("changeScrollTop", this.onScroll);
     }
 
     setupKeybindings() {

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -55,10 +55,6 @@ class CodeEditor extends Component {
                 this.editor.current_iteration = this.props.currentIteration;
             }
 
-            if (this.props.initialSelection !== null) {
-                this.editor.selection.setSelectionRange(this.props.initialSelection);
-            }
-
             if (this.props.autocomplete) {
                 this.editor.setOptions({enableBasicAutocompletion: true});
                 this.editor.setOptions({enableLiveAutocompletion: true});
@@ -86,6 +82,13 @@ class CodeEditor extends Component {
                 this.editor.resize(true);
                 this.editor.scrollToRow(this.props.firstVisibleRow - 1)
                 this.editor.gotoLine(this.props.firstVisibleRow, 0, true);
+            }
+
+            if (this.props.initialSelection !== null) {
+                this.editor.selection.setSelectionRange(this.props.initialSelection);
+                if (this.props.firstVisibleRow !== undefined){
+                    this.editor.scrollToRow(this.props.firstVisibleRow - 1)
+                }
             }
 
             this.setupKeybindings();
@@ -160,6 +163,7 @@ class CodeEditor extends Component {
     _updateData(dataInfos, projector) {
         dataInfos.map((dataInfo) => {
             if (dataInfo.firstVisibleRow){
+                console.log("CodeEditor updating first visible row to " + dataInfo.firstVisibleRow)
                 let row = parseInt(dataInfo.firstVisibleRow);
                 this.editor.resize(true);
                 this.editor.scrollToRow(row - 1)

--- a/object_database/web/content/components/WSMessageTester.js
+++ b/object_database/web/content/components/WSMessageTester.js
@@ -1,0 +1,90 @@
+/**
+ * Button Cell Component
+ */
+
+import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
+import {h} from 'maquette';
+
+/**
+ * About Named Children
+ * ---------------------
+ * `content` (single) - The cell inside of the button (if any)
+ */
+class WSMessageTester extends Component {
+    constructor(props, ...args){
+        super(props, ...args);
+
+        // Bind context to methods
+        this.makeContent = this.makeContent.bind(this);
+        this._getEvents = this._getEvent.bind(this);
+        this._getHTMLClasses = this._getHTMLClasses.bind(this);
+    }
+
+    build(){
+        return(
+            h('button', {
+                id: this.getElementId(),
+                "data-cell-id": this.props.id,
+                "data-cell-type": "Button",
+                class: this._getHTMLClasses(),
+                onclick: this._getEvent('onclick')
+            }, [this.makeContent()]
+             )
+        );
+    }
+
+    makeContent(){
+        return this.renderChildNamed('content');
+    }
+
+    _getEvent(eventName) {
+        return this.props.events[eventName];
+    }
+
+    _getHTMLClasses(){
+        let classes = ['btn'];
+        if(!this.props.active){
+            classes.push(`btn-outline-${this.props.style}`);
+        }
+        if(this.props.style){
+            classes.push(`btn-${this.props.style}`);
+        }
+        if(this.props.small){
+            classes.push('btn-xs');
+        }
+        return classes.join(" ").trim();
+    }
+}
+
+WSMessageTester.propTypes = {
+    active: {
+        description: "Indicates whether or not the Button is active/deactivated",
+        type: PropTypes.boolean
+    },
+    small: {
+        description: "Sets the Button to display as a small button. Defaults to false.",
+        type: PropTypes.boolean
+    },
+    style: {
+        description: "A Bootstrap name for the button style.",
+        type: PropTypes.oneOf([
+            'primary',
+            'secondary',
+            'success',
+            'danger',
+            'warning',
+            'info',
+            'light',
+            'dark',
+            'link'
+        ])
+    },
+
+    events: {
+        description: "A dictionary of event names to arbitrary JS code that should fire on that event",
+        type: PropTypes.object
+    }
+};
+
+export {WSMessageTester, WSMessageTester as default};

--- a/object_database/web/content/components/WSMessageTester.js
+++ b/object_database/web/content/components/WSMessageTester.js
@@ -15,6 +15,8 @@ class WSMessageTester extends Component {
     constructor(props, ...args){
         super(props, ...args);
 
+        this.initialText = "Click the button to run the method."
+
         // Bind context to methods
         this.makeContent = this.makeContent.bind(this);
         this.handleClick = this.handleClick.bind(this);
@@ -22,14 +24,23 @@ class WSMessageTester extends Component {
 
     build(){
         return(
-            h('button', {
+            h("div", {
                 id: this.getElementId(),
                 "data-cell-id": this.props.id,
-                "data-cell-type": "Button",
-                class: "btn btn-primary",
-                onclick: this.handleClick
-            }, [this.makeContent()]
-             )
+                "data-cell-type": "WSTestter",
+            }, [
+                h('button', {
+                    "data-cell-id": this.props.id + "-button",
+                    "data-cell-type": "WSTesterButton",
+                    class: "btn btn-primary",
+                    onclick: this.handleClick
+                }, [this.makeContent()]
+                ),
+                h("div", {
+                    "data-cell-id": this.props.id + "-display",
+                    "data-cell-type": "WSTesterDisplay",
+                }, [this.initialText])
+            ])
         );
     }
 
@@ -44,6 +55,20 @@ class WSMessageTester extends Component {
         };
 
         cellSocket.sendString(JSON.stringify(responseData));
+    }
+
+    /* I handle incoming WS message data updating.
+     */
+    _updateData(dataInfos, projector) {
+        dataInfos.map((dataInfo) => {
+            if (dataInfo.event === "WSTest"){
+                let method = dataInfo["method"];
+                let args = dataInfo["args"];
+                let newText = "I just ran " + method + " with " + JSON.stringify(args);
+                let display = this.getDOMElement().querySelector("[data-cell-type='WSTesterDisplay']")
+                display.textContent = newText;
+            }
+        })
     }
 }
 

--- a/object_database/web/content/components/WSMessageTester.js
+++ b/object_database/web/content/components/WSMessageTester.js
@@ -17,8 +17,7 @@ class WSMessageTester extends Component {
 
         // Bind context to methods
         this.makeContent = this.makeContent.bind(this);
-        this._getEvents = this._getEvent.bind(this);
-        this._getHTMLClasses = this._getHTMLClasses.bind(this);
+        this.handleClick = this.handleClick.bind(this);
     }
 
     build(){
@@ -27,8 +26,8 @@ class WSMessageTester extends Component {
                 id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Button",
-                class: this._getHTMLClasses(),
-                onclick: this._getEvent('onclick')
+                class: "btn btn-primary",
+                onclick: this.handleClick
             }, [this.makeContent()]
              )
         );
@@ -38,53 +37,17 @@ class WSMessageTester extends Component {
         return this.renderChildNamed('content');
     }
 
-    _getEvent(eventName) {
-        return this.props.events[eventName];
-    }
+    handleClick(){
+        let responseData = {
+            event: 'click',
+            'target_cell': this.props.id,
+        };
 
-    _getHTMLClasses(){
-        let classes = ['btn'];
-        if(!this.props.active){
-            classes.push(`btn-outline-${this.props.style}`);
-        }
-        if(this.props.style){
-            classes.push(`btn-${this.props.style}`);
-        }
-        if(this.props.small){
-            classes.push('btn-xs');
-        }
-        return classes.join(" ").trim();
+        cellSocket.sendString(JSON.stringify(responseData));
     }
 }
 
 WSMessageTester.propTypes = {
-    active: {
-        description: "Indicates whether or not the Button is active/deactivated",
-        type: PropTypes.boolean
-    },
-    small: {
-        description: "Sets the Button to display as a small button. Defaults to false.",
-        type: PropTypes.boolean
-    },
-    style: {
-        description: "A Bootstrap name for the button style.",
-        type: PropTypes.oneOf([
-            'primary',
-            'secondary',
-            'success',
-            'danger',
-            'warning',
-            'info',
-            'light',
-            'dark',
-            'link'
-        ])
-    },
-
-    events: {
-        description: "A dictionary of event names to arbitrary JS code that should fire on that event",
-        type: PropTypes.object
-    }
 };
 
 export {WSMessageTester, WSMessageTester as default};


### PR DESCRIPTION
## Motivation and Context
This PR allows programmatic setting of the first visible editor row either at instantiation or after, as well as WS messaging to the server to indicate user actions which change the first visible row. 

## Approach
The CodeEditor component uses the Ace-native `scrollToRow` and `goToLine` to set the first line from props (see implementation [here](https://github.com/APrioriInvestments/object_database/blob/daniel-issue-95/object_database/web/content/components/CodeEditor.js#L85)), which is passed to the client at instantiation of the CodeEditor cell. Furthermore the `onScrollTop` Ace editor events triggers a callback which send the first and last visible rows over the web-socket (see [here](https://github.com/APrioriInvestments/object_database/blob/daniel-issue-95/object_database/web/content/components/CodeEditor.js#L233)). 

There is also an option to set the first visible row programmatically via a CodeEditor [method](https://github.com/APrioriInvestments/object_database/blob/daniel-issue-95/object_database/web/cells/cells.py#L2878) which uses the data update message type. 

## How Has This Been Tested?
Playground example and web tests have been added. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.