### PR TITLE
Allow pip to install object_database directly from github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,10 +61,9 @@ jobs:
         - ulimit -c unlimited -S       # enable core dumps
       install:
         - pip install pipenv codecov
-        - pip3 install -e git+https://github.com/aprioriinvestments/typed_python.git@5289b827355e8969bd777d9ffb9905266597e216#egg=typed_python
         - pipenv lock --dev --requirements > dev-reqs.txt
         - pip install --requirement dev-reqs.txt
-        - pip install --editable .  # install object_database in 'editable' form.
+        - pip install --editable .  # install object_database in 'editable' mode.
         - sudo apt-get install --assume-yes gdb  # install gdb
         - make testcert.cert
         - make node-install

--- a/install-requires.txt
+++ b/install-requires.txt
@@ -19,5 +19,5 @@ redis
 requests
 selenium
 sortedcontainers
-typed_python
+typed_python @ git+https://github.com/aprioriinvestments/typed_python.git@1401860f6731ffa99842a1cb1a94a302e679537d#egg=typed_python-999.999.999
 wtforms

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -866,6 +866,7 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
         with self.database.view():
             return c.k / seconds
 
+    @flaky(max_runs=3, min_passes=1)
     def test_throughput_while_adjusting_servicecount(self):
         with self.database.transaction():
             ServiceManager.createOrUpdateService(MockService, "MockService", target_count=0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "numpy",
+    "typed_python @ git+https://github.com/aprioriinvestments/typed_python.git@1401860f6731ffa99842a1cb1a94a302e679537d#egg=typed_python-999.999.999"
+]

--- a/setup.py
+++ b/setup.py
@@ -28,17 +28,16 @@ class BuildExtension(build_ext):
     """
 
     def run(self):
-        self.include_dirs.append(pkg_resources.resource_filename("numpy", "core/include"))
+        numpy_dir = pkg_resources.resource_filename("numpy", "core/include")
+        self.include_dirs.append(numpy_dir)
 
         # The typed_python includes are inline.
         # We want to find them as #include <typed_python/...>, so we kluge this
         # together this way. Better to modify typed_python to export its
         # includes in a more reasonable way.
-        self.include_dirs.append(
-            os.path.dirname(
-                os.path.dirname(pkg_resources.resource_filename("typed_python", "."))
-            )
-        )
+        tp_dir = pkg_resources.resource_filename("typed_python", ".")
+        dir_to_add = os.path.dirname(os.path.dirname(tp_dir))
+        self.include_dirs.append(dir_to_add)
         build_ext.run(self)
 
 
@@ -80,7 +79,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     cmdclass={"build_ext": BuildExtension},
     ext_modules=ext_modules,
-    setup_requires=["numpy", "typed_python"],
+    # setup_requires: replaced by build-system:requires in pyproject.toml
     install_requires=INSTALL_REQUIRES,
     # https://pypi.org/classifiers/
     classifiers=[


### PR DESCRIPTION
## Motivation and Context
We want to enable 
```
pip install git+https://github.com/aprioriinvestments/object_database.git@branch-or-commit-hash#egg=object_database
```
object_database requires `typed_python` (and `numpy`) to be installed before it is built. With setup_requires, pip was grabbing the latest typed_python from pypi which was too old, building object_database using that version of typed_python, then later installing the requested version of typed_python from `install_requires`. That resulted in a broken installation of object_database


## Approach
PEP 518 supports exactly this usecase: we define in `pyproject.toml` what the build process requires and those dependencies are installed prior to building object_database. Then we can also remove the version-pin for typed_python from `install_requires`.

## How Has This Been Tested?
In a fresh virtual environment, I ran:
```
pip install -v -v -v git+https://github.com/aprioriinvestments/object_database.git@top-of-this-branch#egg=object_database
```
Then made sure that typed_python was built before object_database (which didn't used to be the case) and that the requested version was fetch (and not the latest pypi version). Then made sure we could `import object_database` in a python REPL, which was previously broken because of building object_database with the wrong version of typed_python.

