### PR TITLE
Fix a bug in how we display objects of a Service

### DIFF
--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -44,7 +44,6 @@ from object_database.web.cells import (
     Grid,
     Flex,
     ensureSubscribedType,
-    SubscribeAndRetry,
     Expands,
     AsyncDropdown,
     ButtonGroup,
@@ -52,15 +51,7 @@ from object_database.web.cells import (
     SplitView,
 )
 
-from object_database import (
-    Schema,
-    Indexed,
-    core_schema,
-    Index,
-    service_schema,
-    current_transaction,
-    Reactor,
-)
+from object_database import Schema, Indexed, core_schema, Index, service_schema, Reactor
 
 ownDir = os.path.dirname(os.path.abspath(__file__))
 ownName = os.path.basename(os.path.abspath(__file__))
@@ -470,9 +461,6 @@ class HappyService(ServiceBase):
 
     @staticmethod
     def serviceDisplay(serviceObject, instance=None, objType=None, queryArgs=None):
-        if not current_transaction().db().isSubscribedToType(Happy):
-            raise SubscribeAndRetry(lambda db: db.subscribeToType(Happy))
-
         if instance:
             return instance.display(queryArgs)
 

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -763,6 +763,7 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
         with self.database.view():
             self.assertEqual(s.count, 3)
 
+    @flaky(max_runs=3, min_passes=1)
     def test_racheting_service_count_up_and_down(self):
         with self.database.transaction():
             ServiceManager.createOrUpdateService(MockService, "MockService", target_count=1)

--- a/object_database/web/ActiveWebService_util.py
+++ b/object_database/web/ActiveWebService_util.py
@@ -16,6 +16,7 @@ from itertools import chain
 
 from object_database.web.ActiveWebServiceSchema import active_webservice_schema
 
+from object_database.web import cells
 from object_database.web.cells import (
     Main,
     Subscribed,
@@ -340,6 +341,10 @@ def displayAndHeadersForPathAndQueryArgs(path, queryArgs):
     Returns:
         a tuple made of a cell.Cell and a list of toggles for the
         appropriate rervice
+
+    Raises: SubscribeAndRetry if the odb connection is not subscribed
+        to the schema of the typeObj (c.f., call to
+        cells.ensureSubscribedSchema)
     """
 
     if len(path) and path[0] == "services":
@@ -370,6 +375,7 @@ def displayAndHeadersForPathAndQueryArgs(path, queryArgs):
         for s in schemas:
             typeObj = s.lookupFullyQualifiedTypeByName(typename)
             if typeObj:
+                cells.ensureSubscribedSchema(s)
                 break
 
         if typeObj is None:


### PR DESCRIPTION
## Motivation and Context
The ability to click on an object managed by a service (in the service schema) and having it display was broken by the new recent feature of `ActiveWebService.serviceSingleSession`.

## Approach
Ensure we are subscribed to that schema within the `ActiveWebService_util.displayAndHeadersForPathAndQueryArgs`. Also updated the unit test to check that this call raises `SubscribeAndRetry` if we're not subscribed, and that after subscribing to the requested schema, we are able to display the object. Also, removed some unnecessary subscription code from the serviceDisplay method of the Happy service in `ServiceManager_test`

## How Has This Been Tested?
Updated the unit test. Saw it fail before the fix, then saw it pass after the fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.