### PR TITLE
Alex collect orphan service instances

### DIFF
--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -300,7 +300,8 @@ class ServiceManager(object):
         self.stopServices(orphans)
         with self.db.transaction():
             for instance in orphans:
-                instance.delete()
+                if instance.exists():
+                    instance.delete()
 
     @revisionConflictRetry
     def collectDeadHosts(self):

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -467,7 +467,10 @@ class ServiceManager(object):
         with self.db.transaction():
             for i in service_schema.ServiceInstance.lookupAll(host=self.serviceHostObject):
                 if i.state == "Booting":
-                    res.append(i)
+                    if i.shouldShutdown:
+                        i.delete()
+                    else:
+                        res.append(i)
         return res
 
     def startServiceWorker(self, service, instanceIdentity):

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -802,8 +802,16 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
 
             ServiceManager.stopService("HappyService")
 
+        def serviceState():
+            with self.database.view():
+                service = service_schema.Service.lookupAny(name="HappyService")
+                instances = service_schema.ServiceInstance.lookupAll(service=service)
+                return [i.state for i in instances]
+
         timeout = 6.0 * self.ENVIRONMENT_WAIT_MULTIPLIER
-        self.assertTrue(ServiceManager.waitStopped(self.database, "HappyService", timeout))
+        self.assertTrue(
+            ServiceManager.waitStopped(self.database, "HappyService", timeout), serviceState()
+        )
 
         with self.database.transaction():
             ServiceManager.removeService("HappyService")

--- a/object_database/service_manager/ServiceWorker.py
+++ b/object_database/service_manager/ServiceWorker.py
@@ -77,9 +77,11 @@ class ServiceWorker:
             if not self.instance.exists():
                 raise Exception("Service Instance object %s doesn't exist" % self.instanceId)
             if not self.instance.service.exists():
-                raise Exception(
-                    "Service object %s doesn't exist" % self.instance.service._identity
-                )
+                msg = "Service object %s doesn't exist" % self.instance.service._identity
+                with self.db.transaction():
+                    self.instance.markFailedToStart(msg)
+                raise Exception(msg)
+
             self.serviceName = self.instance.service.name
             self.instance.connection = self.db.connectionObject
             self.instance.codebase = self.instance.service.codebase


### PR DESCRIPTION
## Motivation and Context
I had run a command that removed a service without stopping it and removing its service instances, and that ServiceManager had gotten stuck in a bad state. 

## Approach
Twofold.

First, periodically check for orphan ServiceInstance instances (i.e., one's whose self.service.exists() is False) and remove them after triggering a stop.
Second, provide a `removeService` method that "does the right thing", meaning it makes sure the service instances are stopped before removing the service and its instances. But also allow to force-remove in which case the check is not performed but the system should be robust under that scenario too.

## How Has This Been Tested?
Added unit-tests to test these new scenarios.
