### PR TITLE
Allow redis DB to be served from non-localhost 

### DIFF
--- a/object_database/frontends/database_server.py
+++ b/object_database/frontends/database_server.py
@@ -41,6 +41,7 @@ def main(argv):
         help="path to (self-signed) SSL certificate",
     )
     parser.add_argument("--redis_port", type=int, default=None)
+    parser.add_argument("--redis_host", type=str, default=None)
     parser.add_argument("--inmem", default=False, action="store_true")
 
     parsedArgs = parser.parse_args(argv[1:])
@@ -48,7 +49,7 @@ def main(argv):
     if parsedArgs.inmem:
         mem_store = InMemoryPersistence()
     else:
-        mem_store = RedisPersistence(port=parsedArgs.redis_port)
+        mem_store = RedisPersistence(host=parsedArgs.redis_host, port=parsedArgs.redis_port)
 
     ssl_ctx = sslContextFromCertPathOrNone(parsedArgs.ssl_path)
     databaseServer = TcpServer(

--- a/object_database/frontends/service_manager.py
+++ b/object_database/frontends/service_manager.py
@@ -65,6 +65,7 @@ def startServiceManagerProcess(
     sslPath=None,
     proxyPort=None,
     redisPort=None,
+    redisHost=None,
 ):
     if not verbose:
         kwargs = dict(stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -101,6 +102,10 @@ def startServiceManagerProcess(
     if redisPort is not None:
         cmd.append("--redis_port")
         cmd.append(str(redisPort))
+
+    if redisHost is not None:
+        cmd.append("--redis_host")
+        cmd.append(redisHost)
 
     if logDir:
         logsPath = os.path.join(tempDirectoryName, "logs")
@@ -273,6 +278,7 @@ def main(argv=None):
         help="path to (self-signed) SSL certificate",
     )
     parser.add_argument("--redis_port", type=int, default=None, required=False)
+    parser.add_argument("--redis_host", type=str, default=None, required=False)
     parser.add_argument("--fd-limit", type=int, default=4096, required=False)
 
     parser.add_argument("--max_gb_ram", type=float, default=None, required=False)
@@ -400,7 +406,7 @@ def main(argv=None):
             databaseServer = TcpServer(
                 ownHostname,
                 parsedArgs.port,
-                RedisPersistence(port=parsedArgs.redis_port)
+                RedisPersistence(host=parsedArgs.redis_host, port=parsedArgs.redis_port)
                 if parsedArgs.redis_port is not None
                 else InMemoryPersistence(),
                 ssl_context=ssl_ctx,

--- a/object_database/persistence.py
+++ b/object_database/persistence.py
@@ -146,12 +146,15 @@ class InMemoryPersistence(object):
 
 
 class RedisPersistence(object):
-    def __init__(self, db=0, port=None):
+    def __init__(self, db=0, port=None, host=None):
         self.lock = threading.RLock()
         kwds = {}
 
         if port is not None:
             kwds["port"] = port
+
+        if host is not None:
+            kwds["host"] = host
 
         self.redis = redis.StrictRedis(db=db, **kwds)
         self.cache = {}


### PR DESCRIPTION

## Motivation and Context
The Redis server allows for arbitrary ports and hosts, but only the port is currently configurable through the service manager. This is a problem because when using docker networks, the host is the name of the container (e.g. `redis:6379`), and is very difficult to change.


## How Has This Been Tested?
Standard unit test battery


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.