### PR TITLE
More ODB docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ object_database/web/content/dist
 # Emacs
 \#*
 \.#*
+*~
 
 # leading slash means only match at repo-root level
 /.python-version

--- a/README.md
+++ b/README.md
@@ -20,6 +20,84 @@ N.B. if installing docker for the first time (at least on mac) you may need to:
 a) startup the docker desktop app (it will download some more things and set vars)
 b) run a container such as the example one docker run -d -p 80:80 docker/getting-started
 
+# Installation
+
+The recommended way to install object_database is by cloning the repo and pip install 
+from the repo. The public PyPI release is out of date.
+
+1. Clone repo `git clone git@github.com:APrioriInvestments/object_database`
+2. Create a fresh virtual environment with python 3.6-3.8
+
+    via venv
+    ```shell
+    cd object_database
+    python3 -m venv .venv
+    . .venv/bin/activate
+    export PYTHONPATH=`pwd`
+    ```
+    
+    via conda
+    ```shell
+    cd object_database
+    conda create -y -n odb python=3.8
+    conda activate odb
+    export PYTHONPATH=`pwd`
+    ```
+   
+3. Build and install from source:
+
+    ```shell
+    pip install -e .
+    ```
+   
+# Major components
+
+This repo has 3 major components and 1 notable major dependency:
+- distributed object engine
+- service manager ("k8s-lite")
+- reactive web layer (Cells)
+- typed_python
+
+## In-memory distributed object database
+
+The core of this repo is a distributed in-memory object database engine.
+Using this engine, you can define type-safe collections of objects that
+can be safely and consistently written/read by multiple clients concurrently.
+The database engine supports transactions and takes care of consistency and
+state syncing (via optimistics concurrency control).
+
+For details and examples see [object engine docs](./docs/object_engine.md)
+
+## Service manager (k8s-lite)
+
+Object database has a service management engine can manage distributed compute, 
+run web services, run jobs, and more. This engine lives in 
+[./object_database/service_manager](./object_database/service_manager) and uses
+a running object database to manage state.
+
+For more details see [service manager docs](./docs/service_manager.md)
+
+## Cells (reactive web layer)
+
+TODO: link to Cells docs from @dkrasner
+
+## Typed python
+
+ODB uses [typed_python](https://github.com/APrioriInvestments/typed_python)
+to define object schemas and offer safety/performance. It is also the most 
+frequent source of build/install problems. Most notably, you need to make sure
+that this repo and typed_python are built on the same version of numpy 
+(see [pyproject.toml](./pyproject.toml) for dependencies and version constraints 
+for the build, [requirements.txt](./requirements.txt) package installation deps).
+Note that the `pyproject.toml` is required so the C++ extensions are built on the
+correct version of numpy.
+
+For more details see [typed_python docs](./docs/typed_python.md).
+
 # Support matrix
 
-As of 2022-04-28, only python 3.6-3.8 is supported (due to typed_python not working for 3.9/3.10)
+As of 2022-04-28, only python 3.6-3.8 is supported (due to typed_python not working for 3.9/3.10).
+Linux: works more or less out of the box
+MacOS: requires a decent amount of futzing
+Windows: ahahahahaha good one
+

--- a/docs/examples/consumer.py
+++ b/docs/examples/consumer.py
@@ -1,0 +1,24 @@
+from object_database import connect, Schema
+import time
+
+schema = Schema("hello_world")
+
+@schema.define
+class Message:
+    timestamp = float
+    message = str
+
+db = connect('localhost', 8000, 'TOKEN')
+db.subscribeToSchema(schema)
+
+ts = 0
+while True:
+    with db.view():
+        Message(timestamp=time.time(),
+                message='message_5')
+        messages = Message.lookupAll()
+        for m in messages:
+            if m.timestamp > ts:
+                print((m.message, m.timestamp))
+                ts = m.timestamp
+    time.sleep(1)

--- a/docs/examples/producer.py
+++ b/docs/examples/producer.py
@@ -1,0 +1,22 @@
+from object_database import connect, Schema
+import time
+
+schema = Schema("hello_world")
+
+@schema.define
+class Message:
+    timestamp = float
+    message = str
+
+db = connect('localhost', 8000, 'TOKEN')
+db.subscribeToSchema(schema)
+
+i = 0
+while True:
+    with db.transaction():
+        message = Message(timestamp=time.time(),
+                          message=f'message_{i}')
+        print(f'Created {message}')
+        i += 1
+    time.sleep(1)
+    

--- a/docs/object_engine.md
+++ b/docs/object_engine.md
@@ -1,0 +1,55 @@
+# The ODB engine
+
+ODB's core is distributed in-memory objects. The low-level types, connections, and transactions are
+written in C++ (including interactions with typed_python). The interfaces, persistence management,
+and higher level APIs are written in python.
+
+Let's see a quick example and the remainder of this document will layout the major ODB components 
+
+## Quick example
+
+If you don't have ODB installed yet, see [installation](../README.md#Installation) for instructions.
+
+start in ODB repo root and start an ODB server:
+```shell
+./object_database/frontends/database_server.py --service-token TOKEN --inmem localhost 8000
+```
+
+This starts an ODB server that accepts incoming connection at `localhost:8000`.
+The `--inmem` option indicates that objects are only persisted in process memory and
+will be gone as soon as this server process is terminated.
+And clients will be required to use "TOKEN" in order to be able to connect.
+
+A producer is defined in `docs/examples/producer.py`. 
+Run it in a terminal (from repo root):
+```shell
+python ./docs/examples/producer.py
+```
+
+A consumer is defined in `docs/examples/consumer.py`.
+Run it in a terminal (from repo root):
+```shell
+python ./docs/examples/consumer.py
+```
+
+And you should see the consumer print out new messages like:
+
+```
+(odb) ➜  object_database git:(dev) ✗ python docs/examples/consumer.py
+('message_0', 1652072778.4360642)
+('message_1', 1652072779.4380279)
+('message_2', 1652072780.4426992)
+('message_3', 1652072781.4477468)
+('message_4', 1652072782.4518585)
+('message_5', 1652072783.4566717)
+```
+
+## Major components
+
+### Objects
+
+### Comms 
+
+### Transactions
+
+### Persistence

--- a/docs/service_manager.md
+++ b/docs/service_manager.md
@@ -17,6 +17,8 @@ manages launching and shutdown of AWS ec2 instances.
 
 ### Task Services
 
+**DEPRECATED**: Task Services are no longer used in production and may be phased on in the future. 
+
 A special pair of services is responsible for distributed task execution in odb.
 [TaskDispatchService](../object_database/service_manager/Task.py) manages TaskWorkers and subscribes to changes in TaskStatus.
 New tasks are assigned to workers round-robin. The tasks are executed by the 
@@ -34,7 +36,6 @@ execution, the `TaskContext` containing the db, storage, and the codebase is pas
 
 Subtasks are defined as Tasks with a parent Task. TaskStatus is separately updated for each subtask.
 The parent task is reset to Unassigned status when all subtasks are DoneCalculating.
-
 
 ### TaskStatus
 

--- a/quickstart/hello_world.md
+++ b/quickstart/hello_world.md
@@ -3,7 +3,7 @@
 This file takes us through a very simple example of setting up an ODB/cells project
 from start to finish.  Note that object_database requires typed python, which doesn't
 run on windows right now, so you'll have to run this on linux (preferable) or MacOS (
-ought to work, but not as thorougly tested in the wild).
+ought to work, but not as thoroughly tested in the wild).
 
 
 ## Installation


### PR DESCRIPTION
- Installation instructions on the main README.md
- Description of ODB components
- Added documentation for the core database engine
- Added example to show launching ODB server and reading/writing from/to it without the service manager or cells components