### PR TITLE
fixing the header content overflow issues

### DIFF
--- a/object_database/web/cells_demo/sheet.py
+++ b/object_database/web/cells_demo/sheet.py
@@ -277,3 +277,41 @@ def test_two_column_sheet_locked_rows_columnsdisplay(headless_browser):
     query = '[data-cell-type="Sheet"]'
     sheet = headless_browser.find_by_css(query)
     assert sheet
+
+
+class BiggerSheetLargeCellContent(CellsTestPage):
+    def cell(self):
+        num_columns = 300
+        num_rows = 10000
+        long_text = """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+        eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+        minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+        ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+        sint occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est laborum.
+        """
+
+        def rowFun(
+            start_row,
+            end_row,
+            start_column,
+            end_column,
+            num_rows=num_rows,
+            num_columns=num_columns,
+        ):
+            rows = []
+            if start_row >= num_rows or start_column > num_columns:
+                return rows
+            end_column = min(end_column, num_columns)
+            end_row = min(end_row, num_rows)
+            for i in range(start_row, end_row + 1):
+                r = [long_text for j in range(start_column, end_column + 1)]
+                rows.append(r)
+            return rows
+
+        return cells.Sheet(rowFun, colWidth=80, totalColumns=num_columns, totalRows=num_rows)
+
+    def text(self):
+        return "You should see a bigger sheet with a lot of text in each cell."

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -205,8 +205,15 @@ td.locked {
 }
 
 th.header-info{
-    text-align: right;
-    padding-right: 5px;
+    text-align: center;
+    border-right: 2px double #568eca;
+}
+
+th.header-content{
+    text-align: left;
+    text-overflow: ellipsis;
+    padding-right: 10px;
+    overflow: hidden;
 }
 
 th.header-item {

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -286,8 +286,8 @@ class Sheet extends Component {
         let rows = ["Just a sec..."];
         let header = [
             h("tr", {style: `height: ${this.props.rowHeight}px`}, [
-                h("th", {id: `sheet-${this.props.id}-head-current`}, []),
-                h("th", {id: `sheet-${this.props.id}-head-info`, class: "header-info"}, [])
+                h("th", {id: `sheet-${this.props.id}-head-info`, class: "header-info"}, []),
+                h("th", {id: `sheet-${this.props.id}-head-current`, class: "header-content"}, [])
             ])
         ];
         return (
@@ -694,6 +694,9 @@ class Sheet extends Component {
             let cursor = this.selector.selectionFrame.cursor;
             let th = head.querySelector(`#sheet-${this.props.id}-head-current`);
             let content = this.dataFrame.get(cursor);
+            // cleanup content for the header display
+            content = content.replace(/(\r\n|\n|\r)/gm, "");
+            content = content.replace(/(\r\n|\n|\r)/gm, "").replace(/\s+/gm," ");
             let coordinates = `(${cursor.x}x${cursor.y}): `;
             let fontSize = '.8rem';
             if (th.colSpan < 2){
@@ -707,6 +710,7 @@ class Sheet extends Component {
                 }
             }
             th.style.fontSize = fontSize;
+            th.setAttribute("style", `max-width: ${(this.maxNumColumns - 1) * this.props.colWidth}px`)
             th.textContent = `${coordinates}${content}`;
         } catch(e){
             this.dumpInfo(

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -710,8 +710,24 @@ class Sheet extends Component {
                 }
             }
             th.style.fontSize = fontSize;
-            th.setAttribute("style", `max-width: ${(this.maxNumColumns - 1) * this.props.colWidth}px`)
-            th.textContent = `${coordinates}${content}`;
+            th.setAttribute(
+                "style",
+                `width: ${(this.maxNumColumns - 1) * this.props.colWidth}px;` +
+                `position: relative; overflow: visible`
+            )
+            th.innerHTML=(
+                '<div style="'
+                + `max-width: ${(this.maxNumColumns - 1) * this.props.colWidth}px;`
+                + `width: ${(this.maxNumColumns - 1) * this.props.colWidth}px;`
+                + `min-height: ${this.props.rowHeight}px;`
+                + `max-height: ${this.props.height - 40}px;`
+                + 'background-color:#dcdcdc;border-style: solid; border-size: 1px; white-space: normal;'
+                + 'overflow-wrap: break-word;border-width: thin;'
+                + 'border-color: rgb(86, 142, 202);'
+                + 'top: -1px;left:-1px;position:absolute"'
+                + "></div>"
+            )
+            th.firstChild.textContent = `${coordinates}${content}`;
         } catch(e){
             this.dumpInfo(
                 e,


### PR DESCRIPTION

## Motivation and Context
If the header bar in sheet displays long text it can throw off all the column width for the entire view. 

## Approach
The header content cell is given an explicit max-width (in pixels) which is calculated every time the content is updated. 

## How Has This Been Tested?
A playground example (`BiggerSheetLargeCellContent`) has been added and approach tested in the UI. 



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.