### PR TITLE
Print the exception name along with the message for custom ODB errors

### DIFF
--- a/object_database/view.py
+++ b/object_database/view.py
@@ -27,21 +27,32 @@ class DisconnectedException(Exception):
 
 
 class RevisionConflictException(Exception):
-    pass
+    def __str__(self):
+        return "RevisionConflictException(%s)" % self.args[0]
 
 
 class ServerError(Exception):
-    pass
+    def __str__(self):
+        return "ServerError(%s)" % self.args[0]
+
+
+class MultipleViewError(Exception):
+    def __str__(self):
+        return "MultipleViewError(%s)" % self.args[0]
 
 
 class FieldNotDefaultInitializable(Exception):
-    pass
+    def __str__(self):
+        return "FieldNotDefaultInitializable(%s)" % self.args[0]
 
 
 class ObjectDoesntExistException(Exception):
     def __init__(self, obj):
         super().__init__("%s(%s)" % (type(obj).__qualname__, obj._identity))
         self.obj = obj
+
+    def __str__(self):
+        return "ObjectDoesntExistException(%s)" % self.args[0]
 
 
 class MaskView:
@@ -232,7 +243,9 @@ class View(object):
 
     def __enter__(self):
         if hasattr(_cur_view, "view"):
-            raise Exception("You can't open a view or transaction while another one is open.")
+            raise MultipleViewError(
+                "You can't open a view or transaction while another one is open."
+            )
 
         _cur_view.view = self
         self._view.enter()


### PR DESCRIPTION
## Motivation and Context
When raising and logging errors with ODB, when we hit a custom exception the error message is often difficult to understand. E.g calling `str()` on a RevisionConflictException gives:
```
 ((objId=500000005, fieldId=117, isIndexValue=False), (schema="testlooper_engine", typename="CommitTestDefinitionGenerationTask", fieldname="_status_history"))
```

When used with a general error logger it's impossible to know what the above error message is indicating. This PR modifies `__str__` to include the exception name itself, which helps the user understand the nature of the issue. 

Also adds a MultipleViewError to throw instead of a base Exception when applicable.

## How Has This Been Tested?
`pytest`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.