### PR TITLE
CodeEditor custom Completion (issue 97)

### DIFF
--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -289,6 +289,39 @@ class CodeEditorDelayedMouseover(CellsTestPage):
         return "You should see a code editor and a mirror of its contents."
 
 
+class CodeEditorInSplitView(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("")
+
+        def onTextChange(buffer, selection):
+            contents.set(buffer)
+
+        return cells.ResizablePanel(
+            cells.CodeEditor(onTextChange=onTextChange),
+            cells.Subscribed(lambda: cells.Code(contents.get())),
+        )
+
+    def text(self):
+        return "You should see a code editor and a mirror of its contents."
+
+
+class CodeEditorInSplitViewWithHeader(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("")
+
+        def onTextChange(buffer, selection):
+            contents.set(buffer)
+
+        return cells.ResizablePanel(
+            cells.Text("This is an editor:") + cells.CodeEditor(onTextChange=onTextChange),
+            cells.Text("This should show what's in the editor")
+            + cells.Subscribed(lambda: cells.Code(contents.get())),
+        )
+
+    def text(self):
+        return "You should see a code editor and a mirror of its contents."
+
+
 class CodeEditorSetFirstVisibleRow(CellsTestPage):
     def cell(self):
         contents = cells.Slot("No Text Entered Yet!")
@@ -326,39 +359,6 @@ def test_set_first_row(headless_browser):
     first_line = headless_browser.find_by_css(".ace_gutter-active-line")
     assert first_line
     assert first_line.text == "5"
-
-
-class CodeEditorInSplitView(CellsTestPage):
-    def cell(self):
-        contents = cells.Slot("")
-
-        def onTextChange(buffer, selection):
-            contents.set(buffer)
-
-        return cells.ResizablePanel(
-            cells.CodeEditor(onTextChange=onTextChange),
-            cells.Subscribed(lambda: cells.Code(contents.get())),
-        )
-
-    def text(self):
-        return "You should see a code editor and a mirror of its contents."
-
-
-class CodeEditorInSplitViewWithHeader(CellsTestPage):
-    def cell(self):
-        contents = cells.Slot("")
-
-        def onTextChange(buffer, selection):
-            contents.set(buffer)
-
-        return cells.ResizablePanel(
-            cells.Text("This is an editor:") + cells.CodeEditor(onTextChange=onTextChange),
-            cells.Text("This should show what's in the editor")
-            + cells.Subscribed(lambda: cells.Code(contents.get())),
-        )
-
-    def text(self):
-        return "You should see a code editor and a mirror of its contents."
 
 
 class ServerSideSetFirstVisibleRow(CellsTestPage):
@@ -420,6 +420,25 @@ def test_set_first_row_serverside(headless_browser):
 
     headless_browser.wait(10).until(textIsTen)
     assert textIsTen()
+
+    def text(self):
+        return (
+            "Should see a CodeEditor and its content. Try typing to see the"
+            " custom completer function in action."
+        )
+
+
+class CodeEditorCustomCompleterBasic(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+        customCompleterFunction = lambda s: ["complete ME1!", "complete ME2!"]
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+            onTextChange=onTextChange, customCompleterFunction=customCompleterFunction
+        )
 
     def text(self):
         return (

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -368,6 +368,11 @@ class ServerSideSetFirstVisibleRow(CellsTestPage):
         contents = cells.Slot("No Text Entered Yet!")
 
         textToDisplayFunction = lambda: "some text"
+        class CodeEditorCustomCompleter(CellsTestPage):
+            def cell(self):
+                contents = cells.Slot("No Text Entered Yet!")
+                customCompleterFunction = lambda s: "complete ME!"
+        customCompleterFunction = lambda s: ["complete ME1!", "complete ME2!"]
 
         def onTextChange(content, selection):
             contents.set(content)
@@ -415,3 +420,28 @@ def test_set_first_row_serverside(headless_browser):
 
     headless_browser.wait(10).until(textIsTen)
     assert textIsTen()
+
+    def text(self):
+        return (
+            "Should see a CodeEditor and its content. Try typing to see the"
+            " custom completer function in action."
+        )
+
+
+class CodeEditorCustomCompleterMoreAdvanced(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+        customCompleterFunction = lambda s: [item for item in globals().keys() if s in item]
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+            onTextChange=onTextChange, customCompleterFunction=customCompleterFunction
+        )
+
+    def text(self):
+        return (
+            "Should see a CodeEditor and its content. Try typing to see the"
+            " custom completer function in action."
+        )

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -33,6 +33,9 @@ class CodeEditor extends Component {
         // The autocomplete method used when completions are coming from the
         // server side
         this.suggestCompletion = this.suggestCompletion.bind(this);
+        // in case of initial server lag we initialze the suggestion list
+        // with something informative
+        this.autocompleteSuggestions = ["fetching suggestions..."];
 
         // Used to register and deregister
         // any global KeyListener instance
@@ -373,7 +376,6 @@ class CodeEditor extends Component {
         dataInfos.map((dataInfo) => {
             if (dataInfo.action === "autocomplete"){
                 this.autocompleteSuggestions = dataInfo.suggestions;
-                console.log(this.autocompleteSuggestions);
             } else if (dataInfo.action === "setFirstVisibleRow"){
                 let row = parseInt(dataInfo.firstVisibleRow);
                 this.editor.resize(true);

--- a/object_database/web/content/components/WSMessageTester.js
+++ b/object_database/web/content/components/WSMessageTester.js
@@ -61,7 +61,7 @@ class WSMessageTester extends Component {
      */
     _updateData(dataInfos, projector) {
         dataInfos.map((dataInfo) => {
-            if (dataInfo.message === "WSTest"){
+            if (dataInfo.action === "WSTest"){
                 let method = dataInfo["method"];
                 let args = dataInfo["args"];
                 let newText = "I just ran " + method + " with " + JSON.stringify(args);

--- a/object_database/web/content/components/WSMessageTester.js
+++ b/object_database/web/content/components/WSMessageTester.js
@@ -61,7 +61,7 @@ class WSMessageTester extends Component {
      */
     _updateData(dataInfos, projector) {
         dataInfos.map((dataInfo) => {
-            if (dataInfo.event === "WSTest"){
+            if (dataInfo.message === "WSTest"){
                 let method = dataInfo["method"];
                 let args = dataInfo["args"];
                 let newText = "I just ran " + method + " with " + JSON.stringify(args);


### PR DESCRIPTION
## Motivation and Context
This PR allows for custom auto completion functions (as described in #97) to be defined server side and passed to the CodeEditor cell init method replacing the default Ace autocomplete library. 

## Approach
CodeEditor.init() now accepts a `customCompleterFunction()` which takes a single input string argument and return a list of strings,<sup>1</sup> the completion suggestions. The cell CodeEditor lets the component CodeEditor know that a completer has been set up and this in turn sends WS messages to the server asking for suggestions whenever text input events are fired. The suggestions are returned via the WS `dataUpdated` protocol and stored in an CodeEditor component attribute.<sup>2</sup> Subsequently the Ace autocomplete callback looks in this list of suggestions and returns those which match semantically (i.e. contain as a substring of what is being typed last). 


<sup>1</sup> Ace accepts more information about the suggestions, descriptive metadata and ranking scores. These are not implemented but can be done so as needed. 

<sup>2</sup> Note: ideally the Ace autocomplete callback function would make an HTTP request and wait for the data to return. But since this is not available we use the roundabout WS request and dataUpdated protocol to ask for suggestions and set a CodeEditor instance attribute, which results in a few minor hacks to get natural behavior but still can encounter a slight delay when the first character is typed in.




## How Has This Been Tested?
A number of examples have been set up in playground and are running on our test server:
[Basic example](http://134.209.219.151:8000/services/CellsTestService?category=code_editor&name=CodeEditorCustomCompleterBasic)
[More advanced example](http://134.209.219.151:8000/services/CellsTestService?category=code_editor&name=CodeEditorCustomCompleterMoreAdvanced)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.