### PR TITLE
Daniel issue 96

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -2838,10 +2838,15 @@ class CodeEditor(Cell):
         textToDisplayFunction=lambda: "",
         mouseoverTimeout=1000,
         onMouseover=None,
+        highlightRange=None,
     ):
         """Create a code editor
 
-        keybindings - map from keycode to a lambda function that will receive
+        Parameters
+        ----------
+
+        keybindings: map
+            map from keycode to a lambda function that will receive
             the current buffer and the current selection range when the user
             types ctrl-X and 'X' is a valid keycode. Common values here are also
             'Enter' and 'space'
@@ -2849,21 +2854,28 @@ class CodeEditor(Cell):
         You may call 'setContents' to override the current contents of the editor.
         This version is not robust to mutiple users editing at the same time.
 
-        onTextChange - called when the text buffer changes with the new buffer
+        onTextChange: func
+            called when the text buffer changes with the new buffer
             and a json selection.
 
-        textToDisplayFunction - a function of no arguments that should return
+        textToDisplayFunction: func
+            a function of no arguments that should return
             the current text we _ought_ to be displaying.
 
         onFirstRowChange - a function that is called when the first visible row
-        changes. It takes one argument which is said row.
+            changes. It takes one argument which is said row.
 
         mouseoverTimeout - timeout for mouseover callback WS message in
-        milliseconds
+            milliseconds
 
         onMouseover = a function which is called subsequent to the mouseover
-        event fires on the client side and corresponding WS message is
-        received.The entire message is passed to the function.
+            event fires on the client side and corresponding WS message is
+            received.The entire message is passed to the function.
+
+        highlightRange : dict or None
+            dict should contain 'startRow' and 'endRow' int values setting the
+            highlight range. Additional you can add a "color" key with values
+            of "red" "blue" or "green" to change the highlight background-color.
         """
         super().__init__()
         # contains (current_iteration_number: int, text: str)
@@ -2872,6 +2884,7 @@ class CodeEditor(Cell):
         self.noScroll = noScroll
         self.fontSize = fontSize
         self.minLines = minLines
+        self.highlightRange = highlightRange
         self.readOnly = readOnly
         self.autocomplete = autocomplete
         self.onTextChange = onTextChange
@@ -2928,6 +2941,37 @@ class CodeEditor(Cell):
         self.firstVisibleRowSlot.set(rowNum)
 
         dataInfo = {"firstVisibleRow": rowNum}
+        # stage this piece of data to be sent when we recalculate
+        if self.exportData.get("dataInfo") is None:
+            self.exportData["dataInfo"] = [dataInfo]
+        else:
+            self.exportData["dataInfo"].append(dataInfo)
+
+        self.wasDataUpdated = True
+        self.markDirty()
+
+    def addRowHighlight(self, startRow, endRow):
+        """ Send a message to highlight row range.
+
+        Parameters
+        ----------
+        startRow : int
+        endRow : int
+        """
+        dataInfo = {"startRow": startRow, "endRow": endRow, "highlight": True}
+        # stage this piece of data to be sent when we recalculate
+        if self.exportData.get("dataInfo") is None:
+            self.exportData["dataInfo"] = [dataInfo]
+        else:
+            self.exportData["dataInfo"].append(dataInfo)
+
+        self.wasDataUpdated = True
+        self.markDirty()
+
+    def removeRowHighlight(self):
+        """ Send a message to remove all row highlighting.
+        """
+        dataInfo = {"highlight": False}
         # stage this piece of data to be sent when we recalculate
         if self.exportData.get("dataInfo") is None:
             self.exportData["dataInfo"] = [dataInfo]
@@ -3027,10 +3071,15 @@ class CodeEditor(Cell):
             self.exportData["fontSize"] = self.fontSize
         if self.minLines is not None:
             self.exportData["minLines"] = self.minLines
+
         self.exportData[
             "firstVisibleRow"
         ] = self.firstVisibleRowSlot.getWithoutRegisteringDependency()
+
         self.exportData["mouseoverTimeout"] = self.mouseoverTimeout
+
+        if self.highlightRange is not None:
+            self.exportData["highlightRange"] = self.highlightRange
 
         self.exportData["keybindings"] = [k for k in self.keybindings.keys()]
 

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -328,6 +328,92 @@ def test_set_first_row(headless_browser):
     assert first_line.text == "5"
 
 
