### PR TITLE
CodeEditor Delayed Mouseover events

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -2836,6 +2836,8 @@ class CodeEditor(Cell):
         firstVisibleRow=None,
         onFirstRowChange=None,
         textToDisplayFunction=lambda: "",
+        mouseoverTimeout=1000,
+        onMouseover=None,
     ):
         """Create a code editor
 
@@ -2855,6 +2857,13 @@ class CodeEditor(Cell):
 
         onFirstRowChange - a function that is called when the first visible row
         changes. It takes one argument which is said row.
+
+        mouseoverTimeout - timeout for mouseover callback WS message in
+        milliseconds
+
+        onMouseover = a function which is called subsequent to the mouseover
+        event fires on the client side and corresponding WS message is
+        received.The entire message is passed to the function.
         """
         super().__init__()
         # contains (current_iteration_number: int, text: str)
@@ -2867,6 +2876,8 @@ class CodeEditor(Cell):
         self.autocomplete = autocomplete
         self.onTextChange = onTextChange
         self.textToDisplayFunction = textToDisplayFunction
+        self.mouseoverTimeout = mouseoverTimeout
+        self.onMouseover = onMouseover
 
         # All CodeEditors will be
         # flexed inside of Sequences,
@@ -2902,6 +2913,9 @@ class CodeEditor(Cell):
             self.firstVisibleRowSlot.set(msgFrame["firstVisibleRow"])
             if self.onFirstRowChange is not None:
                 self.onFirstRowChange(msgFrame["firstVisibleRow"])
+        elif msgFrame["event"] == "mouseover":
+            if self.onMouseover is not None:
+                self.onMouseover(msgFrame)
 
     def setFirstVisibleRow(self, rowNum):
         """ Send a message to set the first visible row of the editor to
@@ -3016,6 +3030,7 @@ class CodeEditor(Cell):
         self.exportData[
             "firstVisibleRow"
         ] = self.firstVisibleRowSlot.getWithoutRegisteringDependency()
+        self.exportData["mouseoverTimeout"] = self.mouseoverTimeout
 
         self.exportData["keybindings"] = [k for k in self.keybindings.keys()]
 

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -234,6 +234,61 @@ class CodeEditorFirstVisibleRowChange(CellsTestPage):
         return "You should see a code editor and a mirror of its contents."
 
 
+class CodeEditorDelayedMouseover(CellsTestPage):
+    def cell(self):
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
+
+        contents = cells.Slot("")
+
+        row = cells.Slot("")
+        column = cells.Slot("")
+        line = cells.Slot("")
+        token = cells.Slot("")
+
+        def onTextChange(buffer, selection):
+            contents.set(buffer)
+
+        def onDelayedMouseover(eventData):
+            row.set(str(eventData["row"]))
+            column.set(str(eventData["column"]))
+            line.set(str(eventData["line"]))
+            token.set(str(eventData["token"]))
+
+        return cells.ResizablePanel(
+            cells.CodeEditor(
+                textToDisplayFunction=lambda: text,
+                onTextChange=onTextChange,
+                mouseoverTimeout=1000,
+                onMouseover=onDelayedMouseover,
+            ),
+            cells.Sequence(
+                [
+                    cells.Subscribed(lambda: cells.Text("Hovering over:")),
+                    cells.Subscribed(lambda: cells.Text("row: " + row.get())),
+                    cells.Subscribed(lambda: cells.Text("column: " + column.get())),
+                    cells.Subscribed(lambda: cells.Text("line: " + line.get())),
+                    cells.Subscribed(lambda: cells.Text("token: " + token.get())),
+                ]
+            ),
+        )
+
+    def text(self):
+        return "You should see a code editor and a mirror of its contents."
+
+
 class CodeEditorSetFirstVisibleRow(CellsTestPage):
     def cell(self):
         contents = cells.Slot("No Text Entered Yet!")


### PR DESCRIPTION
## Motivation and Context
This PR adds the ability to create (delayed) mouseover events to the CodeEditor API. From the cells side you can now pass `mouseoverTimeout` (in milliseconds) argument to cell.CodeEditor which will trigger a WS message containing event target data (row, column, line, token) to come over the wire if the user hovers for the corresponding amount of time. There is also a `onMouseover` (func that takes event target data) argument which is passed the WS message and subsequently called. 

Note: this PR is branched from `daniel-issue-95` and could either be merged there or directly into `dev` sub-summing PR #102 

## Approach
Ace prevents much of the classic DOM interface to be useable but does offer a number of nice, if sparsely documented, API's. Here we use the `editor.on("mousemove", callback)` API to trigger the WS message sent with a specified timeout. The callback also clears all existing timeouts which ensures that a WS is sent over only in the case that the timeout has properly elapsed. To prevent the message being sent when the mouse is moved outside the CodeEditor area we bind a `onmouseleave` event to the code-editor container DOM element (unfortunately Ace does not offer an `editor.on("mouseleave",..)` handler).

Note: the event target `token` data is what Ace considers to be a token at that mouse position, i.e. it is the part of the text Ace wraps in a span and subsequently styles. This corresponds to natural code styling and spacing so is probably what we want in most cases, but more granular character by character information is likely possible to get with some hacking. 

## How Has This Been Tested?
A dynamic example has been set up in playground which displays the event target data (row, column, line, token) as you hover the mouse. 

As of writing a live version of the example is running [here](http://134.209.219.151:8000/services/CellsTestService?category=code_editor&name=CodeEditorDelayedMouseover) 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.