### PR TITLE
WS Message Tester

### DIFF
--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -63,6 +63,7 @@ from object_database.web.cells.cells import (
     CircleLoader,
     Timestamp,
     HorizontalSequence,
+    WSMessageTester,
 )
 
 from object_database.web.cells.views.split_view import SplitView

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3355,7 +3355,17 @@ class WSMessageTester(Cell):
 
     def onMessage(self, msgFrame):
         if msgFrame["event"] == "click":
+            # Run the method...
             self.methodToRun(**self.kwargs)
+            # ... and let the client know what you ran
+            dataInfo = {
+                "event": "WSTest",
+                "method": str(self.methodToRun),
+                "args": self.kwargs,
+            }
+            self.exportData["dataInfo"] = [dataInfo]
+            self.wasDataUpdated = True
+            self.markDirty()
 
     def recalculate(self):
         self.children["content"] = self.content

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3334,25 +3334,17 @@ class Highlighted(Cell):
         self.children["content"] = Cell.makeCell(self.content)
 
 
-class WSMessageTester(Clickable):
-    def __init__(self, *args, small=False, active=True, style="primary", **kwargs):
-        self.content = "send message"
-        Clickable.__init__(self, content=self.content, *args, **kwargs)
-        self.small = small
-        self.active = active
-        self.style = style
+class WSMessageTester(Cell):
+    def __init__(self, methodToRun, **kwargs):
+        super().__init__()
+        self.content = "Go!"
+        self.content = Cell.makeCell(self.content)
+        self.methodToRun = methodToRun
+        self.kwargs = kwargs
+
+    def onMessage(self, msgFrame):
+        if msgFrame["event"] == "click":
+            self.methodToRun(**self.kwargs)
 
     def recalculate(self):
         self.children["content"] = self.content
-
-        isActive = False
-        if self.active:
-            isActive = True
-
-        # temporary js WS refactoring data
-        self.exportData["small"] = self.small
-        self.exportData["active"] = isActive
-        self.exportData["style"] = self.style
-
-        # TODO: this event handling situation must be refactored
-        self.exportData["events"] = {"onclick": self.calculatedOnClick()}

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3332,3 +3332,27 @@ class Highlighted(Cell):
 
     def recalculate(self):
         self.children["content"] = Cell.makeCell(self.content)
+
+
+class WSMessageTester(Clickable):
+    def __init__(self, *args, small=False, active=True, style="primary", **kwargs):
+        self.content = "send message"
+        Clickable.__init__(self, content=self.content, *args, **kwargs)
+        self.small = small
+        self.active = active
+        self.style = style
+
+    def recalculate(self):
+        self.children["content"] = self.content
+
+        isActive = False
+        if self.active:
+            isActive = True
+
+        # temporary js WS refactoring data
+        self.exportData["small"] = self.small
+        self.exportData["active"] = isActive
+        self.exportData["style"] = self.style
+
+        # TODO: this event handling situation must be refactored
+        self.exportData["events"] = {"onclick": self.calculatedOnClick()}

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -3335,7 +3335,18 @@ class Highlighted(Cell):
 
 
 class WSMessageTester(Cell):
+    """A helper cell to test cell methods interactively in the browser."""
+
     def __init__(self, methodToRun, **kwargs):
+        """
+        Parameters:
+        ----------
+            methodToRun: cell method
+                The method of an initialized cell to run when the
+                WSMessageTester button is clicked.
+            kwargs: cell method kwargs
+
+        """
         super().__init__()
         self.content = "Go!"
         self.content = Cell.makeCell(self.content)

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -336,4 +336,20 @@ class ServerSideSetFirstVisibleRow(CellsTestPage):
         )
 
     def text(self):
-        return "Clicking 'Go!' you should see the code editor scroll down."
+        return "By clicking 'Go!' you should see the code editor scroll down."
+
+
+def test_set_first_row_serverside(headless_browser):
+    # Test that we can find the editor and set the first visible row
+    # programmatically from the server side
+    demo_root = headless_browser.get_demo_root_for(ServerSideSetFirstVisibleRow)
+    assert demo_root
+    first_line = headless_browser.find_by_css(".ace_gutter-active-line")
+    assert first_line
+    assert first_line.text == "1"
+    toggle_btn = headless_browser.find_by_css('[data-cell-type="WSTesterButton"]')
+    toggle_btn.click()
+    headless_browser.wait(5)
+    first_line = headless_browser.find_by_css(".ace_gutter-active-line")
+    assert first_line
+    assert first_line.text == "10"

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -304,3 +304,36 @@ class CodeEditorInSplitViewWithHeader(CellsTestPage):
 
     def text(self):
         return "You should see a code editor and a mirror of its contents."