+class CodeEditorHighlightRows(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        highlightRange = {"startRow": 5, "endRow": 10}
+
+        return cells.CodeEditor(
+            onTextChange=onTextChange,
+            textToDisplayFunction=lambda: text,
+            highlightRange=highlightRange,
+        )
+
+    def text(self):
+        return "Should see a CodeEditor and its content with rows 5-10 " "highlighted"
+
+
+def test_adding_highlight(headless_browser):
+    # Test that we can find the editor and
+    # add text to it.
+    demo_root = headless_browser.get_demo_root_for(CodeEditorHighlightRows)
+    assert demo_root
+    marker_line = headless_browser.find_by_css(".ace_active-line")
+    assert marker_line
+    marker_line = headless_browser.find_by_css(".highlight-red")
+    assert marker_line
+
+
+class CodeEditorHighlightRowsInColor(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        highlightRange = {"startRow": 5, "endRow": 10, "color": "blue"}
+
+        return cells.CodeEditor(
+            onTextChange=onTextChange,
+            textToDisplayFunction=lambda: text,
+            highlightRange=highlightRange,
+        )
+
+    def text(self):
+        return "Should see a CodeEditor and its content with rows 5-10 " "highlighted"
+
+
+def test_adding_highlight_color(headless_browser):
+    # Test that we can find the editor and
+    # add text to it.
+    demo_root = headless_browser.get_demo_root_for(CodeEditorHighlightRowsInColor)
+    assert demo_root
+    marker_line = headless_browser.find_by_css(".highlight-blue")
+    assert marker_line
+
+
 class CodeEditorInSplitView(CellsTestPage):
     def cell(self):
         contents = cells.Slot("")

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -439,6 +439,18 @@ td.row-index-item {
     height: 100%;
 }
 
+.highlight-red {
+    background-color: red!important;
+}
+
+.highlight-blue {
+    background-color: #007bff!important;
+}
+
+.highlight-green {
+    background-color: green!important;
+}
+
 .code-editor-inner {
     width: 100%;
     min-height: 100%;

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -23,6 +23,8 @@ class CodeEditor extends Component {
         this.setTextFromServer = this.setTextFromServer.bind(this);
         this.lastSentText = null;
         this.mouseoverTimeout = null;
+        // keeps track of any highlight related markers
+        this.highlightMarker = null;
 
         // A cached version of the created
         // DOM node will be put here for
@@ -31,10 +33,11 @@ class CodeEditor extends Component {
 
         // Used to register and deregister
         // any global KeyListener instance
+        this.disableEventFiring = false;
         this._onBlur = this._onBlur.bind(this);
         this._onFocus = this._onFocus.bind(this);
         this.onScroll = this.onScroll.bind(this);
-        this.disableEventFiring = false;
+        this._highlight = this._highlight.bind(this);
     }
 
     componentDidLoad() {
@@ -99,8 +102,14 @@ class CodeEditor extends Component {
                 }
             }
 
-            this.setupKeybindings();
+            if (this.props.highlightRange !== undefined){
+                let startRow = this.props.highlightRange["startRow"] || 1;
+                let endRow = this.props.highlightRange["endRow"] || 1;
+                let highlightColor = this.props.highlightRange["color"] || "red";
+                this._highlight(startRow, endRow, highlightColor);
+            }
 
+            this.setupKeybindings();
             this.installChangeHandlers();
         }
 
@@ -122,7 +131,6 @@ class CodeEditor extends Component {
         newEditor.setSession(this.editor.session);
         this.editor = newEditor;
     }
-
 
     build(){
         if(this.hasRenderedBefore){
@@ -205,6 +213,16 @@ class CodeEditor extends Component {
                 this.editor.resize(true);
                 this.editor.scrollToRow(row - 1)
                 this.editor.gotoLine(row, 0, true);
+            } else if(dataInfo.highlight === true) {
+                let startRow = this.dataInfo.startRow || 1;
+                let endRow = this.dataInfo.endRow || 1;
+                let highlightColor = this.dataInfo.color || "red";
+                this._highlight(startRow, endRow, highlightColor);
+            } else if (dataInfo.highlight === false){
+                // remove the highlighting
+                if (this.highlightMarker !== null){
+                    this.session.removeMarker(this.highlightMarker);
+                }
             }
         })
     }
@@ -332,6 +350,21 @@ class CodeEditor extends Component {
             this.constructor.keyListener.pause();
         }
     }
+
+    /* I highlight rows by specififying their background color.
+     * Note: I use the ace.addMarker API which limits me to adding
+     * specific css classes, so as of writing the available colors are
+     * 'red' 'blue' and 'green.'
+     */
+    _highlight(startRow, endRow, color){
+        let Range = ace.require('ace/range').Range;
+        let highlightRange = new Range(startRow - 1, 0, endRow - 1, 0);
+        this.highlightMarker = this.editor.session.addMarker(
+             highlightRange,
+            `ace_active-line highlight-${color}`,
+            "fullLine"
+        );
+    }
 }
 
 CodeEditor.propTypes = {
@@ -383,6 +416,11 @@ CodeEditor.propTypes = {
     minLines: {
         description: "Sets the minimum number of lines in the Ace Editor",
         type: PropTypes.number
+    },
+
+    highlightRange: {
+        description: "A dictionary object containing 'startRow' 'startColumn' 'endRow' 'endColumn' for code highlighting",
+        type: PropTypes.object
     }
 };
 


### PR DESCRIPTION
## Motivation and Context
This PR adds a highlighting API to the CodeEditor. It builds on top of the [scroll state](https://github.com/APrioriInvestments/object_database/pull/102) PR and allows programmatic setting of various background colors either at instantiation or via the data update WS message protocol. There is also an API for removing highlighted code. 

## Approach
Ace editor provides an `addMarker` (and `removeMarker`) editor session methods which are used to add (or remove) Ace content overlay element css classes. The advantage of these is that they provide a clean way to interact with the editor session state; the disadvantage is that we cannot directly manipulate the style attributes of any specific row elements. However, this is the recommended way to create various markers that won't interfere with the rest of the Ace environment. We use these methods to add classes for red, blue and green colors (other colors can be added as needed, by simply creating the corresponding css classes in our `app.css` file). 

The CodeEditor cell class now has an `addRowHighlight()` as well as a `highlightRange` init param which allow setting the first row, last row and color (limited) of the highlighting. There is also a `.removeRowHighlight()` which gets rid of the marker/highlight. 

## How Has This Been Tested?
Playground demo examples have been added and web/selenium tests written & pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.