### PR TITLE
Refactoring #cellDiscarded message creation and reception

### DIFF
--- a/object_database/web/cells/Messenger.py
+++ b/object_database/web/cells/Messenger.py
@@ -68,6 +68,31 @@ def cellDiscarded(cell):
     }
 
 
+def cellsDiscarded(aListOfCells):
+    """A lifecycle message formatter
+    to be used when a collection of Cells
+    are all marked to be discarded and
+    removed from the session
+
+    Parameters
+    ----------
+    aListOfCells: list(Cell)
+        The collection of Cell
+        instances marked for
+        removal
+
+    Returns
+    -------
+    A JSON parsable dictionary that
+    can be sent over a websocket
+    """
+    return {
+        "channel": "#main",
+        "type": "#cellsDiscarded",
+        "ids": [cell.identity for cell in aListOfCells],
+    }
+
+
 def appendPostscript(jsString):
     """A lifecycle message formatter
     to be used when we are appending a

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -432,14 +432,19 @@ class Cells:
             res.append(Messenger.cellDataUpdated(node))
             node.updateLifecycleState()
 
-        # make messages for discarding
-        for n in self._nodesToDiscard:
-            if n.cells is not None:
-                assert n.cells == self
-                res.append(Messenger.cellDiscarded(n))
+        # Make the compound message
+        # listing all the nodes that
+        # will be discarded
+        finalNodesToDiscard = []
+        for node in self._nodesToDiscard:
+            if node.cells is not None:
+                assert node.cells == self
+                finalNodesToDiscard.append(node)
                 # TODO: in the future this should integrated into a more
                 # structured server side lifecycle management framework
-                n.updateLifecycleState()
+                node.updateLifecycleState()
+        if len(finalNodesToDiscard):
+            res.append(Messenger.cellsDiscarded(finalNodesToDiscard))
 
         # the client reverses the order of postscripts because it wants
         # to do parent nodes before child nodes. We want our postscripts

--- a/object_database/web/content/NewCellHandler.js
+++ b/object_database/web/content/NewCellHandler.js
@@ -51,7 +51,7 @@ class NewCellHandler {
         this.sendMessageFor = this.sendMessageFor.bind(this);
         this.receive = this.receive.bind(this);
         this.cellUpdated = this.cellUpdated.bind(this);
-        this.cellDiscarded = this.cellDiscarded.bind(this);
+        this.cellsDiscarded = this.cellsDiscarded.bind(this);
         this.doesNotUnderstand = this.doesNotUnderstand.bind(this);
         this._getUpdatedComponent = this._getUpdatedComponent.bind(this);
         this._createAndUpdate = this._createAndUpdate.bind(this);
@@ -105,8 +105,8 @@ class NewCellHandler {
             return this.cellUpdated(message);
         case '#cellDataUpdated':
             return this.cellDataUpdated(message);
-        case '#cellDiscarded':
-            return this.cellDiscarded(message);
+        case '#cellsDiscarded':
+            return this.cellsDiscarded(message);
         case '#appendPostscript':
             return this.appendPostscript(message);
         default:
@@ -207,19 +207,20 @@ class NewCellHandler {
      * re-render without the discarded child, so we
      * don't need to do anything complex in this method.
      * @param {Object} message - A JSON decoded message
-     * object containing the id of the Cell/Component
-     * that was discarded.
+     * object containing the ids of the Cell/Components
+     * that were discarded.
      * @returns {Component} - The Component instance
      * that was discarded.
      */
-    cellDiscarded(message){
-        let found = this.activeComponents[message.id];
-        if(found){
-            found.componentWillUnload();
-            delete this.activeComponents[message.id];
-            this._deleted[found.props.id] = found;
-        }
-        return found;
+    cellsDiscarded(message){
+        message.ids.forEach(componentId => {
+            let found = this.activeComponents[componentId];
+            if(found){
+                found.componentWillUnload();
+                delete this.activeComponents[componentId];
+                this._deleted[found.props.id] = found;
+            }
+        });
     }
 
     /* Legacy Methods still required */

--- a/object_database/web/content/tests/NewCellHandlerTests.js
+++ b/object_database/web/content/tests/NewCellHandlerTests.js
@@ -105,7 +105,8 @@ let makeCreateMessage = (compDescription) => {
 let makeDiscardedMessage = (compDescription) => {
     return Object.assign({}, compDescription, {
         channel: "#main",
-        type: "#cellDiscarded"
+        type: "#cellsDiscarded",
+        ids: [compDescription.id]
     });
 };
 
@@ -367,17 +368,17 @@ describe("Complex Structure Handling Component Tests", () => {
 
 
 /**
- * A Note on cellDiscarded Tests
+ * A Note on cellsDiscarded Tests
  * ------------------------------
- * Previously we expected #cellDiscarded messages to have to navigate
+ * Previously we expected #cellsDiscarded messages to have to navigate
  * their parent components and remove themselves from namedChildren collections.
  * In practice, an updated parent Cell/Component will send #cellUpdated with
  * the child already removed, so even the most complex kinds of
- * #cellDiscarded handling seem unnecessary for the moment.
+ * #cellsDiscarded handling seem unnecessary for the moment.
  * We will preserve these tests in case the need arises again
  * to implement more complicated discarding handling.
  */
-describe("#cellDiscarded basic", function(){
+describe("#cellsDiscarded basic", function(){
     var handler;
     before(() => {
         let rootEl = document.createElement('div');
@@ -421,7 +422,7 @@ describe("#cellDiscarded basic", function(){
     });
 });
 
-describe.skip("#cellDiscarded complex case", function(){
+describe.skip("#cellsDiscarded complex case", function(){
     var handler;
     before(() => {
         let rootEl = document.createElement('div');
@@ -440,7 +441,7 @@ describe.skip("#cellDiscarded complex case", function(){
         let foundRoot = handler.activeComponents[simpleRoot.id];
         assert.exists(foundRoot);
     });
-    it("Can call #cellDiscarded on firstText", () => {
+    it("Can call #cellsDiscarded on firstText", () => {
         let textToRemove = Object.assign({}, firstText);
         let discardMessage = makeDiscardedMessage(textToRemove);
         handler.receive(discardMessage);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR restructures the way `cellDiscarded` (now `cellsDiscarded`) messages are composed, received, and ultimately handled on the Component side. This is in relation to #104 

## Motivation and Context
<!-- Why is this change required? -->
See Issue #104 for details. We were sending (potentially) too many messages for discarding cells per rendering cycle
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
Instead of composing a single message per Cell being discarded, we now send over an array of *all* ids of cells to be discarded at the same time.
  
The CellHandler has also been updated to deal with this change.
  
We have changed all references to `cellDiscarded` and renamed them `cellsDiscarded`

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
All existing tests are passing as normal
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.