+
+
+class ServerSideSetFirstVisibleRow(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("")
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
+
+        def onTextChange(buffer, selection):
+            contents.set(buffer)
+
+        codeEditor = cells.CodeEditor(
+            onTextChange=onTextChange, textToDisplayFunction=lambda: text
+        )
+
+        return cells.ResizablePanel(
+            cells.WSMessageTester(codeEditor.setFirstVisibleRow, rowNum=10), codeEditor
+        )
+
+    def text(self):
+        return "Clicking 'Go!' you should see the code editor scroll down."

--- a/object_database/web/cells_demo/wsmessage_tester.py
+++ b/object_database/web/cells_demo/wsmessage_tester.py
@@ -16,7 +16,9 @@ from object_database.web import cells as cells
 from object_database.web.CellsTestPage import CellsTestPage
 
 
-class WSMessageTesterExample(CellsTestPage):
+class WSMessageTesterExampleCodeEditor(CellsTestPage):
+    """An example of updating CodeEditor text from the server."""
+
     def cell(self):
         contents = cells.Slot("")
         text = """def cell(self):
@@ -32,7 +34,8 @@ class WSMessageTesterExample(CellsTestPage):
                 onTextChange=onTextChange, firstVisibleRow=5
                 )
         """
-        text *= 5
+
+        newText = "You just updated me from the server."
 
         def onTextChange(buffer, selection):
             contents.set(buffer)
@@ -42,8 +45,9 @@ class WSMessageTesterExample(CellsTestPage):
         )
 
         return cells.ResizablePanel(
-            cells.WSMessageTester(codeEditor.setFirstVisibleRow, rowNum=10), codeEditor
+            cells.WSMessageTester(codeEditor.setCurrentTextFromServer, text=newText),
+            codeEditor,
         )
 
     def text(self):
-        return "You should see some buttons in various styles."
+        return ""

--- a/object_database/web/cells_demo/wsmessage_tester.py
+++ b/object_database/web/cells_demo/wsmessage_tester.py
@@ -1,0 +1,32 @@
+#   Copyright 2017-2019 object_database Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells as cells
+from object_database.web.CellsTestPage import CellsTestPage
+
+
+class WSMessageTesterExample(CellsTestPage):
+    def cell(self):
+        contents = cells.Slot("")
+
+        def onTextChange(buffer, selection):
+            contents.set(buffer)
+
+        return cells.ResizablePanel(
+            cells.WSMessageTester(onClick=lambda: None),
+            cells.CodeEditor(onTextChange=onTextChange),
+        )
+
+    def text(self):
+        return "You should see some buttons in various styles."

--- a/object_database/web/cells_demo/wsmessage_tester.py
+++ b/object_database/web/cells_demo/wsmessage_tester.py
@@ -19,13 +19,30 @@ from object_database.web.CellsTestPage import CellsTestPage
 class WSMessageTesterExample(CellsTestPage):
     def cell(self):
         contents = cells.Slot("")
+        text = """def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        textToDisplayFunction = lambda: "some text"
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.CodeEditor(
+                textToDisplayFunction=textToDisplayFunction,
+                onTextChange=onTextChange, firstVisibleRow=5
+                )
+        """
+        text *= 5
 
         def onTextChange(buffer, selection):
             contents.set(buffer)
 
+        codeEditor = cells.CodeEditor(
+            onTextChange=onTextChange, textToDisplayFunction=lambda: text
+        )
+
         return cells.ResizablePanel(
-            cells.WSMessageTester(onClick=lambda: None),
-            cells.CodeEditor(onTextChange=onTextChange),
+            cells.WSMessageTester(codeEditor.setFirstVisibleRow, rowNum=10), codeEditor
         )
 
     def text(self):

--- a/object_database/web/content/ComponentRegistry.js
+++ b/object_database/web/content/ComponentRegistry.js
@@ -53,6 +53,7 @@ import {Timestamp} from './components/Timestamp';
 import {SplitView} from './components/SplitView';
 import {PageView} from './components/PageView';
 import {HorizontalSequence} from './components/HorizontalSequence';
