### PR TITLE
bugfix: include ec2 json in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ include object_database/*.hpp
 include object_database/*.cpp
 include object_database/direct_types/*.hpp
 include object_database/direct_types/*.cpp
+include object_database/service_manager/aws/ec2_pricing.json


### PR DESCRIPTION
## Motivation and Context
#148  introduced a bug - we added a json file that the service manager needs in order to run, but which is not included when the package is installed. So when you pip install it, it'll fall over with a FileNotFoundError.

(I think our ODB tests pass because of our directory structure and the nature of python imports)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.