### PR TITLE
Focus on searchbar when clicking table header

### DIFF
--- a/object_database/web/cells/table.py
+++ b/object_database/web/cells/table.py
@@ -152,7 +152,9 @@ class TableHeader(Cell):
             if isNone.get():
                 return Clickable(Octicon("search"), lambda: columnFilterSlot.set(""))
             else:
-                return SingleLineTextBox(columnFilterSlot) >> Button(
+                tb = SingleLineTextBox(columnFilterSlot)
+                tb.focus()
+                return tb >> Button(
                     Octicon("x"), lambda: columnFilterSlot.set(None), small=True
                 )
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Alter the Table behaviour so that when you click the search/filter icon on a table header it focusses on the textbox, taking you from two clicks to one click when searching.

## How Has This Been Tested?
Locally with `object_database_webtest`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.