### PR TITLE
Allow startServiceManagerProcess to persist with Redis

### DIFF
--- a/object_database/frontends/service_manager.py
+++ b/object_database/frontends/service_manager.py
@@ -64,6 +64,7 @@ def startServiceManagerProcess(
     logDir=True,
     sslPath=None,
     proxyPort=None,
+    redisPort=None,
 ):
     if not verbose:
         kwargs = dict(stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -96,6 +97,10 @@ def startServiceManagerProcess(
 
         cmd.append("--proxy-port")
         cmd.append(str(proxyPort))
+
+    if redisPort is not None:
+        cmd.append("--redis_port")
+        cmd.append(str(redisPort))
 
     if logDir:
         logsPath = os.path.join(tempDirectoryName, "logs")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context

As far as I can tell, there was no means of booting ODB with Redis persistence when using startServiceManagerProcess previously - this just adds that functionality.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.