### PR TITLE
Fixing ResizablePanel Code issue (#110)

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1854,14 +1854,10 @@ class Traceback(Cell):
 
 
 class Code(Cell):
-    # TODO: It looks like codeContents might not
-    # need to be an actual Cell, but instead just
-    # some data passed to this Cell.
     def __init__(self, codeContents):
         super().__init__()
         self.codeContents = codeContents
-        codeContentsCell = Cell.makeCell(codeContents)
-        self.children["code"] = codeContentsCell
+        self.exportData["contents"] = str(codeContents)
 
     def sortsAs(self):
         return self.codeContents

--- a/object_database/web/cells_demo/resizable_panel.py
+++ b/object_database/web/cells_demo/resizable_panel.py
@@ -122,3 +122,43 @@ class ResizePanelWithButtons(CellsTestPage):
                 else cells.Subscribed(toggledSecondAndThird)
             )
         )
+
+
+class ResizePanelWithCodeObject(CellsTestPage):
+    def text(self):
+        return (
+            "Should see a resizable panel with a horizontal split. "
+            " The contents should be scrollable code panes."
+        )
+
+    def cell(self):
+        return cells.ResizablePanel(
+            cells.Code("\n".join([f"top panel line {line}" for line in range(100)])),
+            cells.Code(
+                "\n".join([" " * 30 + f"bottom panel line {line}" for line in range(100)])
+            ),
+            ratio=0.50,
+            split="horizontal",
+        )
+
+
+class ResizePanelWithCodeObjectInPanels(CellsTestPage):
+    def text(self):
+        return (
+            "Should see a resizable panel with a horizontal split. "
+            " The contents should be scrollable code panes."
+        )
+
+    def cell(self):
+        return cells.ResizablePanel(
+            cells.Panel(
+                cells.Code("\n".join([f"top panel line {line}" for line in range(100)]))
+            ),
+            cells.Panel(
+                cells.Code(
+                    "\n".join([" " * 30 + f"bottom panel line {line}" for line in range(100)])
+                )
+            ),
+            ratio=0.50,
+            split="horizontal",
+        )

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -68,7 +68,11 @@
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    /*flex: 1 1 auto;*/
+    overflow: auto;
+}
+
+.resizable-panel-item > .cell-panel {
+    overflow: auto;
 }
 
 .resizable-panel-handle {

--- a/object_database/web/content/components/Code.js
+++ b/object_database/web/content/components/Code.js
@@ -3,36 +3,33 @@
  */
 
 import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
 /**
  * About Named Children
  * --------------------
- * `code` (single) - Code that will be rendered inside
  */
 class Code extends Component {
     constructor(props, ...args){
         super(props, ...args);
-
-        // Bind component methods
-        this.makeCode = this.makeCode.bind(this);
     }
 
     build(){
-        return h('pre',
-                 {
-                     class: "cell code",
-                     id: this.getElementId(),
-                     "data-cell-type": "Code"
-                 }, [
-                     h("code", {}, [this.makeCode()])
-                 ]
-                );
-    }
-
-    makeCode(){
-        return this.renderChildNamed('code');
+        return h('pre', {
+            class: "cell code",
+            id: this.getElementId(),
+            'data-cell-id': this.props.id.toString(),
+            'data-cell-type': "Code"
+        }, [this.props.contents]);
     }
 }
+
+Code.propTypes = {
+    content: {
+        type: PropTypes.string,
+        description: 'The code content to display'
+    }
+};
 
 export {Code, Code as default};


### PR DESCRIPTION
This PR fixes Issue #110 

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!-- Why is this change required? -->
When in a ResizablePanel pane, or in a ResizablePanel pane whose direct child is a plain Panel, Code components were overflowing their contents incorrectly.
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
The problem was threefold.
1. Code was too complex: it wrapped a pre in a code in a Text
component. Code no longer produces a Cell child (Text) since it
is always a string. It is now passed in as exportData/props
2. ResizablePanel panes are not set up to automatically deal
with overflows.
3. Plain Pane elements are also not setup to handle overflow,
which is correct in most cases since Panel fills the space it
has. ResizablePanel is dynamic, so Panel was only taking up
the initially rendered space, and overflowed Code was spilling
out. We solve this with a specific selector for Panes that are
the direct children of a ResizablePanel item

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
Normal tests are passing. This behavior is not testable. We used the live demos to test.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.