+import {WSMessageTester} from './components/WSMessageTester';
 
 const ComponentRegistry = {
     AsyncDropdown,
@@ -103,7 +104,8 @@ const ComponentRegistry = {
     Plot,
     _PlotUpdater,
     Timestamp,
-    SplitView
+    SplitView,
+    WSMessageTester
 };
 
 export {ComponentRegistry, ComponentRegistry as default};

--- a/object_database/web/content/components/WSMessageTester.js
+++ b/object_database/web/content/components/WSMessageTester.js
@@ -1,0 +1,90 @@
+/**
+ * Button Cell Component
+ */
+
+import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
+import {h} from 'maquette';
+
+/**
+ * About Named Children
+ * ---------------------
+ * `content` (single) - The cell inside of the button (if any)
+ */
+class WSMessageTester extends Component {
+    constructor(props, ...args){
+        super(props, ...args);
+
+        // Bind context to methods
+        this.makeContent = this.makeContent.bind(this);
+        this._getEvents = this._getEvent.bind(this);
+        this._getHTMLClasses = this._getHTMLClasses.bind(this);
+    }
+
+    build(){
+        return(
+            h('button', {
+                id: this.getElementId(),
+                "data-cell-id": this.props.id,
+                "data-cell-type": "Button",
+                class: this._getHTMLClasses(),
+                onclick: this._getEvent('onclick')
+            }, [this.makeContent()]
+             )
+        );
+    }
+
+    makeContent(){
+        return this.renderChildNamed('content');
+    }
+
+    _getEvent(eventName) {
+        return this.props.events[eventName];
+    }
+
+    _getHTMLClasses(){
+        let classes = ['btn'];
+        if(!this.props.active){
+            classes.push(`btn-outline-${this.props.style}`);
+        }
+        if(this.props.style){
+            classes.push(`btn-${this.props.style}`);
+        }
+        if(this.props.small){
+            classes.push('btn-xs');
+        }
+        return classes.join(" ").trim();
+    }
+}
+
+WSMessageTester.propTypes = {
+    active: {
+        description: "Indicates whether or not the Button is active/deactivated",
+        type: PropTypes.boolean
+    },
+    small: {
+        description: "Sets the Button to display as a small button. Defaults to false.",
+        type: PropTypes.boolean
+    },
+    style: {
+        description: "A Bootstrap name for the button style.",
+        type: PropTypes.oneOf([
+            'primary',
+            'secondary',
+            'success',
+            'danger',
+            'warning',
+            'info',
+            'light',
+            'dark',
+            'link'
+        ])
+    },
+
+    events: {
+        description: "A dictionary of event names to arbitrary JS code that should fire on that event",
+        type: PropTypes.object
+    }
+};
+
+export {WSMessageTester, WSMessageTester as default};

--- a/object_database/web/content/components/WSMessageTester.js
+++ b/object_database/web/content/components/WSMessageTester.js
@@ -15,6 +15,8 @@ class WSMessageTester extends Component {
     constructor(props, ...args){
         super(props, ...args);
 
+        this.initialText = "Click the button to run the method."
+
         // Bind context to methods
         this.makeContent = this.makeContent.bind(this);
         this.handleClick = this.handleClick.bind(this);
@@ -22,14 +24,23 @@ class WSMessageTester extends Component {
 
     build(){
         return(
-            h('button', {
+            h("div", {
                 id: this.getElementId(),
                 "data-cell-id": this.props.id,
-                "data-cell-type": "Button",
-                class: "btn btn-primary",
-                onclick: this.handleClick
-            }, [this.makeContent()]
-             )
+                "data-cell-type": "WSTestter",
+            }, [
+                h('button', {
+                    "data-cell-id": this.props.id + "-button",
+                    "data-cell-type": "WSTesterButton",
+                    class: "btn btn-primary",
+                    onclick: this.handleClick
+                }, [this.makeContent()]
+                ),
+                h("div", {
+                    "data-cell-id": this.props.id + "-display",
+                    "data-cell-type": "WSTesterDisplay",
+                }, [this.initialText])
+            ])
         );
     }
 
@@ -44,6 +55,20 @@ class WSMessageTester extends Component {
         };
 
         cellSocket.sendString(JSON.stringify(responseData));
+    }
+
+    /* I handle incoming WS message data updating.
+     */
+    _updateData(dataInfos, projector) {
+        dataInfos.map((dataInfo) => {
+            if (dataInfo.event === "WSTest"){
+                let method = dataInfo["method"];
+                let args = dataInfo["args"];
+                let newText = "I just ran " + method + " with " + JSON.stringify(args);
+                let display = this.getDOMElement().querySelector("[data-cell-type='WSTesterDisplay']")
+                display.textContent = newText;
+            }
+        })
     }
 }
 

--- a/object_database/web/content/components/WSMessageTester.js
+++ b/object_database/web/content/components/WSMessageTester.js
@@ -17,8 +17,7 @@ class WSMessageTester extends Component {
 
         // Bind context to methods
         this.makeContent = this.makeContent.bind(this);
-        this._getEvents = this._getEvent.bind(this);
-        this._getHTMLClasses = this._getHTMLClasses.bind(this);
+        this.handleClick = this.handleClick.bind(this);
     }
 
     build(){
@@ -27,8 +26,8 @@ class WSMessageTester extends Component {
                 id: this.getElementId(),
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Button",
-                class: this._getHTMLClasses(),
-                onclick: this._getEvent('onclick')
+                class: "btn btn-primary",
+                onclick: this.handleClick
             }, [this.makeContent()]
              )
         );
@@ -38,53 +37,17 @@ class WSMessageTester extends Component {
         return this.renderChildNamed('content');
     }
 
-    _getEvent(eventName) {
-        return this.props.events[eventName];
-    }
+    handleClick(){
+        let responseData = {
+            event: 'click',
+            'target_cell': this.props.id,
+        };
 
-    _getHTMLClasses(){
-        let classes = ['btn'];
-        if(!this.props.active){
-            classes.push(`btn-outline-${this.props.style}`);
-        }
-        if(this.props.style){
-            classes.push(`btn-${this.props.style}`);
-        }
-        if(this.props.small){
-            classes.push('btn-xs');
-        }
-        return classes.join(" ").trim();
+        cellSocket.sendString(JSON.stringify(responseData));
     }
 }
 
 WSMessageTester.propTypes = {
-    active: {
-        description: "Indicates whether or not the Button is active/deactivated",
-        type: PropTypes.boolean
-    },
-    small: {
-        description: "Sets the Button to display as a small button. Defaults to false.",
-        type: PropTypes.boolean
-    },
-    style: {
-        description: "A Bootstrap name for the button style.",
-        type: PropTypes.oneOf([
-            'primary',
-            'secondary',
-            'success',
-            'danger',
-            'warning',
-            'info',
-            'light',
-            'dark',
-            'link'
-        ])
-    },
-
-    events: {
-        description: "A dictionary of event names to arbitrary JS code that should fire on that event",
-        type: PropTypes.object
-    }
 };
 
 export {WSMessageTester, WSMessageTester as default};


### PR DESCRIPTION
## Motivation and Context
This PR adds a [WSMessageTester](https://github.com/APrioriInvestments/object_database/blob/daniel-ws-test-cell/object_database/web/cells/cells.py#L3337) cell and component that allows you to interactively (either in the UI/playground, or via the web/selenium) test the call of a cell method from the server side and its effect on the client. 

For example, to test the `CodeEditor.setFirsVisibleRow(rowNum)` method you simply create a cell_test, such as the one [here](https://github.com/APrioriInvestments/object_database/blob/daniel-ws-test-cell/object_database/web/cells_demo/code_editor.py#L309) passing `WSMessageTester` both the method to test and it's arguments. Clicking the tester button calls the method and the CodeEditor component reacts to the incoming message/change. 

Another example can be found in the [WSMessageTester demo file](https://github.com/APrioriInvestments/object_database/blob/daniel-ws-test-cell/object_database/web/cells_demo/wsmessage_tester.py). 

## Approach
The `WSMessageTester` component is a button with some additional information displayed. Clicking the button will execute the provided method. Generally you would set this up in a split view, where one side is the tester and the other the cell/component to be tested. 

## How Has This Been Tested?
This has been tested in the playground UI and also web/selenium tests have been set up and ran for a few examples. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New dev tool 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.