### PR TITLE
Update chrome driver url

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,9 +21,11 @@ jobs:
         curl https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -O
         sudo apt-get install ./google-chrome-stable_current_amd64.deb
         CHROME_MAIN_VERSION=`google-chrome-stable --version | sed -E 's/(^Google Chrome |\.[0-9]+ )//g'`
-        CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_MAIN_VERSION"`
-        curl "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip" -O
-        unzip chromedriver_linux64.zip -d ~/bin
+        echo "using chrome version $CHROME_MAIN_VERSION"
+        CHROMEDRIVER_VERSION=`curl -s "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$CHROME_MAIN_VERSION"`
+        echo "using driver version $CHROMEDRIVER_VERSION"
+        curl "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip" -O
+        unzip chromedriver-linux64.zip -d ~/bin
         ulimit -c unlimited -S       # enable core dumps
 
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The URL we use in our build script no longer tracks version information for chrome versions > 114.0.5735
(June 2023) - updated to use the new recommended url, and added some prints to make debugging the curl error easier.

NB: this build still segfaulted when running the test suite.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.