### PR TITLE
Support for Codebase kwargs

### DIFF
--- a/object_database/service_manager/Codebase.py
+++ b/object_database/service_manager/Codebase.py
@@ -75,8 +75,10 @@ class Codebase:
     files = ConstDict(str, service_schema.File)
 
     @staticmethod
-    def createFromRootlevelPath(rootPath):
-        return Codebase.createFromCodebase(TypedPythonCodebase.FromRootlevelPath(rootPath))
+    def createFromRootlevelPath(rootPath, **kwargs):
+        return Codebase.createFromCodebase(
+            TypedPythonCodebase.FromRootlevelPath(rootPath, **kwargs)
+        )
 
     @staticmethod
     def createFromCodebase(codebase: TypedPythonCodebase):

--- a/object_database/service_manager/InProcessServiceManager.py
+++ b/object_database/service_manager/InProcessServiceManager.py
@@ -76,20 +76,9 @@ class InProcessServiceManager(ServiceManager):
     def createOrUpdateService(
         serviceClass,
         serviceName,
-        target_count=None,
-        placement=None,
-        isSingleton=None,
-        coresUsed=None,
-        gbRamUsed=None,
         inferCodebase=False,  # don't infer codebase by default
+        **kwargs,
     ):
         ServiceManager.createOrUpdateService(
-            serviceClass,
-            serviceName,
-            target_count=target_count,
-            placement=placement,
-            isSingleton=isSingleton,
-            coresUsed=coresUsed,
-            gbRamUsed=gbRamUsed,
-            inferCodebase=inferCodebase,
+            serviceClass, serviceName, inferCodebase=inferCodebase, **kwargs
         )

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -83,6 +83,7 @@ class ServiceManager(object):
         coresUsed=None,
         gbRamUsed=None,
         inferCodebase=True,
+        extensions=(".py"),
     ):
         service = service_schema.Service.lookupAny(name=serviceName)
 
@@ -104,7 +105,9 @@ class ServiceManager(object):
 
             root_path = TypedPythonCodebase.rootlevelPathFromModule(module)
 
-            tpCodebase = service_schema.Codebase.createFromRootlevelPath(root_path)
+            tpCodebase = service_schema.Codebase.createFromRootlevelPath(
+                root_path, extensions=extensions
+            )
 
             service.setCodebase(tpCodebase)
 

--- a/object_database/web/CellsTestService.py
+++ b/object_database/web/CellsTestService.py
@@ -17,7 +17,7 @@ import textwrap
 import urllib
 import sys
 
-from typed_python.inspect_override import getsourcelines
+from inspect import getsourcelines
 from object_database.service_manager.ServiceBase import ServiceBase
 from typed_python.Codebase import Codebase
 


### PR DESCRIPTION
## Motivation and Context
Codebase typically contains only .py files, but occasionally we may want to specify additional file-types.

## Approach
Codebase already supports this feature, but we needed to propagate that information through a couple of entrypoints of ServiceManager.

## How Has This Been Tested?
- TravisCI is happy
- Our downstream tests are happy
