### PR TITLE
Adds features to ServiceManager

### DIFF
--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -148,16 +148,16 @@ def main(argv=None):
                 )
 
             with database.transaction():
-                ServiceManager.createOrUpdateServiceWithCodebase(
-                    service_schema.Codebase.createFromFiles(
+                ServiceManager.createOrUpdateService(
+                    "test_service.service.TestService",
+                    "TestService",
+                    10,
+                    codebase=service_schema.Codebase.createFromFiles(
                         {
                             "test_service/__init__.py": "",
                             "test_service/service.py": textwrap.dedent(TEST_SERVICE),
                         }
                     ),
-                    "test_service.service.TestService",
-                    "TestService",
-                    10,
                 )
 
             print("SERVER IS BOOTED")

--- a/object_database/service_manager/Codebase.py
+++ b/object_database/service_manager/Codebase.py
@@ -17,11 +17,15 @@ import os
 import object_database
 
 from object_database import Indexed, SubscribeLazilyByDefault
-from typed_python import ConstDict, sha_hash
+from typed_python import ConstDict, sha_hash, NamedTuple
 import threading
 
 from object_database.service_manager.ServiceSchema import service_schema
 from typed_python.Codebase import Codebase as TypedPythonCodebase
+
+
+CommitInfo = NamedTuple(reposUrl=str, commitHash=str)
+
 
 # singleton state objects for the codebase cache
 _codebase_lock = threading.Lock()
@@ -73,6 +77,7 @@ class Codebase:
 
     # filename (at root of project import) to contents
     files = ConstDict(str, service_schema.File)
+    commitInfo = CommitInfo
 
     @staticmethod
     def createFromRootlevelPath(rootPath, **kwargs):
@@ -131,3 +136,6 @@ class Codebase:
                 return _codebase_cache[self.hash]
 
             return _codebase_cache[self.hash].getModuleByName(module_name)
+
+    def setCommitInfo(self, commitInfo):
+        self.commitInfo = commitInfo

--- a/object_database/service_manager/ServiceInstance.py
+++ b/object_database/service_manager/ServiceInstance.py
@@ -56,8 +56,8 @@ class Service:
     service_class_name = str
 
     # per service, how many do we use?
-    gbRamUsed = int
-    coresUsed = int
+    gbRamUsed = float
+    coresUsed = float
     validPlacementGroups = TupleOf(str)
     isSingleton = bool
 

--- a/object_database/service_manager/ServiceInstance.py
+++ b/object_database/service_manager/ServiceInstance.py
@@ -112,9 +112,9 @@ class Service:
             self._codebase = other
             self.deploy()
 
-    def setCodebase(self, codebase, moduleName=None, className=None):
+    def setCodebase(self, codebase=None, moduleName=None, className=None):
         if (
-            codebase != self.codebase
+            (codebase is not None and codebase != self.codebase)
             or (moduleName is not None and moduleName != self.service_module_name)
             or (className is not None and className != self.service_class_name)
         ):
@@ -123,7 +123,8 @@ class Service:
                     "Cannot set codebase of locked service '{}'".format(self.name)
                 )
 
-            self._setCodebase(codebase)
+            if codebase is not None:
+                self._setCodebase(codebase)
 
             if moduleName is not None:
                 self.service_module_name = moduleName

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -925,11 +925,11 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
             self.assertTrue(instances[0].codebase is None)
 
         with self.database.transaction():
-            ServiceManager.createOrUpdateServiceWithCodebase(
-                service_schema.Codebase.createFromFiles(getTestServiceModule(2)),
+            ServiceManager.createOrUpdateService(
                 "test_service.service.Service",
                 "HangingService",
                 10,
+                codebase=service_schema.Codebase.createFromFiles(getTestServiceModule(2)),
             )
 
         # this should force a redeploy.
@@ -1115,13 +1115,13 @@ class ServiceManagerTest(ServiceManagerTestCommon, unittest.TestCase):
         def deploy_helper(codebase_version, expected_version, existing_service=None):
             with self.database.transaction():
                 try:
-                    ServiceManager.createOrUpdateServiceWithCodebase(
-                        service_schema.Codebase.createFromFiles(
-                            getTestServiceModule(codebase_version)
-                        ),
+                    ServiceManager.createOrUpdateService(
                         "test_service.service.Service",
                         serviceName,
-                        targetCount=1,
+                        target_count=1,
+                        codebase=service_schema.Codebase.createFromFiles(
+                            getTestServiceModule(codebase_version)
+                        ),
                     )
                 except Exception:
                     pass

--- a/object_database/service_manager/Task_test.py
+++ b/object_database/service_manager/Task_test.py
@@ -58,11 +58,11 @@ class TaskTest(ServiceManagerTestCommon, unittest.TestCase):
             files = {"TestModule1.py": f.read()}
 
         with self.database.transaction():
-            self.testService1Object = ServiceManager.createOrUpdateServiceWithCodebase(
-                service_schema.Codebase.createFromFiles(files),
+            self.testService1Object = ServiceManager.createOrUpdateService(
                 "TestModule1.TestService1",
                 "TestService1",
                 0,
+                codebase=service_schema.Codebase.createFromFiles(files),
             )
             self.testService1Codebase = self.testService1Object.codebase.instantiate()
 

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -2755,7 +2755,7 @@ class Clickable(Cell):
             onClick: str or zero-argument function that either returns a string which will be
                 the link to follow, or that performs the action to be performed.
             makeBold (bool): should the text be bold
-            aTarget (str): target to an HTML a element. One of _blank, _self,
+            aTarget (str): None or a target to an HTML <a> element. One of _blank, _self,
                 _parent, _top, or a valid framename.
         """
         super().__init__()

--- a/object_database/web/cells_demo/conftest.py
+++ b/object_database/web/cells_demo/conftest.py
@@ -95,16 +95,16 @@ def bootup_server(tmpDirName):
         )
 
     with database.transaction():
-        ServiceManager.createOrUpdateServiceWithCodebase(
-            service_schema.Codebase.createFromFiles(
+        ServiceManager.createOrUpdateService(
+            "test_service.service.TestService",
+            "TestService",
+            10,
+            codebase=service_schema.Codebase.createFromFiles(
                 {
                     "test_service/__init__.py": "",
                     "test_service/service.py": textwrap.dedent(TEST_SERVICE),
                 }
             ),
-            "test_service.service.TestService",
-            "TestService",
-            10,
         )
 
     print("server is booted")


### PR DESCRIPTION
## Motivation and Context
- Adds CommitInfo to Codebase objects which can allow us to map a codebase back to a commit
- Allows gbRamUsed and coresUsed to be floats to allow services to provision fractional amounts.
- Made some changes to ServiceManager improve coverage and reduce code duplication.

## How Has This Been Tested?
Unit-tests here and TL
