### PR TITLE
lookupUnique

### DIFF
--- a/object_database/PyDatabaseObjectType.cpp
+++ b/object_database/PyDatabaseObjectType.cpp
@@ -1096,6 +1096,7 @@ PyObject* PyDatabaseObjectType::pyLookupUnique(PyObject *databaseType, PyObject*
         // check uniqueness
         oid = view->indexLookupNext(lookup.first, lookup.second, oid);
         if (oid != NO_OBJECT) {
+            decref(result);
             throw std::runtime_error(
                 "" + obType->m_schema_and_typename + " not unique."
             );

--- a/object_database/PyDatabaseObjectType.hpp
+++ b/object_database/PyDatabaseObjectType.hpp
@@ -161,6 +161,8 @@ struct PyDatabaseObjectType {
 
   static PyObject* pyLookupOne(PyObject *none, PyObject* args, PyObject* kwargs);
 
+  static PyObject* pyLookupUnique(PyObject *none, PyObject* args, PyObject* kwargs);
+
   static PyObject* pyLookupAny(PyObject *none, PyObject* args, PyObject* kwargs);
 
   static PyObject* pyLookupAll(PyObject *none, PyObject* args, PyObject* kwargs);

--- a/object_database/web/AuthPlugin.py
+++ b/object_database/web/AuthPlugin.py
@@ -15,8 +15,11 @@
 import ldap3
 import logging
 
+from abc import ABC, abstractmethod
 
-class AuthPluginBase:
+
+class AuthPluginBase(ABC):
+    @abstractmethod
     def authenticate(self, username, password) -> str:
         """ Tries to authenticate with given username and password.
 
@@ -25,7 +28,7 @@ class AuthPluginBase:
             str
                 "" if no error occurred, and an error message otherwise
         """
-        raise NotImplementedError("derived class must implement this method")
+        pass
 
     @property
     def authorized_groups(self):
@@ -33,14 +36,24 @@ class AuthPluginBase:
 
 
 class PermissiveAuthPlugin(AuthPluginBase):
-    " An AuthPlugin that allows anyone to login (useful for testing)"
+    """ An AuthPlugin that allows anyone to login (useful for testing). """
 
     def authenticate(self, username, password) -> str:
         return ""
 
 
 class LdapAuthPlugin(AuthPluginBase):
+    """ An AuthPlugin that relegates to LDAP for authentication. """
+
     def __init__(self, hostname, base_dn, ntlm_domain=None, authorized_groups=None):
+        """
+        Args:
+            hostname (str): hostname of the LDAP server
+            base_dn (str): LDAP style base domain name
+            ntlm_domain (str): Microsoft NT (new technology) LAN Manager (LM) domain
+            authorized_groups (List(str) or None): If not None, the groups that are
+                authorized; if None, all groups are authorized.
+        """
         self._hostname = hostname
         self._base_dn = base_dn
         self._ntlm_domain = ntlm_domain


### PR DESCRIPTION
## Motivation and Context
I wanted a method that guarantees that if an object of a certain type exists, it is unique (there isn't a 2nd one). This can be useful for implementing primary-key semantics


## Approach
Implemented lookupUnique that returns None if there's no object, the object if it exists, and raises a TypeError if there is more than one objects. This works with indexing too, such that `Thing.lookupUnique(name="bla")` will raise if there's two Things named bla.

## Testing
Check out the unit-test I wrote

## Bonus
I was reading the LoginPlugin and AuthPlugin stuff and added some docstrings and used the ABC/@abstractmethod pattern where appropriate. 